### PR TITLE
Enable local Fabric and deployment on Windows (resolves #167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,19 @@ Or visit the [Visual Studio Code Marketplace](https://marketplace.visualstudio.c
 
 You will need the following installed in order to start a local Hyperledger Fabric runtime from within the extension:
 - [Node v8.x or greater and npm v5.x or greater](https://nodejs.org/en/download/)
-
 - [Yeoman (yo) v2.x](http://yeoman.io/)
 - [Docker version v17.06.2-ce or greater](https://www.docker.com/get-docker)
 - [Docker Compose v1.14.0 or greater](https://docs.docker.com/compose/install/)
+
+If you are using Windows, you must also ensure the following:
+- Your version of Windows supports Hyper-V and Docker:
+  - Windows 10 Enterprise, Pro, or Education with 1607 Anniversary Update or later
+- Docker for Windows is configured to use Linux containers (this is the default)
+- You have installed the C++ Build Tools for Windows from [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools#windows-build-tools)
+- You have installed OpenSSL v1.0.2 from [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
+  - Install the normal version, not the version marked as "light"
+  - Install the Win32 version into `C:\OpenSSL-Win32` on 32-bit systems
+  - Install the Win64 version into `C:\OpenSSL-Win64` on 64-bit systems
 
 You can check your installed versions by running the following commands from a terminal:
 - `node --version`
@@ -140,10 +149,7 @@ https://hyperledger-fabric.readthedocs.io/en/v1.3.0-rc1/install.html
 
 ## Supported Operating Systems 
 
-Linux and Mac OS are currently the only supported operating systems for use with the extension.
-
-The work to implement Windows support can be tracked in [Issue 72](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/72).
-
+Linux, Mac OS, and Windows are currently the only supported operating systems for use with the extension.
 
 ## Telemetry Reporting
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,6 +1,7 @@
 # IBM Blockchain Platform Extension Change Log
 
-##0.0.3: October 11th, 2018
+## 0.0.3: October 11th, 2018
 * Fix JavaScript packages being packaged as TypeScript [#139](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/139)
 * Improve Tooltip for local_fabric runtime [#146](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/146)
 * Automate extension publishing [#156](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/156)
+* Add support for local_fabric runtime on Windows [#167](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/167)

--- a/client/README.md
+++ b/client/README.md
@@ -16,10 +16,19 @@ If you have find any problems or want to make suggestions for future features pl
 
 You will need the following installed in order to start a local Hyperledger Fabric runtime from within the extension:
 - [Node v8.x or greater and npm v5.x or greater](https://nodejs.org/en/download/)
-
 - [Yeoman (yo) v2.x](http://yeoman.io/)
 - [Docker version v17.06.2-ce or greater](https://www.docker.com/get-docker)
 - [Docker Compose v1.14.0 or greater](https://docs.docker.com/compose/install/)
+
+If you are using Windows, you must also ensure the following:
+- Your version of Windows supports Hyper-V and Docker:
+  - Windows 10 Enterprise, Pro, or Education with 1607 Anniversary Update or later
+- Docker for Windows is configured to use Linux containers (this is the default)
+- You have installed the C++ Build Tools for Windows from [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools#windows-build-tools)
+- You have installed OpenSSL v1.0.2 from [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
+  - Install the normal version, not the version marked as "light"
+  - Install the Win32 version into `C:\OpenSSL-Win32` on 32-bit systems
+  - Install the Win64 version into `C:\OpenSSL-Win64` on 64-bit systems
 
 You can check your installed versions by running the following commands from a terminal:
 - `node --version`
@@ -128,10 +137,7 @@ https://hyperledger-fabric.readthedocs.io/en/v1.3.0-rc1/install.html
 
 ## Supported Operating Systems 
 
-Linux and Mac OS are currently the only supported operating systems for use with the extension.
-
-The work to implement Windows support can be tracked in [Issue 72](https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/72).
-
+Linux, Mac OS, and Windows are currently the only supported operating systems for use with the extension.
 
 ## Telemetry Reporting
 

--- a/client/basic-network/init.cmd
+++ b/client/basic-network/init.cmd
@@ -1,0 +1,14 @@
+@echo off
+rem
+rem Copyright IBM Corp All Rights Reserved
+rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
+
+rem delete previous creds
+if exist %userprofile%\.hfc-key-store (
+    rmdir /q/s %userprofile%\.hfc-key-store
+)
+
+rem copy peer admin credentials into the keyValStore
+mkdir %userprofile%\.hfc-key-store

--- a/client/basic-network/start.cmd
+++ b/client/basic-network/start.cmd
@@ -1,0 +1,34 @@
+@echo off
+rem
+rem Copyright IBM Corp All Rights Reserved
+rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
+
+rem rewrite paths for Windows users to enable Docker socket binding
+set COMPOSE_CONVERT_WINDOWS_PATHS=1
+
+docker-compose -f docker-compose.yml down
+
+docker-compose -f docker-compose.yml up -d ca.example.com orderer.example.com peer0.org1.example.com couchdb
+
+rem wait for Hyperledger Fabric to start
+rem incase of errors when running later commands, issue export FABRIC_START_TIMEOUT=<larger number>
+set FABRIC_START_TIMEOUT=30
+for /L %%i in (1, 1, %FABRIC_START_TIMEOUT%) do (
+    rem This command only works if the peer is up and running
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel list > NUL 2>&1
+    if errorlevel 1 (
+        timeout /t 1 /nobreak > NUL
+    ) else (
+        set i=%%i
+        goto :done
+    )
+)
+:done
+echo Hyperledger Fabric started in %i% seconds
+
+rem Create the channel
+docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
+rem Join peer0.org1.example.com to the channel.
+docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel join -b mychannel.block

--- a/client/basic-network/stop.cmd
+++ b/client/basic-network/stop.cmd
@@ -1,0 +1,9 @@
+@echo off
+rem
+rem Copyright IBM Corp All Rights Reserved
+rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
+
+rem Shut down the Docker containers that might be currently running.
+docker-compose -f docker-compose.yml stop

--- a/client/basic-network/teardown.cmd
+++ b/client/basic-network/teardown.cmd
@@ -1,0 +1,20 @@
+@echo off
+rem
+rem Copyright IBM Corp All Rights Reserved
+rem
+rem SPDX-License-Identifier: Apache-2.0
+rem
+
+rem Shut down the Docker containers for the system tests.
+docker-compose -f docker-compose.yml kill && docker-compose -f docker-compose.yml down
+
+rem remove the local state
+if exist %userprofile%\.hfc-key-store (
+    rmdir /q/s %userprofile%\.hfc-key-store
+)
+
+rem remove chaincode docker images
+rem docker rm $(docker ps -aq)
+rem docker rmi $(docker images dev-* -q)
+
+rem Your system is now clean

--- a/client/package.json
+++ b/client/package.json
@@ -206,20 +206,16 @@
         "menus": {
             "commandPalette": [
                 {
-                    "command": "blockchainExplorer.startFabricRuntime",
-                    "when": "!isWindows"
+                    "command": "blockchainExplorer.startFabricRuntime"
                 },
                 {
-                    "command": "blockchainExplorer.stopFabricRuntime",
-                    "when": "!isWindows"
+                    "command": "blockchainExplorer.stopFabricRuntime"
                 },
                 {
-                    "command": "blockchainExplorer.restartFabricRuntime",
-                    "when": "!isWindows"
+                    "command": "blockchainExplorer.restartFabricRuntime"
                 },
                 {
-                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
-                    "when": "!isWindows"
+                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode"
                 }
             ],
             "view/title": [

--- a/client/src/commands/packageSmartContractCommand.ts
+++ b/client/src/commands/packageSmartContractCommand.ts
@@ -55,7 +55,7 @@ async function createPackageDir(packageDir: string): Promise<void> {
     if (workspaceDir) {
         const dir: string = await getFinalDirectory(packageDir, workspaceDir);
         if (dir) {
-            await createAndPackage(dir, workspaceDir.uri.path);
+            await createAndPackage(dir, workspaceDir.uri.fsPath);
         }
     }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -70,11 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             registerCommands(context);
         }
 
-        if (process.platform === 'win32') {
-            await ensureLocalFabricDoesNotExist();
-        } else {
-            await ensureLocalFabricExists();
-        }
+        await ensureLocalFabricExists();
 
         ExtensionUtil.setExtensionContext(context);
         outputAdapter.log('extension activated');
@@ -143,14 +139,6 @@ export async function ensureLocalFabricExists(): Promise<void> {
         return;
     }
     await runtimeManager.add('local_fabric');
-}
-
-export async function ensureLocalFabricDoesNotExist(): Promise<void> {
-    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
-    if (runtimeManager.exists('local_fabric')) {
-        await runtimeManager.delete('local_fabric');
-    }
-    return;
 }
 
 function disposeExtension(context: vscode.ExtensionContext): void {

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -188,7 +188,7 @@ export class FabricRuntime extends EventEmitter {
         return `fabricvscode${sanitizedName}`;
     }
 
-    private fixHost(host: string) {
+    private fixHost(host: string): string {
         // Windows chokes on 0.0.0.0, so replace it with localhost.
         if (host === '0.0.0.0') {
             return 'localhost';

--- a/client/src/util/CommandUtil.ts
+++ b/client/src/util/CommandUtil.ts
@@ -66,7 +66,7 @@ export class CommandUtil {
             child.on('error', reject);
             child.on('exit', (code) => {
                 if (code) {
-                    return reject(new Error(`Failed to execute command "${command}" with  arguments "${args}" return code ${code}`));
+                    return reject(new Error(`Failed to execute command "${command}" with  arguments "${args.join(', ')}" return code ${code}`));
                 }
                 resolve();
             });

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -231,27 +231,6 @@ describe('Extension Tests', () => {
         addSpy.should.not.have.been.called;
     });
 
-    it('should not create a new local_fabric if one does not exist on Windows', async () => {
-        mySandBox.stub(process, 'platform').value('win32');
-        const addSpy = mySandBox.spy(runtimeManager, 'add');
-        const deleteSpy = mySandBox.spy(runtimeManager, 'delete');
-        const context: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
-        await myExtension.activate(context);
-        addSpy.should.not.have.been.called;
-        deleteSpy.should.not.have.been.called;
-    });
-
-    it('should delete a local_fabric if one already exists on Windows', async () => {
-        mySandBox.stub(process, 'platform').value('win32');
-        await runtimeManager.add('local_fabric');
-        const addSpy = mySandBox.spy(runtimeManager, 'add');
-        const deleteSpy = mySandBox.spy(runtimeManager, 'delete');
-        const context: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
-        await myExtension.activate(context);
-        addSpy.should.not.have.been.called;
-        deleteSpy.should.have.been.calledOnceWithExactly('local_fabric');
-    });
-
     it('should check if production flag is false on extension activiation', async () => {
 
         const extensionUtilStub = mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: false});

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -145,8 +145,8 @@ describe('FabricRuntime', () => {
     describe('#start', () => {
 
         it('should execute the start.sh script and handle success for non-development mode (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -158,8 +158,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.sh script and handle success for development mode (Linux/MacOS)', async () => {
             runtimeRegistryEntry.developmentMode = true;
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -170,8 +170,8 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the start.sh script and handle an error (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -181,21 +181,21 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the start.sh script using a custom output adapter (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.start(outputAdapter);
             outputAdapter.log.should.have.been.calledOnceWith('stdout');
             outputAdapter.error.should.have.been.calledOnceWith('stderr');
         });
 
         it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -207,9 +207,9 @@ describe('FabricRuntime', () => {
         });
 
         it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -222,8 +222,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.cmd script and handle success for non-development mode (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -236,8 +236,8 @@ describe('FabricRuntime', () => {
         it('should execute the start.cmd script and handle success for development mode (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
             runtimeRegistryEntry.developmentMode = true;
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -249,8 +249,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.cmd script and handle an error (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -261,12 +261,12 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.cmd script using a custom output adapter (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.start(outputAdapter);
             outputAdapter.log.should.have.been.calledOnceWith('stdout');
             outputAdapter.error.should.have.been.calledOnceWith('stderr');
@@ -274,9 +274,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling success (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -289,9 +289,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling an error (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -307,8 +307,8 @@ describe('FabricRuntime', () => {
     describe('#stop', () => {
 
         it('should execute the stop.sh and teardown.sh scripts and handle success (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -322,8 +322,8 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the stop.sh and teardown.sh scripts and handle an error from stop.sh (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -336,8 +336,8 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the stop.sh and teardown.sh scripts and handle an error from teardown.sh (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -351,15 +351,15 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the stop.sh script using a custom output adapter (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
             spawnStub.withArgs('/bin/sh', [ 'teardown.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.stop(outputAdapter);
             outputAdapter.log.should.have.been.calledTwice;
             outputAdapter.error.should.have.been.calledTwice;
@@ -370,9 +370,9 @@ describe('FabricRuntime', () => {
         });
 
         it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -387,9 +387,9 @@ describe('FabricRuntime', () => {
         });
 
         it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -405,8 +405,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the stop.cmd and teardown.cmd scripts and handle success (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -421,8 +421,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the stop.cmd and teardown.cmd scripts and handle an error from stop.cmd (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -436,8 +436,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the stop.cmd and teardown.cmd scripts and handle an error from teardown.cmd (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -452,15 +452,15 @@ describe('FabricRuntime', () => {
 
         it('should execute the stop.cmd script using a custom output adapter (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
             spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.stop(outputAdapter);
             outputAdapter.log.should.have.been.calledTwice;
             outputAdapter.error.should.have.been.calledTwice;
@@ -472,9 +472,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling success (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -490,9 +490,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling an error (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
             });
@@ -511,8 +511,8 @@ describe('FabricRuntime', () => {
     describe('#restart', () => {
 
         it('should execute the start.sh, stop.sh and teardown.sh scripts and handle success (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -530,8 +530,8 @@ describe('FabricRuntime', () => {
         });
 
         it('should execute the start.sh, stop.sh and teardown.sh scripts using a custom output adapter (Linux/MacOS)', async () => {
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -541,7 +541,7 @@ describe('FabricRuntime', () => {
             spawnStub.withArgs('/bin/sh', [ 'teardown.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.restart(outputAdapter);
             outputAdapter.log.should.have.been.calledThrice;
             outputAdapter.error.should.have.been.calledThrice;
@@ -554,9 +554,9 @@ describe('FabricRuntime', () => {
         });
 
         it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -574,9 +574,9 @@ describe('FabricRuntime', () => {
         });
 
         it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -595,8 +595,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.cmd, stop.cmd and teardown.cmd scripts and handle success (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -615,8 +615,8 @@ describe('FabricRuntime', () => {
 
         it('should execute the start.sh, stop.sh and teardown.sh scripts using a custom output adapter (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -626,7 +626,7 @@ describe('FabricRuntime', () => {
             spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
-            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            const outputAdapter: sinon.SinonStubbedInstance<TestFabricOutputAdapter> = sinon.createStubInstance(TestFabricOutputAdapter);
             await runtime.restart(outputAdapter);
             outputAdapter.log.should.have.been.calledThrice;
             outputAdapter.error.should.have.been.calledThrice;
@@ -640,9 +640,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling success (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });
@@ -661,9 +661,9 @@ describe('FabricRuntime', () => {
 
         it('should publish busy events before and after handling an error (Windows)', async () => {
             sandbox.stub(process, 'platform').value('win32');
-            const eventStub = sinon.stub();
-            const originalSpawn = child_process.spawn;
-            const spawnStub = sandbox.stub(child_process, 'spawn');
+            const eventStub: sinon.SinonStub = sinon.stub();
+            const originalSpawn: any = child_process.spawn;
+            const spawnStub: sinon.SinonStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
                 return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
             });

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -90,7 +90,7 @@ describe('FabricRuntime', () => {
         mockOrdererInspect = {
             NetworkSettings: {
                 Ports: {
-                    '7050/tcp': [{ HostIp: '0.0.0.0', HostPort: '12347' }]
+                    '7050/tcp': [{ HostIp: '127.0.0.1', HostPort: '12347' }]
                 }
             },
             State: {
@@ -102,7 +102,7 @@ describe('FabricRuntime', () => {
         mockCAInspect = {
             NetworkSettings: {
                 Ports: {
-                    '7054/tcp': [{ HostIp: '0.0.0.0', HostPort: '12348' }]
+                    '7054/tcp': [{ HostIp: '127.0.0.1', HostPort: '12348' }]
                 }
             },
             State: {
@@ -144,7 +144,7 @@ describe('FabricRuntime', () => {
 
     describe('#start', () => {
 
-        it('should execute the start.sh script and handle success for non-development mode', async () => {
+        it('should execute the start.sh script and handle success for non-development mode (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
@@ -156,7 +156,7 @@ describe('FabricRuntime', () => {
             spawnStub.getCall(0).args[2].env.CORE_CHAINCODE_MODE.should.equal('net');
         });
 
-        it('should execute the start.sh script and handle success for development mode', async () => {
+        it('should execute the start.sh script and handle success for development mode (Linux/MacOS)', async () => {
             runtimeRegistryEntry.developmentMode = true;
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -169,7 +169,7 @@ describe('FabricRuntime', () => {
             spawnStub.getCall(0).args[2].env.CORE_CHAINCODE_MODE.should.equal('dev');
         });
 
-        it('should execute the start.sh script and handle an error', async () => {
+        it('should execute the start.sh script and handle an error (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
@@ -180,7 +180,7 @@ describe('FabricRuntime', () => {
             spawnStub.should.have.been.calledWith('/bin/sh', [ 'start.sh' ], sinon.match.any);
         });
 
-        it('should execute the start.sh script using a custom output adapter', async () => {
+        it('should execute the start.sh script using a custom output adapter (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
@@ -192,7 +192,7 @@ describe('FabricRuntime', () => {
             outputAdapter.error.should.have.been.calledOnceWith('stderr');
         });
 
-        it('should publish busy events before and after handling success', async () => {
+        it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -206,7 +206,7 @@ describe('FabricRuntime', () => {
             eventStub.should.have.been.calledWithExactly(false);
         });
 
-        it('should publish busy events before and after handling an error', async () => {
+        it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -220,11 +220,93 @@ describe('FabricRuntime', () => {
             eventStub.should.have.been.calledWithExactly(false);
         });
 
+        it('should execute the start.cmd script and handle success for non-development mode (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            await runtime.start();
+            spawnStub.should.have.been.calledOnce;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'start.cmd' ], sinon.match.any);
+            spawnStub.getCall(0).args[2].env.CORE_CHAINCODE_MODE.should.equal('net');
+        });
+
+        it('should execute the start.cmd script and handle success for development mode (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            runtimeRegistryEntry.developmentMode = true;
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            await runtime.start();
+            spawnStub.should.have.been.calledOnce;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'start.cmd' ], sinon.match.any);
+            spawnStub.getCall(0).args[2].env.CORE_CHAINCODE_MODE.should.equal('dev');
+        });
+
+        it('should execute the start.cmd script and handle an error (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            await runtime.start().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, start.cmd" return code 1`);
+            spawnStub.should.have.been.calledOnce;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'start.cmd' ], sinon.match.any);
+        });
+
+        it('should execute the start.cmd script using a custom output adapter (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            await runtime.start(outputAdapter);
+            outputAdapter.log.should.have.been.calledOnceWith('stdout');
+            outputAdapter.error.should.have.been.calledOnceWith('stderr');
+        });
+
+        it('should publish busy events before and after handling success (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.start();
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
+        it('should publish busy events before and after handling an error (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.start().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, start.cmd" return code 1`);
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
     });
 
     describe('#stop', () => {
 
-        it('should execute the stop.sh and teardown.sh scripts and handle success', async () => {
+        it('should execute the stop.sh and teardown.sh scripts and handle success (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
@@ -239,7 +321,7 @@ describe('FabricRuntime', () => {
             spawnStub.should.have.been.calledWith('/bin/sh', [ 'teardown.sh' ], sinon.match.any);
         });
 
-        it('should execute the stop.sh and teardown.sh scripts and handle an error from stop.sh', async () => {
+        it('should execute the stop.sh and teardown.sh scripts and handle an error from stop.sh (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
@@ -253,7 +335,7 @@ describe('FabricRuntime', () => {
             spawnStub.should.have.been.calledWith('/bin/sh', [ 'stop.sh' ], sinon.match.any);
         });
 
-        it('should execute the stop.sh and teardown.sh scripts and handle an error from teardown.sh', async () => {
+        it('should execute the stop.sh and teardown.sh scripts and handle an error from teardown.sh (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
@@ -268,7 +350,7 @@ describe('FabricRuntime', () => {
             spawnStub.should.have.been.calledWith('/bin/sh', [ 'teardown.sh' ], sinon.match.any);
         });
 
-        it('should execute the stop.sh script using a custom output adapter', async () => {
+        it('should execute the stop.sh script using a custom output adapter (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'stop.sh' ], sinon.match.any).callsFake(() => {
@@ -287,7 +369,7 @@ describe('FabricRuntime', () => {
             outputAdapter.error.should.have.been.calledWith('stderr');
         });
 
-        it('should publish busy events before and after handling success', async () => {
+        it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -304,7 +386,7 @@ describe('FabricRuntime', () => {
             eventStub.should.have.been.calledWithExactly(false);
         });
 
-        it('should publish busy events before and after handling an error', async () => {
+        it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -321,11 +403,114 @@ describe('FabricRuntime', () => {
             eventStub.should.have.been.calledWithExactly(false);
         });
 
+        it('should execute the stop.cmd and teardown.cmd scripts and handle success (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            await runtime.stop();
+            spawnStub.should.have.been.calledTwice;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'stop.cmd' ], sinon.match.any);
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any);
+        });
+
+        it('should execute the stop.cmd and teardown.cmd scripts and handle an error from stop.cmd (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            await runtime.stop().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, stop.cmd" return code 1`);
+            spawnStub.should.have.been.calledOnce;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'stop.cmd' ], sinon.match.any);
+        });
+
+        it('should execute the stop.cmd and teardown.cmd scripts and handle an error from teardown.cmd (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            await runtime.stop().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, teardown.cmd" return code 1`);
+            spawnStub.should.have.been.calledTwice;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'stop.cmd' ], sinon.match.any);
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any);
+        });
+
+        it('should execute the stop.cmd script using a custom output adapter (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            await runtime.stop(outputAdapter);
+            outputAdapter.log.should.have.been.calledTwice;
+            outputAdapter.error.should.have.been.calledTwice;
+            outputAdapter.log.should.have.been.calledWith('stdout');
+            outputAdapter.error.should.have.been.calledWith('stderr');
+            outputAdapter.log.should.have.been.calledWith('stdout');
+            outputAdapter.error.should.have.been.calledWith('stderr');
+        });
+
+        it('should publish busy events before and after handling success (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.stop();
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
+        it('should publish busy events before and after handling an error (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.stop().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, stop.cmd" return code 1`);
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
     });
 
     describe('#restart', () => {
 
-        it('should execute the start.sh, stop.sh and teardown.sh scripts and handle success', async () => {
+        it('should execute the start.sh, stop.sh and teardown.sh scripts and handle success (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
@@ -344,7 +529,7 @@ describe('FabricRuntime', () => {
             spawnStub.should.have.been.calledWith('/bin/sh', [ 'teardown.sh' ], sinon.match.any);
         });
 
-        it('should execute the start.sh, stop.sh and teardown.sh scripts using a custom output adapter', async () => {
+        it('should execute the start.sh, stop.sh and teardown.sh scripts using a custom output adapter (Linux/MacOS)', async () => {
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
             spawnStub.withArgs('/bin/sh', [ 'start.sh' ], sinon.match.any).callsFake(() => {
@@ -368,7 +553,7 @@ describe('FabricRuntime', () => {
             outputAdapter.error.should.have.been.calledWith('stderr');
         });
 
-        it('should publish busy events before and after handling success', async () => {
+        it('should publish busy events before and after handling success (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -388,7 +573,7 @@ describe('FabricRuntime', () => {
             eventStub.should.have.been.calledWithExactly(false);
         });
 
-        it('should publish busy events before and after handling an error', async () => {
+        it('should publish busy events before and after handling an error (Linux/MacOS)', async () => {
             const eventStub = sinon.stub();
             const originalSpawn = child_process.spawn;
             const spawnStub = sandbox.stub(child_process, 'spawn');
@@ -403,6 +588,93 @@ describe('FabricRuntime', () => {
             });
             runtime.on('busy', eventStub);
             await runtime.restart().should.be.rejectedWith(`Failed to execute command "/bin/sh" with  arguments "teardown.sh" return code 1`);
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
+        it('should execute the start.cmd, stop.cmd and teardown.cmd scripts and handle success (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            await runtime.restart();
+            spawnStub.should.have.been.calledThrice;
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'start.cmd' ], sinon.match.any);
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'stop.cmd' ], sinon.match.any);
+            spawnStub.should.have.been.calledWith('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any);
+        });
+
+        it('should execute the start.sh, stop.sh and teardown.sh scripts using a custom output adapter (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            const outputAdapter = sinon.createStubInstance(TestFabricOutputAdapter);
+            await runtime.restart(outputAdapter);
+            outputAdapter.log.should.have.been.calledThrice;
+            outputAdapter.error.should.have.been.calledThrice;
+            outputAdapter.log.should.have.been.calledWith('stdout');
+            outputAdapter.error.should.have.been.calledWith('stderr');
+            outputAdapter.log.should.have.been.calledWith('stdout');
+            outputAdapter.error.should.have.been.calledWith('stderr');
+            outputAdapter.log.should.have.been.calledWith('stdout');
+            outputAdapter.error.should.have.been.calledWith('stderr');
+        });
+
+        it('should publish busy events before and after handling success (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.restart();
+            eventStub.should.have.been.calledTwice;
+            eventStub.should.have.been.calledWithExactly(true);
+            eventStub.should.have.been.calledWithExactly(false);
+        });
+
+        it('should publish busy events before and after handling an error (Windows)', async () => {
+            sandbox.stub(process, 'platform').value('win32');
+            const eventStub = sinon.stub();
+            const originalSpawn = child_process.spawn;
+            const spawnStub = sandbox.stub(child_process, 'spawn');
+            spawnStub.withArgs('cmd', [ '/c', 'start.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'stop.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && true' ]);
+            });
+            spawnStub.withArgs('cmd', [ '/c', 'teardown.cmd' ], sinon.match.any).callsFake(() => {
+                return originalSpawn('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false' ]);
+            });
+            runtime.on('busy', eventStub);
+            await runtime.restart().should.be.rejectedWith(`Failed to execute command "cmd" with  arguments "/c, teardown.cmd" return code 1`);
             eventStub.should.have.been.calledTwice;
             eventStub.should.have.been.calledWithExactly(true);
             eventStub.should.have.been.calledWithExactly(false);
@@ -453,18 +725,18 @@ describe('FabricRuntime', () => {
                 },
                 orderers: {
                     'orderer.example.com': {
-                        url: 'grpc://0.0.0.0:12347'
+                        url: 'grpc://127.0.0.1:12347'
                     }
                 },
                 peers: {
                     'peer0.org1.example.com': {
-                        url: 'grpc://0.0.0.0:12345',
-                        eventUrl: 'grpc://0.0.0.0:12346'
+                        url: 'grpc://localhost:12345',
+                        eventUrl: 'grpc://localhost:12346'
                     }
                 },
                 certificateAuthorities: {
                     'ca.org1.example.com': {
-                        url: 'http://0.0.0.0:12348',
+                        url: 'http://127.0.0.1:12348',
                         caName: 'ca.org1.example.com'
                     }
                 }

--- a/client/test/util/CommandUtil.test.ts
+++ b/client/test/util/CommandUtil.test.ts
@@ -122,7 +122,7 @@ describe('CommandUtil Tests', () => {
         it('should send a command and handle error code', async () => {
             const spawnSpy = mySandBox.spy(child_process, 'spawn');
 
-            await CommandUtil.sendCommandWithOutput('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false']).should.be.rejectedWith(`Failed to execute command "/bin/sh" with  arguments "-c,echo stdout && echo stderr >&2 && false" return code 1`);
+            await CommandUtil.sendCommandWithOutput('/bin/sh', [ '-c', 'echo stdout && echo stderr >&2 && false']).should.be.rejectedWith(`Failed to execute command "/bin/sh" with  arguments "-c, echo stdout && echo stderr >&2 && false" return code 1`);
             spawnSpy.should.have.been.calledOnce;
             spawnSpy.should.have.been.calledWith('/bin/sh', ['-c', 'echo stdout && echo stderr >&2 && false']);
         });


### PR DESCRIPTION
- Add basic-network scripts for Windows (batch)
- Enable creation of local Fabric on Windows
- Enable local Fabric commands on Windows
- Fix packaging to work on Windows
- Add additional prerequisites to the README.md files

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>