### PR TITLE
Remove commands from Command Palette on Windows

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -204,6 +204,24 @@
             }
         ],
         "menus": {
+            "commandPalette": [
+                {
+                    "command": "blockchainExplorer.startFabricRuntime",
+                    "when": "!isWindows"
+                },
+                {
+                    "command": "blockchainExplorer.stopFabricRuntime",
+                    "when": "!isWindows"
+                },
+                {
+                    "command": "blockchainExplorer.restartFabricRuntime",
+                    "when": "!isWindows"
+                },
+                {
+                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
+                    "when": "!isWindows"
+                }
+            ],
             "view/title": [
                 {
                     "command": "blockchainExplorer.addConnectionEntry",


### PR DESCRIPTION
Fabric runtime will not work on Windows so don't show the
related commands in the Command Palette

Contibutes to #72

Signed-off-by: James Taylor <jamest@uk.ibm.com>