### PR TITLE
Fix node_modules path on Windows

### DIFF
--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -107,7 +107,6 @@ export async function createSmartContractProject(): Promise<void> {
 
     try {
         const npmPrefix: string = await CommandUtil.sendCommand('npm config get prefix');
-        const packagePath: string = npmPrefix + '/lib/node_modules/generator-fabric/generators/contract';
 
         // tslint:disable-next-line
         let env = yeoman.createEnv([], {}, new YeomanAdapter());
@@ -314,7 +313,7 @@ async function checkForUnsavedFiles(): Promise<void> {
 
 async function getPackageJson(): Promise<any> {
     const npmPrefix: string = await CommandUtil.sendCommand('npm config get prefix');
-    const packagePath: string = npmPrefix + '/lib/node_modules/generator-fabric/package.json';
+    const packagePath: string = path.join(npmPrefix, (process.platform === 'win32') ? '' : 'lib', 'node_modules', 'generator-fabric', 'package.json');
     const packageJson: any = await fs.readJson(packagePath);
     return packageJson;
 }

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -419,4 +419,15 @@ describe('CreateSmartContractProjectCommand', () => {
         reporterSpy.should.have.been.calledWith('createSmartContractProject', {contractLanguage: 'typescript'});
     }).timeout(40000);
 
+    it('should find the generator-fabric package.json in the correct path on Windows', async () => {
+        sendCommandStub.resolves('0.0.0');
+        sendCommandStub.withArgs('npm view generator-fabric version').resolves('0.0.0');
+        sendCommandStub.withArgs('npm config get prefix').resolves('PREFIX');
+        mySandBox.stub(process, 'platform').value('win32');
+        const readJsonStub = mySandBox.stub(fs, 'readJson').resolves({version: '0.0.0'});
+
+        await vscode.commands.executeCommand('blockchain.createSmartContractProjectEntry');
+        readJsonStub.should.always.have.been.calledWith('PREFIX/node_modules/generator-fabric/package.json');
+    });
+
 }); // end of createFabricCommand tests


### PR DESCRIPTION
Global installs do not include the lib folder on Windows. See:

https://docs.npmjs.com/files/folders#node-modules

Contributes to #72

Signed-off-by: James Taylor <jamest@uk.ibm.com>