### PR TITLE
Add command to stop local_fabric runtime

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -41,7 +41,8 @@
             "blockchain.createSmartContractProjectEntry",
             "blockchainAPackageExplorer.refreshEntry",
             "blockchainAPackageExplorer.packageSmartContractProject",
-            "blockchainExplorer.startFabricRuntime"
+            "blockchainExplorer.startFabricRuntime",
+            "blockchainExplorer.stopFabricRuntime"
         ]
     },
     "main": "./out/src/extension",
@@ -163,6 +164,11 @@
               "command": "blockchainExplorer.startFabricRuntime",
               "title": "Start Fabric Runtime",
               "category": "Blockchain"
+            },
+            {
+              "command": "blockchainExplorer.stopFabricRuntime",
+              "title": "Stop Fabric Runtime",
+              "category": "Blockchain"
             }
         ],
         "menus": {
@@ -208,6 +214,10 @@
                 },
                 {
                   "command": "blockchainExplorer.startFabricRuntime",
+                  "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
+                },
+                {
+                  "command": "blockchainExplorer.stopFabricRuntime",
                   "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
                 }
             ]

--- a/client/src/commands/stopFabricRuntime.ts
+++ b/client/src/commands/stopFabricRuntime.ts
@@ -19,7 +19,7 @@ import { RuntimeTreeItem } from '../explorer/model/RuntimeTreeItem';
 import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
 import { FabricRuntime } from '../fabric/FabricRuntime';
 
-export async function startFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Promise<void> {
+export async function stopFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Promise<void> {
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtimeName: string;
     if (!runtimeTreeItem) {
@@ -33,8 +33,8 @@ export async function startFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Pro
         title: 'Blockchain Extension',
         cancellable: false
     }, async (progress, token) => {
-        progress.report({ message: `Starting Fabric runtime ${runtimeName}` });
+        progress.report({ message: `Stopping Fabric runtime ${runtimeName}` });
         const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
-        await runtime.start(outputAdapter);
+        await runtime.stop(outputAdapter);
     });
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -29,6 +29,7 @@ import { ExtensionUtil } from './util/ExtensionUtil';
 import { FabricRuntimeManager } from './fabric/FabricRuntimeManager';
 import { RuntimeTreeItem } from './explorer/model/RuntimeTreeItem';
 import { startFabricRuntime } from './commands/startFabricRuntime';
+import { stopFabricRuntime } from './commands/stopFabricRuntime';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -89,6 +90,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('blockchain.createSmartContractProjectEntry', createSmartContractProject));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainAPackageExplorer.refreshEntry', () => blockchainPackageExplorerProvider.refresh()));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.startFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => startFabricRuntime(runtimeTreeItem)));
+    context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.stopFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => stopFabricRuntime(runtimeTreeItem)));
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
 

--- a/client/test/commands/stopFabricRuntime.test.ts
+++ b/client/test/commands/stopFabricRuntime.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as myExtension from '../../src/extension';
+import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegistry';
+import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
+import { CommandsUtil } from '../../src/commands/commandsUtil';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+chai.should();
+
+// tslint:disable no-unused-expression
+describe('stopFabricRuntime', () => {
+
+    let sandbox: sinon.SinonSandbox;
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtime: FabricRuntime;
+    let runtimeTreeItem: RuntimeTreeItem;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        await ExtensionUtil.activateExtension();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('local_fabric');
+        runtime = runtimeManager.get('local_fabric');
+        const provider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+        const children: BlockchainTreeItem[] = await provider.getChildren();
+        runtimeTreeItem = children.find((child: BlockchainTreeItem) => child instanceof RuntimeTreeItem) as RuntimeTreeItem;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    it('should stop a Fabric runtime specified by right clicking the tree', async () => {
+        const stopStub: sinon.SinonStub = sandbox.stub(runtime, 'stop').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.stopFabricRuntime', runtimeTreeItem);
+        stopStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+    it('should stop a Fabric runtime specified by selecting it from the quick pick', async () => {
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const stopStub: sinon.SinonStub = sandbox.stub(runtime, 'stop').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.stopFabricRuntime');
+        quickPickStub.should.have.been.called.calledOnce;
+        stopStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+});

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -68,7 +68,8 @@ describe('Extension Tests', () => {
             'blockchainExplorer.addConnectionIdentityEntry',
             'blockchain.createSmartContractProjectEntry',
             'blockchainAPackageExplorer.refreshEntry',
-            'blockchainExplorer.startFabricRuntime'
+            'blockchainExplorer.startFabricRuntime',
+            'blockchainExplorer.stopFabricRuntime'
         ]);
     });
 
@@ -87,7 +88,8 @@ describe('Extension Tests', () => {
             'onCommand:blockchain.createSmartContractProjectEntry',
             'onCommand:blockchainAPackageExplorer.refreshEntry',
             'onCommand:blockchainAPackageExplorer.packageSmartContractProject',
-            'onCommand:blockchainExplorer.startFabricRuntime'
+            'onCommand:blockchainExplorer.startFabricRuntime',
+            'onCommand:blockchainExplorer.stopFabricRuntime'
         ]);
     });
 


### PR DESCRIPTION
Add a new command, Stop Fabric Runtime, that allows a user of the extension to stop the automatically created local_fabric runtime delivered in PR #26.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>