### PR TITLE
Show the status of the local_fabric runtime in the tree

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -224,15 +224,15 @@
                 },
                 {
                     "command": "blockchainExplorer.startFabricRuntime",
-                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-stopped"
                 },
                 {
                     "command": "blockchainExplorer.stopFabricRuntime",
-                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
                 },
                 {
                     "command": "blockchainExplorer.restartFabricRuntime",
-                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
                 }
             ]
         }

--- a/client/src/commands/restartFabricRuntime.ts
+++ b/client/src/commands/restartFabricRuntime.ts
@@ -25,7 +25,7 @@ export async function restartFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): P
     if (!runtimeTreeItem) {
         runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
     } else {
-        runtimeName = runtimeTreeItem.label;
+        runtimeName = runtimeTreeItem.getName();
     }
     const runtime: FabricRuntime = runtimeManager.get(runtimeName);
     await vscode.window.withProgress({

--- a/client/src/commands/startFabricRuntime.ts
+++ b/client/src/commands/startFabricRuntime.ts
@@ -25,7 +25,7 @@ export async function startFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Pro
     if (!runtimeTreeItem) {
         runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
     } else {
-        runtimeName = runtimeTreeItem.label;
+        runtimeName = runtimeTreeItem.getName();
     }
     const runtime: FabricRuntime = runtimeManager.get(runtimeName);
     await vscode.window.withProgress({

--- a/client/src/commands/stopFabricRuntime.ts
+++ b/client/src/commands/stopFabricRuntime.ts
@@ -25,7 +25,7 @@ export async function stopFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Prom
     if (!runtimeTreeItem) {
         runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
     } else {
-        runtimeName = runtimeTreeItem.label;
+        runtimeName = runtimeTreeItem.getName();
     }
     const runtime: FabricRuntime = runtimeManager.get(runtimeName);
     await vscode.window.withProgress({

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -285,6 +285,8 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
             let command: vscode.Command;
             if (connection.identities && connection.identities.length > 1) {
                 collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+            } else if (connection.managedRuntime) {
+                collapsibleState = vscode.TreeItemCollapsibleState.None;
             } else {
                 collapsibleState = vscode.TreeItemCollapsibleState.None;
                 command = {

--- a/client/src/explorer/model/RuntimeTreeItem.ts
+++ b/client/src/explorer/model/RuntimeTreeItem.ts
@@ -17,11 +17,108 @@
 import * as vscode from 'vscode';
 import { ConnectionTreeItem } from './ConnectionTreeItem';
 import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
+import { FabricRuntimeManager } from '../../fabric/FabricRuntimeManager';
+import { FabricRuntime } from '../../fabric/FabricRuntime';
 
 export class RuntimeTreeItem extends ConnectionTreeItem {
     contextValue = 'blockchain-runtime-item';
 
+    private name: string;
+    private runtime: FabricRuntime;
+    private busyTicker: NodeJS.Timer;
+    private busyTicks: number = 0;
+
     constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly connection: any, public readonly collapsableState: vscode.TreeItemCollapsibleState, public readonly command?: vscode.Command) {
         super(provider, label, connection, collapsableState, command);
+        const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+        this.runtime = runtimeManager.get(label);
+        this.name = this.runtime.getName();
+        this.runtime.on('busy', () => {
+            this.safelyUpdateProperties();
+        });
+        process.nextTick(() => {
+            this.safelyUpdateProperties();
+        });
     }
+
+    public getName(): string {
+        return this.name;
+    }
+
+    private safelyUpdateProperties() {
+        this.updateProperties().catch((error) => vscode.window.showErrorMessage(error.message));
+    }
+
+    private async updateProperties() {
+        const busy: boolean = this.runtime.isBusy();
+        const running: boolean = await this.runtime.isRunning();
+        let newLabel: string = this.name + '  ';
+        let newCommand: vscode.Command = this.command;
+        let newContextLabel: string = this.contextValue;
+        if (busy) {
+            // Busy!
+            this.enableBusyTicker();
+            const busyStates: string[] = [ '◐', '◓', '◑', '◒' ];
+            newLabel += busyStates[this.busyTicks % 4];
+            newCommand = null;
+            newContextLabel = 'blockchain-runtime-item-busy';
+        } else if (running) {
+            // Running!
+            this.disableBusyTicker();
+            newLabel += '●';
+            newCommand = {
+                command: 'blockchainExplorer.connectEntry',
+                title: '',
+                arguments: [this.name]
+            };
+            newContextLabel = 'blockchain-runtime-item-started';
+        } else {
+            // Not running!
+            this.disableBusyTicker();
+            newLabel += '○';
+            newCommand = {
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [this]
+            };
+            newContextLabel = 'blockchain-runtime-item-stopped';
+        }
+        this.setLabel(newLabel);
+        this.setCommand(newCommand);
+        this.setContextValue(newContextLabel);
+        this.refresh();
+    }
+
+    private setLabel(label: string) {
+        // label is readonly so make it less readonly
+        (this as any).label = label;
+    }
+
+    private setCommand(command: vscode.Command) {
+        // command is readonly so make it less readonly
+        (this as any).command = command;
+    }
+
+    private setContextValue(contextValue: string) {
+        this.contextValue = contextValue;
+    }
+
+    private enableBusyTicker() {
+        if (!this.busyTicker) {
+            this.busyTicker = setInterval(() => {
+                this.busyTicks++;
+                this.safelyUpdateProperties();
+            }, 500);
+            this.busyTicks = 0;
+        }
+    }
+
+    private disableBusyTicker() {
+        if (this.busyTicker) {
+            clearInterval(this.busyTicker);
+            this.busyTicker = null;
+            this.busyTicks = 0;
+        }
+    }
+
 }

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -372,17 +372,21 @@ describe('ConnectCommand', () => {
             await vscode.workspace.getConfiguration().update('fabric.connections', connections, vscode.ConfigurationTarget.Global);
             await vscode.workspace.getConfiguration().update('fabric.runtimes', runtimes, vscode.ConfigurationTarget.Global);
 
+            const mockRuntime = sinon.createStubInstance(FabricRuntime);
+            mockRuntime.getName.returns('myRuntime');
+            mockRuntime.isBusy.returns(false);
+            mockRuntime.isRunning.resolves(true);
+            mySandBox.stub(FabricRuntimeManager.instance(), 'get').withArgs('myRuntime').returns(mockRuntime);
+
             const blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
             const allChildren: Array<BlockchainTreeItem> = await blockchainNetworkExplorerProvider.getChildren();
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
 
             const myConnectionItem: ConnectionTreeItem = allChildren[0] as ConnectionTreeItem;
 
             const loadFromConfigStub = mySandBox.stub(fabricClient, 'loadFromConfig').returns(fabricClientMock);
 
             const connectStub = mySandBox.stub(myExtension.getBlockchainNetworkExplorerProvider(), 'connect');
-
-            const mockRuntime = sinon.createStubInstance(FabricRuntime);
-            mySandBox.stub(FabricRuntimeManager.instance(), 'get').withArgs('myRuntime').returns(mockRuntime);
 
             await vscode.commands.executeCommand(myConnectionItem.command.command, ...myConnectionItem.command.arguments);
 

--- a/client/test/explorer/model/RuntimeTreeItem.test.ts
+++ b/client/test/explorer/model/RuntimeTreeItem.test.ts
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { getBlockchainNetworkExplorerProvider } from '../../../src/extension';
+import { RuntimeTreeItem } from '../../../src/explorer/model/RuntimeTreeItem';
+import { BlockchainNetworkExplorerProvider } from '../../../src/explorer/BlockchainNetworkExplorer';
+import { FabricRuntimeManager } from '../../../src/fabric/FabricRuntimeManager';
+import { FabricRuntime } from '../../../src/fabric/FabricRuntime';
+import { FabricRuntimeRegistry } from '../../../src/fabric/FabricRuntimeRegistry';
+import { FabricConnectionRegistry } from '../../../src/fabric/FabricConnectionRegistry';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
+const should = chai.should();
+
+describe('RuntimeTreeItem', () => {
+
+    const provider: BlockchainNetworkExplorerProvider = getBlockchainNetworkExplorerProvider();
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+
+    let sandbox: sinon.SinonSandbox;
+    let clock: sinon.SinonFakeTimers;
+    let runtime: FabricRuntime;
+
+    beforeEach(async () => {
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('myRuntime');
+        runtime = runtimeManager.get('myRuntime');
+        sandbox = sinon.createSandbox();
+        clock = sinon.useFakeTimers({ toFake: ['setInterval', 'clearInterval' ]});
+    });
+
+    afterEach(async () => {
+        clock.runToLast();
+        clock.restore();
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    describe('#constructor', () => {
+
+        it('should have the right properties for a runtime that is not running', async () => {
+            sandbox.stub(runtime, 'isBusy').returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ○');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [treeItem]
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-stopped');
+        });
+
+        it('should have the right properties for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isBusy').returns(true);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ◐');
+            should.equal(treeItem.command, null);
+            treeItem.contextValue.should.equal('blockchain-runtime-item-busy');
+        });
+
+        it('should animate the label for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isBusy').returns(true);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            const states: string[] = [ '◐', '◓', '◑', '◒', '◐' ];
+            for (const state of states) {
+                treeItem.label.should.equal(`myRuntime  ${state}`);
+                clock.tick(500);
+                await new Promise((resolve) => { setTimeout(resolve, 0); });
+            }
+        });
+
+        it('should have the right properties for a runtime that is running', async () => {
+            sandbox.stub(runtime, 'isBusy').returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(true);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ●');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.connectEntry',
+                title: '',
+                arguments: ['myRuntime']
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-started');
+        });
+
+        it('should have the right properties for a runtime that becomes busy', async () => {
+            const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
+            isBusyStub.returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ○');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [treeItem]
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-stopped');
+            isBusyStub.returns(true);
+            runtime.emit('busy', true);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ◐');
+            should.equal(treeItem.command, null);
+            treeItem.contextValue.should.equal('blockchain-runtime-item-busy');
+        });
+
+        it('should animate the label for a runtime that becomes busy', async () => {
+            const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
+            isBusyStub.returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            isBusyStub.returns(true);
+            runtime.emit('busy', true);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            const states: string[] = [ '◐', '◓', '◑', '◒', '◐' ];
+            for (const state of states) {
+                treeItem.label.should.equal(`myRuntime  ${state}`);
+                clock.tick(500);
+                await new Promise((resolve) => { setTimeout(resolve, 0); });
+            }
+        });
+
+        it('should have the right properties for a runtime that stops being busy', async () => {
+            const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
+            isBusyStub.returns(true);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ◐');
+            should.equal(treeItem.command, null);
+            treeItem.contextValue.should.equal('blockchain-runtime-item-busy');
+            isBusyStub.returns(false);
+            runtime.emit('busy', false);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ○');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [treeItem]
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-stopped');
+        });
+
+    });
+
+});


### PR DESCRIPTION
Show the status of the local_fabric runtime in the tree:

`local_fabric  ○` for a stopped runtime
`local_fabric  ●` for a started runtime
`local_fabric ◐` `local_fabric ◓` `local_fabric ◑` `local_fabric ◒` for a "busy" runtime

A runtime is busy when it is starting, stopping, or restarting.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>