### PR TITLE
Fix Instantiated smart contracts to match packages listing, add tslinting to integration test

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -20,3 +20,4 @@ coverage
 /test/data/fabricProject
 /test/data/smartContractDir/
 /integrationTest/smartContractDir/
+/integrationTest/mySmartContract/

--- a/client/integrationTest/integration.test.ts
+++ b/client/integrationTest/integration.test.ts
@@ -86,7 +86,7 @@ describe('Integration Test', () => {
 
     beforeEach(() => {
         mySandBox = sinon.createSandbox();
-        getWorkspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders')
+        getWorkspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders');
         findFilesStub = mySandBox.stub(vscode.workspace, 'findFiles').resolves([]);
         showPeerQuickPickStub = mySandBox.stub(UserInputUtil, 'showPeerQuickPickBox');
         showPackagesStub = mySandBox.stub(UserInputUtil, 'showSmartContractPackagesQuickPickBox');
@@ -129,8 +129,8 @@ describe('Integration Test', () => {
     }
 
     async function packageSmartContract() {
-       getWorkspaceFoldersStub.returns([{uri: {path: testContractDir}}]);
-      
+        getWorkspaceFoldersStub.returns([{uri: {path: testContractDir}}]);
+
         findFilesStub.withArgs('**/*.js', '**/node_modules/**', 1).resolves([vscode.Uri.file('chaincode.js')]);
 
         await vscode.commands.executeCommand('blockchainAPackageExplorer.packageSmartContractProjectEntry');
@@ -419,11 +419,11 @@ describe('Integration Test', () => {
 
         instantiatedSmartContracts.length.should.equal(1);
 
-        instantiatedSmartContracts[0].label.should.equal('mySmartContract - 0.0.1');
+        instantiatedSmartContracts[0].label.should.equal('mySmartContract@0.0.1');
 
     }).timeout(0);
 
-    // TODO: put this back in when upgrade is more reliable, the problem is with the 
+    // TODO: put this back in when upgrade is more reliable, the problem is with the
     // new event handling stuff it doesn't always unblock even though the upgrade happens
     xit('should upgrade a smart contract', async () => {
         await createFabricConnection();
@@ -472,6 +472,6 @@ describe('Integration Test', () => {
 
         instantiatedSmartContracts.length.should.equal(1);
 
-        instantiatedSmartContracts[0].label.should.equal('anotherSmartContract - 0.0.2');
+        instantiatedSmartContracts[0].label.should.equal('anotherSmartContract@0.0.2');
     }).timeout(0);
 });

--- a/client/package.json
+++ b/client/package.json
@@ -287,7 +287,7 @@
         "systest": "node ./node_modules/vscode/bin/test --verbose",
         "licchk": "license-check-and-add",
         "tslint": "tslint",
-        "lint": "npm run tslint 'src/**/*.ts' 'test/**/*.test.ts'",
+        "lint": "npm run tslint 'src/**/*.ts' 'test/**/*.test.ts' 'integrationTest/integration.test.ts'",
         "updatePackageJSON": "node ../.travis/rewritePackageJson.js",
         "prepublishOnly": "node ../.travis/rewritePackageJson.js publish"
     },

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -165,7 +165,7 @@ export class UserInputUtil {
 
     public static showPeerQuickPickBox(prompt: string): Thenable<string | undefined> {
         const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
-        const connection = fabricConnectionManager.getConnection();
+        const connection: IFabricConnection = fabricConnectionManager.getConnection();
         if (!connection) {
             return Promise.reject('No connection to a blockchain found');
         }

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -174,7 +174,7 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
         const tree: Array<ChainCodeTreeItem> = [];
 
         instantiatedChainCodesElement.chaincodes.forEach((instantiatedChaincode) => {
-            tree.push(new ChainCodeTreeItem(this, instantiatedChaincode.name + ' - ' + instantiatedChaincode.version));
+            tree.push(new ChainCodeTreeItem(this, instantiatedChaincode.name + '@' + instantiatedChaincode.version));
         });
 
         return tree;

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -812,7 +812,7 @@ describe('BlockchainNetworkExplorer', () => {
                 instantiatedChainItemsOne.length.should.equal(1);
                 instantiatedChainItemsOne[0].collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChainItemsOne[0].contextValue.should.equal('blockchain-chaincode-item');
-                instantiatedChainItemsOne[0].label.should.equal('biscuit-network - 0.7');
+                instantiatedChainItemsOne[0].label.should.equal('biscuit-network@0.7');
 
                 const channelTwo: ChannelTreeItem = allChildren[1] as ChannelTreeItem;
 
@@ -826,7 +826,7 @@ describe('BlockchainNetworkExplorer', () => {
                 instantiatedChainItemsTwo.length.should.equal(1);
                 instantiatedChainItemsTwo[0].collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChainItemsTwo[0].contextValue.should.equal('blockchain-chaincode-item');
-                instantiatedChainItemsTwo[0].label.should.equal('cake-network - 0.10');
+                instantiatedChainItemsTwo[0].label.should.equal('cake-network@0.10');
             });
         });
     });


### PR DESCRIPTION
- Fixed Instantiated Smart Contracts listing so it contains @ instead of ' - ', to match the packages listing
- Add smart contract project folder created by integration test to gitignore 
- added integration.test.ts to tslinting and added missing semicolon
- added missing type

Signed-off-by: heatherlp <heatherpollard0@gmail.com>