### PR TITLE
Upgrade local Fabric and integration tests to Fabric v1.3.0

### DIFF
--- a/client/basic-network/docker-compose.yml
+++ b/client/basic-network/docker-compose.yml
@@ -10,7 +10,7 @@ networks:
 
 services:
   ca.example.com:
-    image: hyperledger/fabric-ca:1.3.0-rc1
+    image: hyperledger/fabric-ca:1.3.0
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.example.com
@@ -28,7 +28,7 @@ services:
 
   orderer.example.com:
     # VSCODE container_name: orderer.example.com
-    image: hyperledger/fabric-orderer:1.3.0-rc1
+    image: hyperledger/fabric-orderer:1.3.0
     environment:
       - ORDERER_GENERAL_LOGLEVEL=info
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -50,7 +50,7 @@ services:
 
   peer0.org1.example.com:
     # VSCODE container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer:1.3.0-rc1
+    image: hyperledger/fabric-peer:1.3.0
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
@@ -93,7 +93,7 @@ services:
 
   couchdb:
     # VSCODE container_name: couchdb
-    image: hyperledger/fabric-couchdb:0.4.12
+    image: hyperledger/fabric-couchdb:0.4.13
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.
     environment:
@@ -107,7 +107,7 @@ services:
 
   cli:
     container_name: cli
-    image: hyperledger/fabric-tools:1.3.0-rc1
+    image: hyperledger/fabric-tools:1.3.0
     tty: true
     environment:
       - GOPATH=/opt/gopath

--- a/client/basic-network/start.cmd
+++ b/client/basic-network/start.cmd
@@ -19,7 +19,8 @@ for /L %%i in (1, 1, %FABRIC_START_TIMEOUT%) do (
     rem This command only works if the peer is up and running
     docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel list > NUL 2>&1
     if errorlevel 1 (
-        timeout /t 1 /nobreak > NUL
+        rem This is the closest thing that Windows has to the sleep command
+        choice /t 1 /c x /d x /n > NUL
     ) else (
         set i=%%i
         goto :done

--- a/client/integrationTest/hlfv1/docker-compose-dev.yml
+++ b/client/integrationTest/hlfv1/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   ca.org1.example.com:
-    image: hyperledger/fabric-ca:1.2.0
+    image: hyperledger/fabric-ca:1.3.0
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
@@ -16,7 +16,7 @@ services:
 
   orderer.example.com:
     container_name: orderer.example.com
-    image: hyperledger/fabric-orderer:1.2.0
+    image: hyperledger/fabric-orderer:1.3.0
     environment:
       - ORDERER_GENERAL_LOGLEVEL=debug
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -34,7 +34,7 @@ services:
 
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer:1.2.0
+    image: hyperledger/fabric-peer:1.3.0
     environment:
       - CORE_LOGGING_LEVEL=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
@@ -63,7 +63,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb:0.4.10
+    image: hyperledger/fabric-couchdb:0.4.13
     ports:
       - 5984:5984
     environment:

--- a/client/integrationTest/hlfv1/docker-compose.yml
+++ b/client/integrationTest/hlfv1/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 services:
   ca.org1.example.com:
-    image: hyperledger/fabric-ca
+    image: hyperledger/fabric-ca:1.3.0
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca.org1.example.com
@@ -16,7 +16,7 @@ services:
 
   orderer.example.com:
     container_name: orderer.example.com
-    image: hyperledger/fabric-orderer
+    image: hyperledger/fabric-orderer:1.3.0
     environment:
       - ORDERER_GENERAL_LOGLEVEL=debug
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -34,7 +34,7 @@ services:
 
   peer0.org1.example.com:
     container_name: peer0.org1.example.com
-    image: hyperledger/fabric-peer
+    image: hyperledger/fabric-peer:1.3.0
     environment:
       - CORE_LOGGING_LEVEL=debug
       - CORE_CHAINCODE_LOGGING_LEVEL=DEBUG
@@ -62,7 +62,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: hyperledger/fabric-couchdb
+    image: hyperledger/fabric-couchdb:0.4.13
     ports:
       - 5984:5984
     environment:

--- a/client/integrationTest/scripts/run-integration-tests.sh
+++ b/client/integrationTest/scripts/run-integration-tests.sh
@@ -33,12 +33,6 @@ cd "${DIR}"
 # Pull any required Docker images.
 
 DOCKER_FILE=${DIR}/hlfv1/docker-compose.yml
-for IMAGE in hyperledger/fabric-ca hyperledger/fabric-orderer hyperledger/fabric-peer hyperledger/fabric-tools hyperledger/fabric-ccenv
-do
-    docker pull nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable
-    docker tag nexus3.hyperledger.org:10001/${IMAGE}:amd64-1.3.0-stable ${IMAGE}
-done
-
 
 if [ -d ./hlfv1/crypto-config ]; then
     rm -rf ./hlfv1/crypto-config


### PR DESCRIPTION
#189 

Also removed the `timeout` command on Windows which gives some junk about cannot handle redirected input (it doesn't even need any input!) when running inside a headless terminal 🤦‍♂️ 

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>