### PR TITLE
Use directory base name as smart contract name

### DIFF
--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -16,6 +16,7 @@ import { window, Uri, commands } from 'vscode';
 import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
 import { CommandUtil } from '../util/CommandUtil';
 import * as child_process from 'child_process';
+import * as path from 'path';
 
 export async function createSmartContractProject(): Promise<void> {
     console.log('create Smart Contract Project');
@@ -115,15 +116,19 @@ export async function createSmartContractProject(): Promise<void> {
     const folderSelect: Uri[] | undefined = await window.showOpenDialog(openDialogOptions);
     if (folderSelect) {  // undefined if the user cancels the open dialog box
 
+        const folderUri: Uri = folderSelect[0];
+        const folderPath: string = folderUri.fsPath;
+        const folderName: string = path.basename(folderPath);
+
         // Open the returned folder in explorer, in a new window
-        console.log('new smart contract project folder is :' + folderSelect[0].fsPath);
-        await commands.executeCommand('vscode.openFolder', folderSelect[0], true);
+        console.log('new smart contract project folder is :' + folderPath);
+        await commands.executeCommand('vscode.openFolder', folderUri, true);
 
         // Run yo:fabric with default options in folderSelect
         // redirect to stdout as yo fabric prints to stderr
-        const yoFabricCmd: string = `yo fabric:contract -- --language="${smartContractLanguage}" --name="new-smart-contract" --version=0.0.1 --description="My Smart Contract" --author="John Doe" --license=Apache-2.0 2>&1`;
+        const yoFabricCmd: string = `yo fabric:contract -- --language="${smartContractLanguage}" --name="${folderName}" --version=0.0.1 --description="My Smart Contract" --author="John Doe" --license=Apache-2.0 2>&1`;
         try {
-            const yoFabricOut = await CommandUtil.sendCommand(yoFabricCmd, folderSelect[0].fsPath);
+            const yoFabricOut = await CommandUtil.sendCommand(yoFabricCmd, folderPath);
             outputAdapter.log(yoFabricOut);
             outputAdapter.log('Successfully generated smart contract project');
         } catch (error) {

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -76,10 +76,17 @@ describe('CreateSmartContractProjectCommand', () => {
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         const pathToCheck = path.join(uri.fsPath, 'package.json');
         const smartContractExists = await fs_extra.pathExists(pathToCheck);
+        const fileContents = await fs_extra.readFile(pathToCheck, 'utf8');
+        const packageJSON = JSON.parse(fileContents);
         smartContractExists.should.be.true;
         executeCommandStub.should.have.been.calledTwice;
         executeCommandStub.should.have.been.calledWith('vscode.openFolder', uriArr[0], true);
         errorSpy.should.not.have.been.called;
+        packageJSON.name.should.equal(path.basename(uri.fsPath));
+        packageJSON.version.should.equal('0.0.1');
+        packageJSON.description.should.equal('My Smart Contract');
+        packageJSON.author.should.equal('John Doe');
+        packageJSON.license.should.equal('Apache-2.0');
     }).timeout(20000);
 
     it('should show error if npm is not installed', async () => {


### PR DESCRIPTION
Resolves #54

The smart contract name passed to the generator is always `new-smart-contract`, which means that the package created is called `new-smart-contract`, and it will be deployed as `new-smart-contract`. We should use the base name of the directory - e.g. `commerical-paper` for `~/git/commercial-paper`.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>