### PR TITLE
Make travis build quicker

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -25,9 +25,8 @@ npm install --ignore-scripts
 
 npm run compile
 
-
 if [ "${TASK}" == "unit" ]; then
-    node ./node_modules/.bin/electron-rebuild -v 2.0
+    npm rebuild grpc --target=2.0.0 --runtime=electron --dist-url=https://atom.io/download/electron
 
     if [ $TRAVIS_OS_NAME == "linux" ]; then
         export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;

--- a/client/package.json
+++ b/client/package.json
@@ -307,8 +307,6 @@
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
     "decache": "4.4.0",
-    "electron": "2.0.7",
-    "electron-rebuild": "1.8.2",
     "generator-fabric": "^0.0.4",
     "glob": "7.1.2",
     "istanbul": "0.4.5",


### PR DESCRIPTION
Update to use npm rebuild rather than electron rebuild

contributes to IBM-Blockchain/blockchain-vscode-extension#88

Signed-off-by: Caroline Church <caroline.church@uk.ibm.com>