### PR TITLE
Support 32-bit and 64-bit versions of VS Code (resolves #182)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -359,15 +359,23 @@
     },
     "nativeDependencies": {
         "grpc": {
-            "linux": {
+            "linux-ia32": {
+                "original": "./node_modules/grpc/src/node/extension_binary/node-v57-linux-ia32-glibc",
+                "new": "./node_modules/grpc/src/node/extension_binary/electron-v2.0-linux-ia32-glibc"
+            },
+            "linux-x64": {
                 "original": "./node_modules/grpc/src/node/extension_binary/node-v57-linux-x64-glibc",
                 "new": "./node_modules/grpc/src/node/extension_binary/electron-v2.0-linux-x64-glibc"
             },
-            "darwin": {
+            "darwin-x64": {
                 "original": "./node_modules/grpc/src/node/extension_binary/node-v57-darwin-x64-unknown",
                 "new": "./node_modules/grpc/src/node/extension_binary/electron-v2.0-darwin-x64-unknown"
             },
-            "win32": {
+            "win32-ia32": {
+                "original": "./node_modules/grpc/src/node/extension_binary/node-v57-win32-ia32-unknown",
+                "new": "./node_modules/grpc/src/node/extension_binary/electron-v2.0-win32-ia32-unknown"
+            },
+            "win32-x64": {
                 "original": "./node_modules/grpc/src/node/extension_binary/node-v57-win32-x64-unknown",
                 "new": "./node_modules/grpc/src/node/extension_binary/electron-v2.0-win32-x64-unknown"
             }

--- a/client/src/dependencies/DependencyManager.ts
+++ b/client/src/dependencies/DependencyManager.ts
@@ -58,7 +58,7 @@ export class DependencyManager {
     }
 
     private loadDependencies() {
-        const os: string = process.platform;
+        const os: string = `${process.platform}-${process.arch}`;
         const packageJSON: any = ExtensionUtil.getPackageJSON();
 
         this.dependencies = [];


### PR DESCRIPTION
Switch dependency manager to using the current architecture to ensure we work with both 32-bit and 64-bit versions of VS Code.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>