### PR TITLE
Clear extension cache after rewriting extension manifest (resolves #133)

### DIFF
--- a/client/src/dependencies/DependencyManager.ts
+++ b/client/src/dependencies/DependencyManager.ts
@@ -49,6 +49,7 @@ export class DependencyManager {
         this.loadDependencies();
         await this.installNativeDependenciesInternal();
         await this.rewritePackageJson();
+        await this.clearExtensionCache();
         await tempCommandRegistry.restoreCommands();
     }
 
@@ -147,6 +148,13 @@ export class DependencyManager {
         });
 
         return this.writePackageJson(packageJson);
+    }
+
+    private async clearExtensionCache(): Promise<void> {
+        const extensionPath: string = ExtensionUtil.getExtensionPath();
+        const extensionsPath: string = path.resolve(extensionPath, '..');
+        const currentDate: Date = new Date();
+        await fs.utimes(extensionsPath, currentDate, currentDate);
     }
 
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -66,7 +66,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
             const tempCommandRegistry: TemporaryCommandRegistry = TemporaryCommandRegistry.instance();
             await tempCommandRegistry.executeStoredCommands();
-            await vscode.commands.executeCommand('workbench.action.reloadWindow');
         } else {
             registerCommands(context);
         }

--- a/client/test/dependencies/DependencyManager.test.ts
+++ b/client/test/dependencies/DependencyManager.test.ts
@@ -80,6 +80,7 @@ describe('DependencyManager Tests', () => {
             const removeStub = mySandBox.stub(fs, 'remove').resolves();
             const renameStub = mySandBox.stub(fs, 'rename').resolves();
             const writeFileStub = mySandBox.stub(fs, 'writeFile').resolves();
+            const utimesFileStub = mySandBox.stub(fs, 'utimes').resolves();
 
             const tempCommandCreateCommandsStub = mySandBox.stub(TemporaryCommandRegistry.instance(), 'createTempCommands');
             const tempCommandRegistryStub = mySandBox.stub(TemporaryCommandRegistry.instance(), 'restoreCommands');
@@ -97,6 +98,7 @@ describe('DependencyManager Tests', () => {
             renameStub.should.have.been.called;
 
             writeFileStub.should.have.been.called;
+            utimesFileStub.should.have.been.called;
 
             tempCommandCreateCommandsStub.should.have.been.called;
             tempCommandRegistryStub.should.have.been.called;
@@ -108,6 +110,7 @@ describe('DependencyManager Tests', () => {
             const removeStub = mySandBox.stub(fs, 'remove').resolves();
             const renameStub = mySandBox.stub(fs, 'rename').resolves();
             const writeFileStub = mySandBox.stub(fs, 'writeFile').resolves();
+            const utimesFileStub = mySandBox.stub(fs, 'utimes').resolves();
 
             const tempCommandCreateCommandsStub = mySandBox.stub(TemporaryCommandRegistry.instance(), 'createTempCommands');
             const tempCommandRegistryStub = mySandBox.stub(TemporaryCommandRegistry.instance(), 'restoreCommands');
@@ -125,6 +128,7 @@ describe('DependencyManager Tests', () => {
             renameStub.should.have.been.called;
 
             writeFileStub.should.have.been.called;
+            utimesFileStub.should.have.been.called;
 
             tempCommandCreateCommandsStub.should.have.been.called;
             tempCommandRegistryStub.should.have.been.called;

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -157,7 +157,6 @@ describe('Extension Tests', () => {
         const dependencyManager = DependencyManager.instance();
         mySandBox.stub(vscode.commands, 'registerCommand');
         mySandBox.stub(dependencyManager, 'hasNativeDependenciesInstalled').returns(false);
-        const reloadStub = mySandBox.stub(vscode.commands, 'executeCommand').resolves();
         const installStub = mySandBox.stub(dependencyManager, 'installNativeDependencies').resolves();
         const tempRegistryExecuteStub = mySandBox.stub(TemporaryCommandRegistry.instance(), 'executeStoredCommands');
 
@@ -165,7 +164,6 @@ describe('Extension Tests', () => {
         await myExtension.activate(context);
         installStub.should.have.been.called;
         tempRegistryExecuteStub.should.have.been.called;
-        reloadStub.should.have.been.calledWith('workbench.action.reloadWindow');
     });
 
     it('should not install native dependencies if already installed', async () => {


### PR DESCRIPTION
By updating the atime/mtime on the top level extensions directory, VSCode will drop its cache of extension manifests and reload them from the file system. This stops VSCode from re-reading the original extension manifest with activationEvents === * and getting into a loop of rerunning the install of the native modules.

We also no longer need the manual reload of VSCode after running the install of the native modules, so removing that as well.

Kudos to https://github.com/Microsoft/vscode/issues/40500 for pointing me in the right direction!

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>