### PR TITLE
Pull and tag Fabric v1.3 development images from Nexus

### DIFF
--- a/client/basic-network/docker-compose.yml
+++ b/client/basic-network/docker-compose.yml
@@ -78,6 +78,7 @@ services:
       # VSCODE - 7051:7051
       # VSCODE - 7053:7053
       - 7051
+      - 7052
       - 7053
     volumes:
         - /var/run/:/host/var/run/

--- a/client/basic-network/start.sh
+++ b/client/basic-network/start.sh
@@ -12,6 +12,14 @@ export MSYS_NO_PATHCONV=1
 
 docker-compose -f docker-compose.yml down
 
+# Download and tag latest development images from Hyperledger Nexus server.
+# Delete these 5 lines once Fabric v1.3 has been shipped!
+for IMAGE in hyperledger/fabric-ca hyperledger/fabric-orderer hyperledger/fabric-peer hyperledger/fabric-tools hyperledger/fabric-ccenv
+do
+    docker pull nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable
+    docker tag nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable ${IMAGE}
+done
+
 docker-compose -f docker-compose.yml up -d ca.example.com orderer.example.com peer0.org1.example.com couchdb
 
 # wait for Hyperledger Fabric to start


### PR DESCRIPTION
Pull and tag Fabric v1.3 development images from Nexus, so that the `local_fabric` is running Fabric v1.3, and you can actually deploy the new smart contract code to the `local_fabric`. This code will need modifying once Fabric v1.3 is released to Docker Hub, but for now...

Also, expose the chaincode gRPC port so that you can attach chaincode to the `local_fabric` in development mode - currently it's not exposed! This will come in handy for debugging later on.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>