### PR TITLE
Use vscode.Uri.fsPath instead of vscode.Uri.path (resolves #184)

### DIFF
--- a/client/src/commands/packageSmartContractCommand.ts
+++ b/client/src/commands/packageSmartContractCommand.ts
@@ -103,7 +103,7 @@ async function getFinalDirectory(packageDir: string, workspaceDir: vscode.Worksp
     if (language === '/go/src/') {
         properties = await golangPackageAndVersion();
     } else {
-        properties = await packageJsonNameAndVersion(workspaceDir.uri.path);
+        properties = await packageJsonNameAndVersion(workspaceDir.uri.fsPath);
     }
 
     if (!properties) {


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>