### PR TITLE
Preserve user settings after running tests

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -19,3 +19,4 @@ coverage
 .DS_Store
 /test/data/fabricProject
 /test/data/smartContractDir/
+/integrationTest/smartContractDir/

--- a/client/integrationTest/integration.test.ts
+++ b/client/integrationTest/integration.test.ts
@@ -37,6 +37,7 @@ import { InstalledChainCodeTreeItem } from '../src/explorer/model/InstalledChain
 import { InstalledChainCodeVersionTreeItem } from '../src/explorer/model/InstalledChaincodeVersionTreeItem';
 import { PackageRegistryEntry } from '../src/packages/PackageRegistryEntry';
 import { PackageRegistry } from '../src/packages/PackageRegistry';
+import { TestUtil } from '../test/TestUtil';
 
 chai.should();
 chai.use(sinonChai);
@@ -59,12 +60,18 @@ describe('Integration Test', () => {
         certPath = path.join(__dirname, `../../integrationTest/hlfv1/crypto-config/peerOrganizations/org1.example.com/users/Admin@org1.example.com/msp/signcerts/Admin@org1.example.com-cert.pem`);
 
         await ExtensionUtil.activateExtension();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+        await TestUtil.storePackageDirectoryConfig();
 
         VSCodeOutputAdapter.instance().setConsole(true);
     });
 
-    after(() => {
+    after(async () => {
         VSCodeOutputAdapter.instance().setConsole(false);
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+        await TestUtil.restorePackageDirectoryConfig();
     });
 
     beforeEach(() => {

--- a/client/src/fabric/FabricClientConnection.ts
+++ b/client/src/fabric/FabricClientConnection.ts
@@ -40,7 +40,7 @@ export class FabricClientConnection extends FabricConnection implements IFabricC
         let connectionProfile;
         if (this.connectionProfilePath.endsWith('.json')) {
             connectionProfile = JSON.parse(connectionProfileContents);
-        } else if (this.connectionProfilePath.endsWith('.yaml')) {
+        } else if (this.connectionProfilePath.endsWith('.yaml') || this.connectionProfilePath.endsWith('.yml')) {
             connectionProfile = yaml.safeLoad(connectionProfileContents);
         } else {
             console.log('Connection Profile given is not .json/.yaml format:', this.connectionProfilePath);

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -26,4 +26,33 @@ export class TestUtil {
             myExtension.registerCommands(context);
         }
     }
+    static async storePackageDirectoryConfig() {
+        this.USER_PACKAGE_DIR_CONFIG = await vscode.workspace.getConfiguration().get('fabric.package.directory');
+        console.log('Storing user package directory:', this.USER_PACKAGE_DIR_CONFIG);
+    }
+    static async restorePackageDirectoryConfig() {
+        console.log('Restoring user package directory to settings:', this.USER_PACKAGE_DIR_CONFIG);
+        await vscode.workspace.getConfiguration().update('fabric.package.directory', this.USER_PACKAGE_DIR_CONFIG, vscode.ConfigurationTarget.Global);
+    }
+    static async storeConnectionsConfig() {
+        this.USER_CONNECTIONS_CONFIG = await vscode.workspace.getConfiguration().get('fabric.connections');
+        console.log('Storing user connections config:', this.USER_CONNECTIONS_CONFIG);
+    }
+    static async restoreConnectionsConfig() {
+        console.log('Restoring user connections config to settings:', this.USER_CONNECTIONS_CONFIG);
+        await vscode.workspace.getConfiguration().update('fabric.connections', this.USER_CONNECTIONS_CONFIG, vscode.ConfigurationTarget.Global);
+    }
+
+    static async storeRuntimesConfig() {
+        this.USER_RUNTIMES_CONFIG = await vscode.workspace.getConfiguration().get('fabric.runtimes');
+        console.log('Storing user runtimes:', this.USER_RUNTIMES_CONFIG);
+    }
+    static async restoreRuntimesConfig() {
+        console.log('Restoring user runtimes config to settings:', this.USER_RUNTIMES_CONFIG);
+        await vscode.workspace.getConfiguration().update('fabric.runtimes', this.USER_RUNTIMES_CONFIG, vscode.ConfigurationTarget.Global);
+    }
+
+    private static USER_PACKAGE_DIR_CONFIG;
+    private static USER_CONNECTIONS_CONFIG;
+    private static USER_RUNTIMES_CONFIG;
 }

--- a/client/test/commands/addConnectionCommand.test.ts
+++ b/client/test/commands/addConnectionCommand.test.ts
@@ -29,6 +29,11 @@ describe('AddConnectionCommand', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
     });
 
     describe('addConnection', () => {

--- a/client/test/commands/addConnectionIdentityCommand.test.ts
+++ b/client/test/commands/addConnectionIdentityCommand.test.ts
@@ -31,6 +31,11 @@ describe('AddConnectionIdentityCommand', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
     });
 
     describe('addConnectionIdentity', () => {

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -46,6 +46,13 @@ describe('ConnectCommand', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
     });
 
     describe('connect', () => {

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -302,7 +302,7 @@ describe('CreateSmartContractProjectCommand', () => {
         quickPickStub.onCall(0).resolves('yes');
         // npm install works
         sendCommandStub.onCall(1).resolves(USER_TEST_DATA);
-        const sendCommandWithProgressStub = mySandBox.stub(CommandUtil, 'sendCommandWithProgress').rejects();
+        mySandBox.stub(CommandUtil, 'sendCommandWithProgress').rejects();
         quickPickStub.onCall(1).returns('JavaScript');
         quickPickStub.onCall(2).resolves(UserInputUtil.OPEN_IN_NEW_WINDOW);
         openDialogStub.resolves(uriArr);
@@ -376,19 +376,18 @@ describe('CreateSmartContractProjectCommand', () => {
         openDialogStub.should.not.have.been.called;
     }).timeout(20000);
 
-    it('generator-fabric package.json does not exist', async () => {
+    it('should show an error if generator-fabric package.json does not exist', async () => {
         sendCommandStub.onCall(0).resolves();
 
         sendCommandStub.onCall(1).resolves('0.0.7');
         const wrongPath = path.join(path.dirname(__dirname), '../../test/data/nonexistent');
         sendCommandStub.onCall(2).resolves(wrongPath);
-        const sendCommandWithProgressSpy = mySandBox.spy(CommandUtil, 'sendCommandWithProgress');
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         errorSpy.should.have.been.calledWith('npm modules: yo and generator-fabric are required before creating a smart contract project');
     });
 
-    it('contract languages doesnt exist in generator-fabric package.json', async () => {
+    it('should show an error if contract languages doesnt exist in generator-fabric package.json', async () => {
         sendCommandStub.withArgs('npm config get prefix').resolves(USER_TEST_DATA);
 
         mySandBox.stub(fs, 'readJson').resolves({name: 'generator-fabric', version: '0.0.7'});
@@ -397,7 +396,6 @@ describe('CreateSmartContractProjectCommand', () => {
         sendCommandStub.onCall(1).resolves('0.0.7');
 
         sendCommandStub.onCall(2).resolves(USER_TEST_DATA);
-        const sendCommandWithProgressSpy = mySandBox.spy(CommandUtil, 'sendCommandWithProgress');
 
         await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
         const error = 'Contract languages not found in package.json';
@@ -405,7 +403,7 @@ describe('CreateSmartContractProjectCommand', () => {
     });
 
     it('should send a telemetry event if the extension is for production', async () => {
-        const extensionUtilStub = mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: true});
+        mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: true});
         const reporterSpy = mySandBox.spy(Reporter.instance(), 'sendTelemetryEvent');
 
         sendCommandStub.restore();

--- a/client/test/commands/deleteConnectionCommand.test.ts
+++ b/client/test/commands/deleteConnectionCommand.test.ts
@@ -31,6 +31,11 @@ describe('DeleteConnectionCommand', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
     });
 
     describe('deleteConnection', () => {

--- a/client/test/commands/deleteSmartContractPackageCommand.test.ts
+++ b/client/test/commands/deleteSmartContractPackageCommand.test.ts
@@ -29,19 +29,17 @@ chai.should();
 chai.use(sinonChai);
 
 describe('DeleteSmartContractPackageCommand', () => {
-    let USER_PACKAGE_DIRECTORY;
-    // Update the user's configuration
     const TEST_PACKAGE_DIRECTORY = path.join(path.dirname(__dirname), '../../test/data/smartContractDir');
 
     before(async () => {
-        // Get the user's current 'smart contract packages' directory location. This will be used later to update the configuration.
-        USER_PACKAGE_DIRECTORY = await vscode.workspace.getConfiguration().get('fabric.package.directory');
-        await vscode.workspace.getConfiguration().update('fabric.package.directory', TEST_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
         await TestUtil.setupTests();
+        await TestUtil.storePackageDirectoryConfig();
+        await vscode.workspace.getConfiguration().update('fabric.package.directory', TEST_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
+
     });
 
     after(async () => {
-        await vscode.workspace.getConfiguration().update('fabric.package.directory', USER_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
+        await TestUtil.restorePackageDirectoryConfig();
 
     });
 

--- a/client/test/commands/restartFabricRuntime.test.ts
+++ b/client/test/commands/restartFabricRuntime.test.ts
@@ -24,6 +24,7 @@ import { BlockchainNetworkExplorerProvider } from '../../src/explorer/Blockchain
 import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
 import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { TestUtil } from '../TestUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -38,6 +39,17 @@ describe('restartFabricRuntime', () => {
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtime: FabricRuntime;
     let runtimeTreeItem: RuntimeTreeItem;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();

--- a/client/test/commands/startFabricRuntime.test.ts
+++ b/client/test/commands/startFabricRuntime.test.ts
@@ -24,6 +24,7 @@ import { BlockchainNetworkExplorerProvider } from '../../src/explorer/Blockchain
 import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
 import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { TestUtil } from '../TestUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -39,6 +40,17 @@ describe('startFabricRuntime', () => {
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtime: FabricRuntime;
     let runtimeTreeItem: RuntimeTreeItem;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();

--- a/client/test/commands/stopFabricRuntime.test.ts
+++ b/client/test/commands/stopFabricRuntime.test.ts
@@ -24,6 +24,7 @@ import { BlockchainNetworkExplorerProvider } from '../../src/explorer/Blockchain
 import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
 import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { TestUtil } from '../TestUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -38,6 +39,17 @@ describe('stopFabricRuntime', () => {
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtime: FabricRuntime;
     let runtimeTreeItem: RuntimeTreeItem;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();

--- a/client/test/commands/toggleFabricRuntimeDevMode.test.ts
+++ b/client/test/commands/toggleFabricRuntimeDevMode.test.ts
@@ -24,6 +24,7 @@ import { BlockchainNetworkExplorerProvider } from '../../src/explorer/Blockchain
 import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
 import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { TestUtil } from '../TestUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -38,6 +39,17 @@ describe('toggleFabricRuntimeDevMode', () => {
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
     let runtime: FabricRuntime;
     let runtimeTreeItem: RuntimeTreeItem;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -47,6 +47,13 @@ describe('Commands Utility Function Tests', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
     });
 
     beforeEach(async () => {

--- a/client/test/data/connectionYaml/otherConnectionProfile.yml
+++ b/client/test/data/connectionYaml/otherConnectionProfile.yml
@@ -1,0 +1,37 @@
+name: hlfv1
+x-type: hlfv1
+x-commitTimeout: 300
+version: "1.0.0"
+client: 
+ organization: Org1
+ connection: 
+  timeout: 
+   peer: 
+    endorser: 300
+    eventHub: 300
+    eventReg: 300
+   orderer: 300
+channels: 
+ composerchannel: 
+  orderers: 
+   - "orderer.example.com"
+  peers: 
+   "peer0.org1.example.com": {}
+organizations: 
+ Org1: 
+  mspid: Org1MSP
+  peers: 
+   - "peer0.org1.example.com"
+  certificateAuthorities: 
+   - "ca.org1.example.com"
+orderers: 
+ "orderer.example.com": 
+  url: "grpc://localhost:7050"
+peers: 
+ "peer0.org1.example.com": 
+  url: "grpc://localhost:7051"
+  eventUrl: "grpc://localhost:7053"
+certificateAuthorities: 
+ "ca.org1.example.com": 
+  url: "http://localhost:7054"
+  caName: "ca.org1.example.com"

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -56,6 +56,18 @@ describe('BlockchainNetworkExplorer', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
+
+    beforeEach(async () => {
+        await vscode.workspace.getConfiguration().update('fabric.runtimes', [], vscode.ConfigurationTarget.Global);
+        await vscode.workspace.getConfiguration().update('fabric.connections', [], vscode.ConfigurationTarget.Global);
     });
 
     describe('constructor', () => {

--- a/client/test/explorer/blockchainPackageExplorer.test.ts
+++ b/client/test/explorer/blockchainPackageExplorer.test.ts
@@ -72,6 +72,16 @@ describe('BlockchainPackageExplorer', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storePackageDirectoryConfig();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restorePackageDirectoryConfig();
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+
     });
 
     beforeEach(async () => {

--- a/client/test/explorer/model/RuntimeTreeItem.test.ts
+++ b/client/test/explorer/model/RuntimeTreeItem.test.ts
@@ -22,6 +22,7 @@ import { FabricRuntimeRegistry } from '../../../src/fabric/FabricRuntimeRegistry
 import { FabricConnectionRegistry } from '../../../src/fabric/FabricConnectionRegistry';
 import { FabricConnectionRegistryEntry } from '../../../src/fabric/FabricConnectionRegistryEntry';
 import { ExtensionUtil } from '../../../src/util/ExtensionUtil';
+import { TestUtil } from '../../TestUtil';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
@@ -39,6 +40,18 @@ describe('RuntimeTreeItem', () => {
     let clock: sinon.SinonFakeTimers;
     let provider: BlockchainNetworkExplorerProvider;
     let runtime: FabricRuntime;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+
+    });
 
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -37,6 +37,13 @@ describe('Extension Tests', () => {
 
     before(async () => {
         await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
     });
 
     beforeEach(async () => {
@@ -44,6 +51,7 @@ describe('Extension Tests', () => {
         if (runtimeManager.exists('local_fabric')) {
             await runtimeManager.delete('local_fabric');
         }
+        await vscode.workspace.getConfiguration().update('fabric.connections', [], vscode.ConfigurationTarget.Global);
     });
 
     afterEach(async () => {

--- a/client/test/fabric/FabricClientConnection.test.ts
+++ b/client/test/fabric/FabricClientConnection.test.ts
@@ -32,6 +32,7 @@ describe('FabricClientConnection', () => {
     let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
     let fabricClientConnection: FabricClientConnection;
     let fabricClientConnectionYaml: FabricClientConnection;
+    let otherFabricClientConnectionYml: FabricClientConnection;
     let fabricClientConnectionWrong: FabricClientConnection;
     let errorSpy: sinon.SinonSpy;
 
@@ -99,6 +100,20 @@ describe('FabricClientConnection', () => {
             fabricClientConnectionYaml['gateway'] = gatewayStub;
 
             await fabricClientConnectionYaml.connect();
+            gatewayStub.connect.should.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should connect to a fabric with a .yml connection profile', async () => {
+            const otherConnectionYmlData = {
+                connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/otherConnectionProfile.yml'),
+                certificatePath: path.join(rootPath, '../../test/data/connectionYaml/credentials/certificate'),
+                privateKeyPath: path.join(rootPath, '../../test/data/connectionYaml/credentials/privateKey')
+            };
+            otherFabricClientConnectionYml = FabricConnectionFactory.createFabricClientConnection(otherConnectionYmlData) as FabricClientConnection;
+            otherFabricClientConnectionYml['gateway'] = gatewayStub;
+
+            await otherFabricClientConnectionYml.connect();
             gatewayStub.connect.should.have.been.called;
             errorSpy.should.not.have.been.called;
         });

--- a/client/test/fabric/FabricConnectionRegistry.test.ts
+++ b/client/test/fabric/FabricConnectionRegistry.test.ts
@@ -18,12 +18,21 @@ import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegis
 import * as chai from 'chai';
 import { FabricConnectionRegistryEntry } from '../../src/fabric/FabricConnectionRegistryEntry';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { TestUtil } from '../TestUtil';
 
 chai.should();
 
 describe('FabricConnectionRegistry', () => {
 
     const registry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+
+    before(async () => {
+        await TestUtil.storeConnectionsConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+    });
 
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();

--- a/client/test/fabric/FabricRegistry.test.ts
+++ b/client/test/fabric/FabricRegistry.test.ts
@@ -18,6 +18,7 @@ import { FabricRegistryEntry } from '../../src/fabric/FabricRegistryEntry';
 
 import * as chai from 'chai';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { TestUtil } from '../TestUtil';
 
 chai.should();
 
@@ -39,6 +40,15 @@ describe('FabricRegistry', () => {
         }
 
     }
+    before(async () => {
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     let registry: TestFabricRegistry;
 
@@ -46,10 +56,7 @@ describe('FabricRegistry', () => {
         await ExtensionUtil.activateExtension();
         registry = new TestFabricRegistry();
         await vscode.workspace.getConfiguration().update(testFabricRegistryName, [], vscode.ConfigurationTarget.Global);
-    });
-
-    afterEach(async () => {
-        await vscode.workspace.getConfiguration().update(testFabricRegistryName, [], vscode.ConfigurationTarget.Global);
+        await vscode.workspace.getConfiguration().update('fabric.connections', [], vscode.ConfigurationTarget.Global);
     });
 
     describe('#getAll', () => {

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -25,6 +25,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { OutputAdapter } from '../../src/logging/OutputAdapter';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { TestUtil } from '../TestUtil';
 chai.should();
 
 // tslint:disable no-unused-expression
@@ -53,6 +54,14 @@ describe('FabricRuntime', () => {
         }
 
     }
+
+    before(async () => {
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();

--- a/client/test/fabric/FabricRuntimeManager.test.ts
+++ b/client/test/fabric/FabricRuntimeManager.test.ts
@@ -22,6 +22,7 @@ import { FabricRuntime } from '../../src/fabric/FabricRuntime';
 import { FabricRuntimeRegistryEntry } from '../../src/fabric/FabricRuntimeRegistryEntry';
 import { FabricConnectionRegistryEntry } from '../../src/fabric/FabricConnectionRegistryEntry';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { TestUtil } from '../TestUtil';
 
 chai.should();
 
@@ -31,6 +32,16 @@ describe('FabricRuntimeManager', () => {
     const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
     const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
     const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+
+    before(async () => {
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();

--- a/client/test/fabric/FabricRuntimeRegistry.test.ts
+++ b/client/test/fabric/FabricRuntimeRegistry.test.ts
@@ -18,12 +18,21 @@ import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
 import * as chai from 'chai';
 import { FabricRuntimeRegistryEntry } from '../../src/fabric/FabricRuntimeRegistryEntry';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { TestUtil } from '../TestUtil';
 
 chai.should();
 
 describe('FabricRuntimeRegistry', () => {
 
     const registry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+
+    before(async () => {
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreRuntimesConfig();
+    });
 
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();

--- a/client/test/packages/PackageRegistry.test.ts
+++ b/client/test/packages/PackageRegistry.test.ts
@@ -33,18 +33,15 @@ describe('PackageRegistry', () => {
     let errorSpy;
     let infoSpy;
 
-    let USER_PACKAGE_DIRECTORY;
-    // Update the user's configuration
     const TEST_PACKAGE_DIRECTORY = path.join(path.dirname(__dirname), '../../test/data/smartContractDir');
 
     before(async () => {
-        // Get the user's current 'smart contract packages' directory location. This will be used later to update the configuration.
-        USER_PACKAGE_DIRECTORY = await vscode.workspace.getConfiguration().get('fabric.package.directory');
-        await vscode.workspace.getConfiguration().update('fabric.package.directory', TEST_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
         await TestUtil.setupTests();
+        await TestUtil.storePackageDirectoryConfig();
+        await vscode.workspace.getConfiguration().update('fabric.package.directory', TEST_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
     });
     after(async () => {
-        await vscode.workspace.getConfiguration().update('fabric.package.directory', USER_PACKAGE_DIRECTORY, vscode.ConfigurationTarget.Global);
+        await TestUtil.restorePackageDirectoryConfig();
     });
 
     async function createTestFiles(dirName: string, packageName, version: string, language, createValid: boolean): Promise<void> {
@@ -266,7 +263,7 @@ describe('PackageRegistry', () => {
         packageRegistryEntries[0].path.should.equal(path.join(packagesDir, packageRegistryEntries[0].chaincodeLanguage, packageRegistryEntries[0].name));
     });
 
-    it('should show erro if no package json in javascript package', async () => {
+    it('should show error if no package json in javascript package', async () => {
         const packagesDir: string = path.join(rootPath, '../../test/data/smartContractDir');
 
         await vscode.workspace.getConfiguration().update('fabric.package.directory', packagesDir, true);


### PR DESCRIPTION
Also fixed typos, added integration smart contract data folder to gitignore and added support .yml connection profiles

Some limitations: 
- can't store/restore empty user settings, with the exception of the package.directory setting. We think that's to do with vscode/typescript/json handling an empty object
- local_fabric connection is added to fabric.connections and fabric.runtimes by some tests, but doesn't overwrite any existing settings
- integration.test.ts performs similarly, user settings are added to and not wiped. It's not possible to remove these changes at the end of the test. 

I'll add these caveats to the issue too! Fixes #75 

Signed-off-by: heatherlp <heatherpollard0@gmail.com>