### PR TITLE
Allow user to toggle development mode for local_fabric runtime

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -47,7 +47,8 @@
             "blockchainAPackageExplorer.packageSmartContractProject",
             "blockchainExplorer.startFabricRuntime",
             "blockchainExplorer.stopFabricRuntime",
-            "blockchainExplorer.restartFabricRuntime"
+            "blockchainExplorer.restartFabricRuntime",
+            "blockchainExplorer.toggleFabricRuntimeDevMode"
         ]
     },
     "main": "./out/src/extension",
@@ -179,6 +180,11 @@
                 "command": "blockchainExplorer.restartFabricRuntime",
                 "title": "Restart Fabric Runtime",
                 "category": "Blockchain"
+            },
+            {
+                "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
+                "title": "Toggle Development Mode",
+                "category": "Blockchain"
             }
         ],
         "menus": {
@@ -233,6 +239,14 @@
                 {
                     "command": "blockchainExplorer.restartFabricRuntime",
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
+                },
+                {
+                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
+                },
+                {
+                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-stopped"
                 }
             ]
         }

--- a/client/src/commands/restartFabricRuntime.ts
+++ b/client/src/commands/restartFabricRuntime.ts
@@ -23,7 +23,7 @@ export async function restartFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): P
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtimeName: string;
     if (!runtimeTreeItem) {
-        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
+        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Select the Fabric runtime to restart');
     } else {
         runtimeName = runtimeTreeItem.getName();
     }

--- a/client/src/commands/stopFabricRuntime.ts
+++ b/client/src/commands/stopFabricRuntime.ts
@@ -23,7 +23,7 @@ export async function stopFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Prom
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtimeName: string;
     if (!runtimeTreeItem) {
-        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
+        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Select the Fabric runtime to stop');
     } else {
         runtimeName = runtimeTreeItem.getName();
     }

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -297,11 +297,12 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
             }
 
             if (connection.managedRuntime) {
-                tree.push(new RuntimeTreeItem(this,
+                const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(this,
                     connection.name,
                     connection,
                     collapsibleState,
-                    command));
+                    command);
+                tree.push(treeItem);
             } else {
                 tree.push(new ConnectionTreeItem(this,
                     connection.name,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -31,6 +31,7 @@ import { RuntimeTreeItem } from './explorer/model/RuntimeTreeItem';
 import { startFabricRuntime } from './commands/startFabricRuntime';
 import { stopFabricRuntime } from './commands/stopFabricRuntime';
 import { restartFabricRuntime } from './commands/restartFabricRuntime';
+import { toggleFabricRuntimeDevMode } from './commands/toggleFabricRuntimeDevMode';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -94,6 +95,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.startFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => startFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.stopFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => stopFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.restartFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => restartFabricRuntime(runtimeTreeItem)));
+    context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.toggleFabricRuntimeDevMode', (runtimeTreeItem?: RuntimeTreeItem) => toggleFabricRuntimeDevMode(runtimeTreeItem)));
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
 

--- a/client/test/commands/restartFabricRuntime.test.ts
+++ b/client/test/commands/restartFabricRuntime.test.ts
@@ -59,18 +59,18 @@ describe('restartFabricRuntime', () => {
         await runtimeManager.clear();
     });
 
-    it('should start a Fabric runtime specified by right clicking the tree', async () => {
-        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+    it('should restart a Fabric runtime specified by right clicking the tree', async () => {
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
         await vscode.commands.executeCommand('blockchainExplorer.restartFabricRuntime', runtimeTreeItem);
-        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
     });
 
-    it('should start a Fabric runtime specified by selecting it from the quick pick', async () => {
+    it('should restart a Fabric runtime specified by selecting it from the quick pick', async () => {
         const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
-        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
         await vscode.commands.executeCommand('blockchainExplorer.restartFabricRuntime');
         quickPickStub.should.have.been.called.calledOnce;
-        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
     });
 
 });

--- a/client/test/commands/toggleFabricRuntimeDevMode.test.ts
+++ b/client/test/commands/toggleFabricRuntimeDevMode.test.ts
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as myExtension from '../../src/extension';
+import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegistry';
+import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
+import { CommandsUtil } from '../../src/commands/commandsUtil';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+chai.should();
+
+// tslint:disable no-unused-expression
+describe('toggleFabricRuntimeDevMode', () => {
+
+    let sandbox: sinon.SinonSandbox;
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtime: FabricRuntime;
+    let runtimeTreeItem: RuntimeTreeItem;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        await ExtensionUtil.activateExtension();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('local_fabric');
+        runtime = runtimeManager.get('local_fabric');
+        const provider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+        const children: BlockchainTreeItem[] = await provider.getChildren();
+        runtimeTreeItem = children.find((child: BlockchainTreeItem) => child instanceof RuntimeTreeItem) as RuntimeTreeItem;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    it('should enable development mode and not restart a stopped Fabric runtime specified by right clicking the tree', async () => {
+        await runtime.setDevelopmentMode(false);
+        sandbox.stub(runtime, 'isRunning').resolves(false);
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode', runtimeTreeItem);
+        restartStub.should.have.not.been.called;
+        runtime.isDevelopmentMode().should.be.true;
+    });
+
+    it('should disable development mode and not restart a stopped Fabric runtime specified by right clicking the tree', async () => {
+        await runtime.setDevelopmentMode(true);
+        sandbox.stub(runtime, 'isRunning').resolves(false);
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode', runtimeTreeItem);
+        restartStub.should.have.not.been.called;
+        runtime.isDevelopmentMode().should.be.false;
+    });
+
+    it('should enable development mode and restart a running Fabric runtime specified by right clicking the tree', async () => {
+        await runtime.setDevelopmentMode(false);
+        sandbox.stub(runtime, 'isRunning').resolves(true);
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode', runtimeTreeItem);
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        runtime.isDevelopmentMode().should.be.true;
+    });
+
+    it('should disable development mode and restart a running Fabric runtime specified by right clicking the tree', async () => {
+        await runtime.setDevelopmentMode(true);
+        sandbox.stub(runtime, 'isRunning').resolves(true);
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode', runtimeTreeItem);
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        runtime.isDevelopmentMode().should.be.false;
+    });
+
+    it('should enable development mode and not restart a stopped Fabric runtime specified by selecting it from the quick pick', async () => {
+        await runtime.setDevelopmentMode(false);
+        sandbox.stub(runtime, 'isRunning').resolves(false);
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode');
+        quickPickStub.should.have.been.called.calledOnce;
+        restartStub.should.have.not.been.called;
+        runtime.isDevelopmentMode().should.be.true;
+    });
+
+    it('should disable development mode and not restart a stopped Fabric runtime specified by selecting it from the quick pick', async () => {
+        await runtime.setDevelopmentMode(true);
+        sandbox.stub(runtime, 'isRunning').resolves(false);
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode');
+        quickPickStub.should.have.been.called.calledOnce;
+        restartStub.should.have.not.been.called;
+        runtime.isDevelopmentMode().should.be.false;
+    });
+
+    it('should enable development mode and restart a running Fabric runtime specified by selecting it from the quick pick', async () => {
+        await runtime.setDevelopmentMode(false);
+        sandbox.stub(runtime, 'isRunning').resolves(true);
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode');
+        quickPickStub.should.have.been.called.calledOnce;
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        runtime.isDevelopmentMode().should.be.true;
+    });
+
+    it('should disable development mode and restart a running Fabric runtime specified by selecting it from the quick pick', async () => {
+        await runtime.setDevelopmentMode(true);
+        sandbox.stub(runtime, 'isRunning').resolves(true);
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const restartStub: sinon.SinonStub = sandbox.stub(runtime, 'restart').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.toggleFabricRuntimeDevMode');
+        quickPickStub.should.have.been.called.calledOnce;
+        restartStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+        runtime.isDevelopmentMode().should.be.false;
+    });
+
+});

--- a/client/test/explorer/model/RuntimeTreeItem.test.ts
+++ b/client/test/explorer/model/RuntimeTreeItem.test.ts
@@ -20,6 +20,7 @@ import { FabricRuntimeManager } from '../../../src/fabric/FabricRuntimeManager';
 import { FabricRuntime } from '../../../src/fabric/FabricRuntime';
 import { FabricRuntimeRegistry } from '../../../src/fabric/FabricRuntimeRegistry';
 import { FabricConnectionRegistry } from '../../../src/fabric/FabricConnectionRegistry';
+import { ExtensionUtil } from '../../../src/util/ExtensionUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -28,20 +29,22 @@ const should = chai.should();
 
 describe('RuntimeTreeItem', () => {
 
-    const provider: BlockchainNetworkExplorerProvider = getBlockchainNetworkExplorerProvider();
     const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
     const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
 
     let sandbox: sinon.SinonSandbox;
     let clock: sinon.SinonFakeTimers;
+    let provider: BlockchainNetworkExplorerProvider;
     let runtime: FabricRuntime;
 
     beforeEach(async () => {
+        await ExtensionUtil.activateExtension();
         await connectionRegistry.clear();
         await runtimeRegistry.clear();
         await runtimeManager.clear();
         await runtimeManager.add('myRuntime');
+        provider = getBlockchainNetworkExplorerProvider();
         runtime = runtimeManager.get('myRuntime');
         sandbox = sinon.createSandbox();
         clock = sinon.useFakeTimers({ toFake: ['setInterval', 'clearInterval' ]});
@@ -61,7 +64,7 @@ describe('RuntimeTreeItem', () => {
         it('should have the right properties for a runtime that is not running', async () => {
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             treeItem.label.should.equal('myRuntime  ○');
             treeItem.command.should.deep.equal({
@@ -75,7 +78,7 @@ describe('RuntimeTreeItem', () => {
         it('should have the right properties for a runtime that is busy', async () => {
             sandbox.stub(runtime, 'isBusy').returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             treeItem.label.should.equal('myRuntime  ◐');
             should.equal(treeItem.command, null);
@@ -85,7 +88,7 @@ describe('RuntimeTreeItem', () => {
         it('should animate the label for a runtime that is busy', async () => {
             sandbox.stub(runtime, 'isBusy').returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             const states: string[] = [ '◐', '◓', '◑', '◒', '◐' ];
             for (const state of states) {
@@ -98,7 +101,7 @@ describe('RuntimeTreeItem', () => {
         it('should have the right properties for a runtime that is running', async () => {
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(true);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             treeItem.label.should.equal('myRuntime  ●');
             treeItem.command.should.deep.equal({
@@ -113,7 +116,7 @@ describe('RuntimeTreeItem', () => {
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             treeItem.label.should.equal('myRuntime  ○');
             treeItem.command.should.deep.equal({
@@ -134,7 +137,7 @@ describe('RuntimeTreeItem', () => {
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             isBusyStub.returns(true);
             runtime.emit('busy', true);
@@ -151,7 +154,7 @@ describe('RuntimeTreeItem', () => {
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
-            const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
             await new Promise((resolve) => { setTimeout(resolve, 0); });
             treeItem.label.should.equal('myRuntime  ◐');
             should.equal(treeItem.command, null);
@@ -166,6 +169,53 @@ describe('RuntimeTreeItem', () => {
                 arguments: [treeItem]
             });
             treeItem.contextValue.should.equal('blockchain-runtime-item-stopped');
+        });
+
+        it('should have the right properties for a runtime that is not running in development mode', async () => {
+            sandbox.stub(runtime, 'isDevelopmentMode').returns(true);
+            sandbox.stub(runtime, 'isBusy').returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ○  ∞');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [treeItem]
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-stopped');
+        });
+
+        it('should have the right properties for a runtime that is running in development mode', async () => {
+            sandbox.stub(runtime, 'isDevelopmentMode').returns(true);
+            sandbox.stub(runtime, 'isBusy').returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(true);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            treeItem.label.should.equal('myRuntime  ●  ∞');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.connectEntry',
+                title: '',
+                arguments: ['myRuntime']
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-started');
+        });
+
+        it('should report errors animating the label for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isBusy').returns(true);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', { name: 'myRuntime', managedRuntime: true }, vscode.TreeItemCollapsibleState.None);
+            sandbox.stub(treeItem, 'refresh').throws(new Error('such error'));
+            const showErrorMessageSpy: sinon.SinonSpy = sandbox.spy(vscode.window, 'showErrorMessage');
+            await new Promise((resolve) => { setTimeout(resolve, 0); });
+            const states: string[] = [ '◐', '◓', '◑', '◒', '◐' ];
+            for (const state of states) {
+                treeItem.label.should.equal(`myRuntime  ${state}`);
+                clock.tick(500);
+                await new Promise((resolve) => { setTimeout(resolve, 0); });
+                showErrorMessageSpy.should.have.been.calledOnceWithExactly('such error');
+                showErrorMessageSpy.resetHistory();
+            }
         });
 
     });

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -70,7 +70,8 @@ describe('Extension Tests', () => {
             'blockchainAPackageExplorer.refreshEntry',
             'blockchainExplorer.startFabricRuntime',
             'blockchainExplorer.stopFabricRuntime',
-            'blockchainExplorer.restartFabricRuntime'
+            'blockchainExplorer.restartFabricRuntime',
+            'blockchainExplorer.toggleFabricRuntimeDevMode'
         ]);
     });
 
@@ -91,7 +92,8 @@ describe('Extension Tests', () => {
             'onCommand:blockchainAPackageExplorer.packageSmartContractProject',
             'onCommand:blockchainExplorer.startFabricRuntime',
             'onCommand:blockchainExplorer.stopFabricRuntime',
-            'onCommand:blockchainExplorer.restartFabricRuntime'
+            'onCommand:blockchainExplorer.restartFabricRuntime',
+            'onCommand:blockchainExplorer.toggleFabricRuntimeDevMode'
         ]);
     });
 


### PR DESCRIPTION
Add a new command "Toggle Development Mode" that toggles development mode for the automatically created Fabric runtime `local_fabric`. The command will restart the Fabric runtime if it is already running, but not start it if it is already stopped. The tree view will show the "infinity" symbol next to the Fabric runtime if it is in development mode. This contributes to issue #42.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>