### PR TITLE
Add command to restart local_fabric runtime

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,7 +42,8 @@
             "blockchainAPackageExplorer.refreshEntry",
             "blockchainAPackageExplorer.packageSmartContractProject",
             "blockchainExplorer.startFabricRuntime",
-            "blockchainExplorer.stopFabricRuntime"
+            "blockchainExplorer.stopFabricRuntime",
+            "blockchainExplorer.restartFabricRuntime"
         ]
     },
     "main": "./out/src/extension",
@@ -169,6 +170,11 @@
               "command": "blockchainExplorer.stopFabricRuntime",
               "title": "Stop Fabric Runtime",
               "category": "Blockchain"
+            },
+            {
+                "command": "blockchainExplorer.restartFabricRuntime",
+                "title": "Restart Fabric Runtime",
+                "category": "Blockchain"
             }
         ],
         "menus": {
@@ -219,6 +225,10 @@
                 {
                   "command": "blockchainExplorer.stopFabricRuntime",
                   "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
+                },
+                {
+                    "command": "blockchainExplorer.restartFabricRuntime",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
                 }
             ]
         }

--- a/client/src/commands/restartFabricRuntime.ts
+++ b/client/src/commands/restartFabricRuntime.ts
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
+import { CommandsUtil } from './commandsUtil';
+import { RuntimeTreeItem } from '../explorer/model/RuntimeTreeItem';
+import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
+import { FabricRuntime } from '../fabric/FabricRuntime';
+
+export async function restartFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Promise<void> {
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtimeName: string;
+    if (!runtimeTreeItem) {
+        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
+    } else {
+        runtimeName = runtimeTreeItem.label;
+    }
+    const runtime: FabricRuntime = runtimeManager.get(runtimeName);
+    await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token) => {
+        progress.report({ message: `Restarting Fabric runtime ${runtimeName}` });
+        const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
+        await runtime.restart(outputAdapter);
+    });
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -30,6 +30,7 @@ import { FabricRuntimeManager } from './fabric/FabricRuntimeManager';
 import { RuntimeTreeItem } from './explorer/model/RuntimeTreeItem';
 import { startFabricRuntime } from './commands/startFabricRuntime';
 import { stopFabricRuntime } from './commands/stopFabricRuntime';
+import { restartFabricRuntime } from './commands/restartFabricRuntime';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -91,6 +92,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('blockchainAPackageExplorer.refreshEntry', () => blockchainPackageExplorerProvider.refresh()));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.startFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => startFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.stopFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => stopFabricRuntime(runtimeTreeItem)));
+    context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.restartFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => restartFabricRuntime(runtimeTreeItem)));
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
 

--- a/client/test/commands/restartFabricRuntime.test.ts
+++ b/client/test/commands/restartFabricRuntime.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as myExtension from '../../src/extension';
+import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegistry';
+import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
+import { CommandsUtil } from '../../src/commands/commandsUtil';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+chai.should();
+
+// tslint:disable no-unused-expression
+describe('restartFabricRuntime', () => {
+
+    let sandbox: sinon.SinonSandbox;
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtime: FabricRuntime;
+    let runtimeTreeItem: RuntimeTreeItem;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        await ExtensionUtil.activateExtension();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('local_fabric');
+        runtime = runtimeManager.get('local_fabric');
+        const provider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+        const children: BlockchainTreeItem[] = await provider.getChildren();
+        runtimeTreeItem = children.find((child: BlockchainTreeItem) => child instanceof RuntimeTreeItem) as RuntimeTreeItem;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    it('should start a Fabric runtime specified by right clicking the tree', async () => {
+        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.restartFabricRuntime', runtimeTreeItem);
+        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+    it('should start a Fabric runtime specified by selecting it from the quick pick', async () => {
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.restartFabricRuntime');
+        quickPickStub.should.have.been.called.calledOnce;
+        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+});

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -69,7 +69,8 @@ describe('Extension Tests', () => {
             'blockchain.createSmartContractProjectEntry',
             'blockchainAPackageExplorer.refreshEntry',
             'blockchainExplorer.startFabricRuntime',
-            'blockchainExplorer.stopFabricRuntime'
+            'blockchainExplorer.stopFabricRuntime',
+            'blockchainExplorer.restartFabricRuntime'
         ]);
     });
 
@@ -89,7 +90,8 @@ describe('Extension Tests', () => {
             'onCommand:blockchainAPackageExplorer.refreshEntry',
             'onCommand:blockchainAPackageExplorer.packageSmartContractProject',
             'onCommand:blockchainExplorer.startFabricRuntime',
-            'onCommand:blockchainExplorer.stopFabricRuntime'
+            'onCommand:blockchainExplorer.stopFabricRuntime',
+            'onCommand:blockchainExplorer.restartFabricRuntime'
         ]);
     });
 


### PR DESCRIPTION
Add a new command, Restart Fabric Runtime, that allows a user of the extension to restart the automatically created local_fabric runtime delivered in PR #26.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>