### PR TITLE
Use new contract generator instead of chaincode generator

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -284,7 +284,7 @@
         "decache": "4.4.0",
         "electron": "2.0.7",
         "electron-rebuild": "1.8.2",
-        "generator-fabric": "^0.0.2",
+        "generator-fabric": "^0.0.4",
         "glob": "7.1.2",
         "istanbul": "0.4.5",
         "license-check-and-add": "2.3.6",

--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -84,28 +84,28 @@ export async function createSmartContractProject(): Promise<void> {
         }
     }
 
-    let chaincodeLanguageOptions: string[];
-    let chaincodeLanguage: string;
-    outputAdapter.log('Getting chaincode languages...');
+    let smartContractLanguageOptions: string[];
+    let smartContractLanguage: string;
+    outputAdapter.log('Getting smart contract languages...');
     try {
-        chaincodeLanguageOptions = await getChaincodeLanguageOptions();
+        smartContractLanguageOptions = await getSmartContractLanguageOptions();
     } catch (error) {
-        console.log('Issue determining available chaincode languages:', error);
-        window.showErrorMessage('Issue determining available chaincode language options');
+        console.log('Issue determining available smart contract languages:', error);
+        window.showErrorMessage('Issue determining available smart contract language options');
         return;
     }
-    const choseChaincodeLanguageQuickPickOptions = {
-        placeHolder: 'Chose chaincode language (Esc to cancel)',
+    const choseSmartContractLanguageQuickPickOptions = {
+        placeHolder: 'Chose smart contract language (Esc to cancel)',
         ignoreFocusOut: true,
         matchOnDetail: true
     };
-    chaincodeLanguage = await window.showQuickPick(chaincodeLanguageOptions, choseChaincodeLanguageQuickPickOptions);
-    if (!chaincodeLanguageOptions.includes(chaincodeLanguage)) {
+    smartContractLanguage = await window.showQuickPick(smartContractLanguageOptions, choseSmartContractLanguageQuickPickOptions);
+    if (!smartContractLanguageOptions.includes(smartContractLanguage)) {
         // User has cancelled the QuickPick box
         return;
     }
-    chaincodeLanguage = chaincodeLanguage.toLowerCase();
-    console.log('chosen chaincode language is:' + chaincodeLanguage);
+    smartContractLanguage = smartContractLanguage.toLowerCase();
+    console.log('chosen contract language is:' + smartContractLanguage);
 
     // Prompt the user for a file system folder
     const openDialogOptions = {
@@ -121,7 +121,7 @@ export async function createSmartContractProject(): Promise<void> {
 
         // Run yo:fabric with default options in folderSelect
         // redirect to stdout as yo fabric prints to stderr
-        const yoFabricCmd: string = `yo fabric:chaincode -- --language="${chaincodeLanguage}" --name="new-smart-contract" --version=0.0.1 --description="My Smart Contract" --author="John Doe" --license=Apache-2.0 2>&1`;
+        const yoFabricCmd: string = `yo fabric:contract -- --language="${smartContractLanguage}" --name="new-smart-contract" --version=0.0.1 --description="My Smart Contract" --author="John Doe" --license=Apache-2.0 2>&1`;
         try {
             const yoFabricOut = await CommandUtil.sendCommand(yoFabricCmd, folderSelect[0].fsPath);
             outputAdapter.log(yoFabricOut);
@@ -136,29 +136,29 @@ export async function createSmartContractProject(): Promise<void> {
 
 } // end of createSmartContractProject function
 
-export async function getChaincodeLanguageOptions(): Promise<string[]> {
-    const yoFabricChild: child_process.ChildProcess = await child_process.spawn('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+export async function getSmartContractLanguageOptions(): Promise<string[]> {
+    const yoFabricChild: child_process.ChildProcess = await child_process.spawn('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
     return new Promise<string[]>((resolve, reject) => {
         yoFabricChild.on('exit', (returnCode: number) => {
             const stdout: Buffer = yoFabricChild.stdout.read();
             if (returnCode) {
-                return reject(new Error(`yo fabric: chaincode failed to run with return code ${returnCode}`));
+                return reject(new Error(`yo fabric: contract failed to run with return code ${returnCode}`));
             } else if (stdout) {
-                const chaincodeLanguageArray: string[] = stdout.toString().split('\n');
-                chaincodeLanguageArray.shift();
-                const cleanChaincodeLangaugeArray: string[] = [];
-                for (const language of chaincodeLanguageArray) {
+                const smartContractLanguageArray: string[] = stdout.toString().split('\n');
+                smartContractLanguageArray.shift();
+                const cleanSmartContractLangaugeArray: string[] = [];
+                for (const language of smartContractLanguageArray) {
                     if (language !== '') {
                         // Grab the first word in the string and remove non-word characters
                         const regex: RegExp = /^[^\w]*([\w]+)/g;
                         const regexMatchArray: RegExpMatchArray = regex.exec(language);
-                        cleanChaincodeLangaugeArray.push(regexMatchArray[1]);
+                        cleanSmartContractLangaugeArray.push(regexMatchArray[1]);
                     }
                 }
-                console.log('printing available chaincode languages from yo fabric:chaincode output:', cleanChaincodeLangaugeArray);
-                return resolve(cleanChaincodeLangaugeArray);
+                console.log('printing available contract languages from yo fabric:contract output:', cleanSmartContractLangaugeArray);
+                return resolve(cleanSmartContractLangaugeArray);
             } else {
-                return reject(new Error(`Failed to get output from yo fabric:chaincode`));
+                return reject(new Error(`Failed to get output from yo fabric:contract`));
             }
         });
     });

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -75,8 +75,8 @@ describe('CreateSmartContractProjectCommand', () => {
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         const pathToCheck = path.join(uri.fsPath, 'package.json');
-        const chaincodeExists = await fs_extra.pathExists(pathToCheck);
-        chaincodeExists.should.be.true;
+        const smartContractExists = await fs_extra.pathExists(pathToCheck);
+        smartContractExists.should.be.true;
         executeCommandStub.should.have.been.calledTwice;
         executeCommandStub.should.have.been.calledWith('vscode.openFolder', uriArr[0], true);
         errorSpy.should.not.have.been.called;
@@ -126,7 +126,7 @@ describe('CreateSmartContractProjectCommand', () => {
 
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo blah && echo "  Go" && echo "  JavaScript" && echo "  TypeScript  [45R"']);
         });
         quickPickStub.onCall(1).returns('Go');
@@ -134,7 +134,7 @@ describe('CreateSmartContractProjectCommand', () => {
         openDialogStub.resolves(uriArr);
         sendCommandStub.onCall(3).rejects();
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         errorSpy.should.have.been.calledWith('Issue creating smart contract project');
     });
 
@@ -144,7 +144,7 @@ describe('CreateSmartContractProjectCommand', () => {
 
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo blah && echo "  Go" && echo "  JavaScript" && echo "  TypeScript  [45R"']);
         });
         quickPickStub.onCall(0).returns('JavaScript');
@@ -152,18 +152,19 @@ describe('CreateSmartContractProjectCommand', () => {
         openDialogStub.resolves(undefined);
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         openDialogStub.should.have.been.calledOnce;
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         executeCommandStub.should.have.been.calledOnce;
         executeCommandStub.should.have.not.been.calledWith('vscode.openFolder');
         errorSpy.should.not.have.been.called;
     });
 
-    it('should create a go chaincode project when the user selects go as the language', async () => {
+    // Go not currently supported as a smart contract language (targetted at Fabric v1.4).
+    it.skip('should create a go smart contract project when the user selects go as the language', async () => {
         sendCommandStub.restore();
 
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo blah && echo "  Go" && echo "  JavaScript" && echo "  TypeScript  [45R"']);
         });
         quickPickStub.onCall(0).returns('Go');
@@ -171,56 +172,56 @@ describe('CreateSmartContractProjectCommand', () => {
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         const pathToCheck = path.join(uri.fsPath, 'main.go');
-        const chaincodeExists = await fs_extra.pathExists(pathToCheck);
-        chaincodeExists.should.be.true;
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        const smartContractExists = await fs_extra.pathExists(pathToCheck);
+        smartContractExists.should.be.true;
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         executeCommandStub.should.have.been.calledTwice;
         executeCommandStub.should.have.been.calledWith('vscode.openFolder', uriArr[0], true);
         errorSpy.should.not.have.been.called;
     }).timeout(20000);
 
-    it('should show an error if determining available chaincode languages fails', async () => {
+    it('should show an error if determining available smart contract languages fails', async () => {
         sendCommandStub.restore();
 
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo stderr >&2 && false']);
         });
         openDialogStub.resolves(uriArr);
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         executeCommandStub.should.have.been.calledOnce;
-        errorSpy.should.have.been.calledWith('Issue determining available chaincode language options');
+        errorSpy.should.have.been.calledWith('Issue determining available smart contract language options');
     }).timeout(20000);
 
-    it('should show an error if determining available chaincode languages returns nothing', async () => {
+    it('should show an error if determining available smart contract languages returns nothing', async () => {
         sendCommandStub.restore();
 
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo stderr >&2 && true']);
         });
         openDialogStub.resolves(uriArr);
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         executeCommandStub.should.have.been.calledOnce;
-        errorSpy.should.have.been.calledWith('Issue determining available chaincode language options');
+        errorSpy.should.have.been.calledWith('Issue determining available smart contract language options');
     }).timeout(20000);
 
-    it('should not do anything if the user cancels chosing a chaincode language', async () => {
+    it('should not do anything if the user cancels chosing a smart contract language', async () => {
         sendCommandStub.restore();
         const originalSpawn = child_process.spawn;
         const spawnStub: sinon.SinonStub = mySandBox.stub(child_process, 'spawn');
-        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']).callsFake(() => {
+        spawnStub.withArgs('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']).callsFake(() => {
             return originalSpawn('/bin/sh', ['-c', 'echo blah && echo "  Go" && echo "  JavaScript" && echo "  TypeScript  [45R"']);
         });
         quickPickStub.resolves(undefined);
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
-        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:chaincode < /dev/null']);
+        spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         quickPickStub.should.have.been.calledOnce;
         errorSpy.should.not.have.been.called;
         openDialogStub.should.not.have.been.called;


### PR DESCRIPTION
Resolves #51 

Switch to the new `fabric:contract` generator delivered in `generator-fabric@0.0.4`, which generates smart contracts as per the work being delivered in Fabric v1.3 - see [FAB-11246](https://jira.hyperledger.org/browse/FAB-11246) for details!

As part of this PR, we lose support for Go, for which smart contract support has been deferred to Fabric v1.4 😢

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>