### PR TITLE
Add progress boxes, switch ordering

### DIFF
--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -12,41 +12,34 @@
  * limitations under the License.
 */
 'use strict';
-import { window, Uri, commands } from 'vscode';
+import { window, Uri, commands, ProgressLocation } from 'vscode';
 import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
 import { CommandUtil } from '../util/CommandUtil';
 import * as child_process from 'child_process';
 import * as path from 'path';
 
+class GeneratorDependencies {
+    needYo: boolean = false;
+    needGenFab: boolean = false;
+    constructor(options?: object) {
+        Object.assign(this, options);
+    }
+    missingDependencies(): boolean {
+        return this.needYo || this.needGenFab;
+    }
+}
+
 export async function createSmartContractProject(): Promise<void> {
     console.log('create Smart Contract Project');
-    // check for yo and generator-fabric
-    let needYo: boolean = false;
-    let needGenFab: boolean = false;
 
-    try {
-        await CommandUtil.sendCommand('npm view yo version');
-        console.log('yo is installed');
-        try {
-            await CommandUtil.sendCommand('npm view generator-fabric version');
-            console.log('generator-fabric installed');
-        } catch (error) {
-            needGenFab = true;
-            console.log('generator-fabric missing');
-        }
-    } catch (error) {
-        if (error.message.includes('npm ERR')) {
-            console.log('npm installed, yo missing');
-            needYo = true;
-            needGenFab = true; // assume generator-fabric isn't installed either
-        } else {
-            console.log('npm not installed');
-            window.showErrorMessage('npm is required before creating a smart contract project');
-            return;
-        }
+    // check for yo and generator-fabric
+    const dependencies: GeneratorDependencies = await checkGeneratorDependenciesWithProgress();
+    if (!dependencies) {
+        return;
     }
+
     // if yo/generator fabric are missing, ask if we can install them
-    if (needYo || needGenFab) {
+    if (dependencies.missingDependencies()) {
         const quickPickOptions = {
             placeHolder: 'Can this extension install missing npm packages before proceeding?',
             ignoreFocusOut: true
@@ -62,25 +55,9 @@ export async function createSmartContractProject(): Promise<void> {
     const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
 
     // Install missing node modules
-    if (needYo) {
-        outputAdapter.log('Installing yo');
-        try {
-            const yoInstOut: string = await CommandUtil.sendCommand('npm install -g yo');
-            outputAdapter.log(yoInstOut);
-        } catch (error) {
-            window.showErrorMessage('Issue installing yo node module');
-            outputAdapter.log(error);
-            return;
-        }
-    }
-    if (needGenFab) {
-        outputAdapter.log('Installing generator-fabric');
-        try {
-            const genFabInstOut: string = await CommandUtil.sendCommand('npm install -g generator-fabric');
-            outputAdapter.log(genFabInstOut);
-        } catch (error) {
-            window.showErrorMessage('Issue installing generator-fabric module');
-            outputAdapter.log(error);
+    if (dependencies.missingDependencies()) {
+        const successful: boolean = await installGeneratorDependenciesWithProgress(dependencies);
+        if (!successful) {
             return;
         }
     }
@@ -89,7 +66,7 @@ export async function createSmartContractProject(): Promise<void> {
     let smartContractLanguage: string;
     outputAdapter.log('Getting smart contract languages...');
     try {
-        smartContractLanguageOptions = await getSmartContractLanguageOptions();
+        smartContractLanguageOptions = await getSmartContractLanguageOptionsWithProgress();
     } catch (error) {
         console.log('Issue determining available smart contract languages:', error);
         window.showErrorMessage('Issue determining available smart contract language options');
@@ -120,26 +97,121 @@ export async function createSmartContractProject(): Promise<void> {
         const folderPath: string = folderUri.fsPath;
         const folderName: string = path.basename(folderPath);
 
-        // Open the returned folder in explorer, in a new window
-        console.log('new smart contract project folder is :' + folderPath);
-        await commands.executeCommand('vscode.openFolder', folderUri, true);
-
         // Run yo:fabric with default options in folderSelect
         // redirect to stdout as yo fabric prints to stderr
         const yoFabricCmd: string = `yo fabric:contract -- --language="${smartContractLanguage}" --name="${folderName}" --version=0.0.1 --description="My Smart Contract" --author="John Doe" --license=Apache-2.0 2>&1`;
         try {
-            const yoFabricOut = await CommandUtil.sendCommand(yoFabricCmd, folderPath);
+            const yoFabricOut = await CommandUtil.sendCommandWithProgress(yoFabricCmd, folderPath, 'Generating smart contract...');
             outputAdapter.log(yoFabricOut);
             outputAdapter.log('Successfully generated smart contract project');
         } catch (error) {
             console.log('found issue running yo:fabric command:', error);
             window.showErrorMessage('Issue creating smart contract project');
             outputAdapter.log(error);
+            return;
         }
+
+        // Open the returned folder in explorer, in a new window
+        console.log('new smart contract project folder is :' + folderPath);
+        await commands.executeCommand('vscode.openFolder', folderUri, true);
 
     } // end of if folderSelect
 
 } // end of createSmartContractProject function
+
+export async function checkGeneratorDependenciesWithProgress(): Promise<GeneratorDependencies> {
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token): Promise<GeneratorDependencies> => {
+        progress.report({ message: `Checking smart contract generator dependencies...` });
+        return checkGeneratorDependencies();
+    });
+}
+
+export async function checkGeneratorDependencies(): Promise<GeneratorDependencies> {
+    let needYo: boolean = false;
+    let needGenFab: boolean = false;
+
+    try {
+        await CommandUtil.sendCommand('npm view yo version');
+        console.log('yo is installed');
+        try {
+            await CommandUtil.sendCommand('npm view generator-fabric version');
+            console.log('generator-fabric installed');
+        } catch (error) {
+            needGenFab = true;
+            console.log('generator-fabric missing');
+        }
+    } catch (error) {
+        if (error.message.includes('npm ERR')) {
+            console.log('npm installed, yo missing');
+            needYo = true;
+            needGenFab = true; // assume generator-fabric isn't installed either
+        } else {
+            console.log('npm not installed');
+            window.showErrorMessage('npm is required before creating a smart contract project');
+            return null;
+        }
+    }
+
+    return new GeneratorDependencies({ needYo, needGenFab });
+}
+
+export async function installGeneratorDependenciesWithProgress(dependencies: GeneratorDependencies): Promise<boolean> {
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token) => {
+        progress.report({ message: `Installing smart contract generator dependencies...` });
+        return installGeneratorDependencies(dependencies);
+    });
+}
+
+export async function installGeneratorDependencies(dependencies: GeneratorDependencies): Promise<boolean> {
+
+    // Create and show output channel
+    const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
+
+    // Install missing node modules
+    if (dependencies.needYo) {
+        outputAdapter.log('Installing yo');
+        try {
+            const yoInstOut: string = await CommandUtil.sendCommand('npm install -g yo');
+            outputAdapter.log(yoInstOut);
+        } catch (error) {
+            window.showErrorMessage('Issue installing yo node module');
+            outputAdapter.log(error);
+            return false;
+        }
+    }
+
+    // it is assumed that if we got here we need to install the generator.
+    outputAdapter.log('Installing generator-fabric');
+    try {
+        const genFabInstOut: string = await CommandUtil.sendCommand('npm install -g generator-fabric');
+        outputAdapter.log(genFabInstOut);
+    } catch (error) {
+        window.showErrorMessage('Issue installing generator-fabric module');
+        outputAdapter.log(error);
+        return false;
+    }
+    return true;
+
+}
+
+export async function getSmartContractLanguageOptionsWithProgress(): Promise<string[]> {
+    return window.withProgress({
+        location: ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token): Promise<string[]> => {
+        progress.report({ message: `Getting smart contract languages...` });
+        return getSmartContractLanguageOptions();
+    });
+}
 
 export async function getSmartContractLanguageOptions(): Promise<string[]> {
     const yoFabricChild: child_process.ChildProcess = await child_process.spawn('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);

--- a/client/src/util/CommandUtil.ts
+++ b/client/src/util/CommandUtil.ts
@@ -13,6 +13,7 @@
 */
 'use strict';
 
+import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 import stripAnsi = require('strip-ansi');
 
@@ -28,6 +29,17 @@ export class CommandUtil {
     public static async sendCommand(command: string, cwd ?: string): Promise<string> {
         const result: childProcessPromise.childProcessPromise = await exec(command, {cwd: cwd});
         return result.stdout.trim();
+    }
+
+    public static async sendCommandWithProgress(command: string, cwd: string, message: string): Promise<string> {
+        return vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'Blockchain Extension',
+            cancellable: false
+        }, async (progress, token): Promise<string> => {
+            progress.report({ message });
+            return this.sendCommand(command, cwd);
+        });
     }
 
     public static async sendCommandWithOutput(command: string, args: Array<string>, cwd?: string, env?: any, outputAdapter?: OutputAdapter): Promise<void> {

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -94,7 +94,7 @@ describe('CreateSmartContractProjectCommand', () => {
         sendCommandStub.onCall(0).rejects();
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         errorSpy.should.have.been.calledWith('npm is required before creating a smart contract project');
-    });
+    }).timeout(20000);
 
     it('should show error is yo is not installed and not wanted', async () => {
         // yo not installed and not wanted
@@ -102,7 +102,7 @@ describe('CreateSmartContractProjectCommand', () => {
         quickPickStub.resolves('no');
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         errorSpy.should.have.been.calledWith('npm modules: yo and generator-fabric are required before creating a smart contract project');
-    });
+    }).timeout(20000);
 
     it('should show error message if generator-fabric fails to install', async () => {
         // generator-fabric not installed and wanted but fails to install
@@ -112,7 +112,7 @@ describe('CreateSmartContractProjectCommand', () => {
         sendCommandStub.onCall(2).rejects();
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         errorSpy.should.have.been.calledWith('Issue installing generator-fabric module');
-    });
+    }).timeout(20000);
 
     it('should show error message if yo fails to install', async () => {
         // yo not installed and wanted but fails to install
@@ -121,7 +121,7 @@ describe('CreateSmartContractProjectCommand', () => {
         sendCommandStub.onCall(1).rejects();
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         errorSpy.should.have.been.calledWith('Issue installing yo node module');
-    });
+    }).timeout(20000);
 
     it('should show error message if we fail to create a smart contract', async () => {
         // generator-fabric and yo not installed and wanted
@@ -143,7 +143,7 @@ describe('CreateSmartContractProjectCommand', () => {
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         spawnStub.should.have.been.calledWith('/bin/sh', ['-c', 'yo fabric:contract < /dev/null']);
         errorSpy.should.have.been.calledWith('Issue creating smart contract project');
-    });
+    }).timeout(20000);
 
     it('should should not do anything if the user cancels the open dialog', async () => {
         // We actually want to execute the command!
@@ -163,7 +163,7 @@ describe('CreateSmartContractProjectCommand', () => {
         executeCommandStub.should.have.been.calledOnce;
         executeCommandStub.should.have.not.been.calledWith('vscode.openFolder');
         errorSpy.should.not.have.been.called;
-    });
+    }).timeout(20000);
 
     // Go not currently supported as a smart contract language (targetted at Fabric v1.4).
     it.skip('should create a go smart contract project when the user selects go as the language', async () => {
@@ -232,6 +232,6 @@ describe('CreateSmartContractProjectCommand', () => {
         quickPickStub.should.have.been.calledOnce;
         errorSpy.should.not.have.been.called;
         openDialogStub.should.not.have.been.called;
-    });
+    }).timeout(20000);
 
 }); // end of createFabricCommand tests

--- a/client/test/util/CommandUtil.test.ts
+++ b/client/test/util/CommandUtil.test.ts
@@ -48,6 +48,15 @@ describe('CommandUtil Tests', () => {
         });
     });
 
+    describe('sendCommandWithProgress', () => {
+        it('should send a shell command', async () => {
+            const rootPath = path.dirname(__dirname);
+            const uri: vscode.Uri = vscode.Uri.file(path.join(rootPath, '../../test'));
+            const command = await CommandUtil.sendCommandWithProgress('echo Hyperledgendary', uri.fsPath, 'such progress message');
+            command.should.equal('Hyperledgendary');
+        });
+    });
+
     describe('sendCommandWithOutput', () => {
         it('should send a command and get output', async () => {
             const spawnSpy = mySandBox.spy(child_process, 'spawn');


### PR DESCRIPTION
Resolves #33
Resolves #49 

Add progress boxes to the new smart contract command so that long running operations do not appear as if nothing is happening, and re-order the generator and the opening of the folder so that an empty folder is not opened before the code appears!

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>