### PR TITLE
Persist Fabric data in volumes, add teardown command (resolves #190)

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -21,3 +21,4 @@ coverage
 /test/data/smartContractDir/
 /integrationTest/smartContractDir/
 /integrationTest/mySmartContract/
+/integrationTest/teardownSmartContract/

--- a/client/basic-network/docker-compose.yml
+++ b/client/basic-network/docker-compose.yml
@@ -5,6 +5,12 @@
 #
 version: '2.1'
 
+volumes:
+  ca.example.com:
+  orderer.example.com:
+  peer0.org1.example.com:
+  couchdb:
+
 networks:
   basic:
 
@@ -22,6 +28,7 @@ services:
     command: sh -c 'fabric-ca-server start -b admin:adminpw'
     volumes:
       - ./crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
+      - ca.example.com:/etc/hyperledger/fabric-ca-server
     # VSCODE container_name: ca.example.com
     networks:
       - basic
@@ -42,9 +49,10 @@ services:
       # VSCODE - 7050:7050
       - 7050
     volumes:
-        - ./config/:/etc/hyperledger/configtx
-        - ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/msp/orderer
-        - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peerOrg1
+      - ./config/:/etc/hyperledger/configtx
+      - ./crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/msp/orderer
+      - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/:/etc/hyperledger/msp/peerOrg1
+      - orderer.example.com:/var/hyperledger/production/orderer
     networks:
       - basic
 
@@ -81,10 +89,11 @@ services:
       - 7052
       - 7053
     volumes:
-        - /var/run/:/host/var/run/
-        - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
-        - ./crypto-config/peerOrganizations/org1.example.com/users:/etc/hyperledger/msp/users
-        - ./config:/etc/hyperledger/configtx
+      - /var/run/:/host/var/run/
+      - ./crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
+      - ./crypto-config/peerOrganizations/org1.example.com/users:/etc/hyperledger/msp/users
+      - ./config:/etc/hyperledger/configtx
+      - peer0.org1.example.com:/var/hyperledger/production
     depends_on:
       - orderer.example.com
       - couchdb
@@ -102,6 +111,8 @@ services:
     ports:
       # VSCODE - 5984:5984
       - 5984
+    volumes:
+      - couchdb:/opt/couchdb/data
     networks:
       - basic
 

--- a/client/basic-network/start.sh
+++ b/client/basic-network/start.sh
@@ -10,8 +10,6 @@ set -ev
 # don't rewrite paths for Windows Git Bash users
 export MSYS_NO_PATHCONV=1
 
-docker-compose -f docker-compose.yml down
-
 docker-compose -f docker-compose.yml up -d ca.example.com orderer.example.com peer0.org1.example.com couchdb
 
 # wait for Hyperledger Fabric to start
@@ -31,7 +29,11 @@ do
 done
 echo Hyperledger Fabric started in $i seconds
 
-# Create the channel
-docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
-# Join peer0.org1.example.com to the channel.
-docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel join -b mychannel.block
+# Check to see if the channel already exists
+if ! docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel getinfo -c mychannel
+then
+    # Create the channel
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
+    # Join peer0.org1.example.com to the channel.
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel join -b mychannel.block
+fi

--- a/client/basic-network/teardown.sh
+++ b/client/basic-network/teardown.sh
@@ -8,7 +8,7 @@
 set -e
 
 # Shut down the Docker containers for the system tests.
-docker-compose -f docker-compose.yml kill && docker-compose -f docker-compose.yml down
+docker-compose -f docker-compose.yml kill && docker-compose -f docker-compose.yml down -v
 
 # remove the local state
 rm -f ~/.hfc-key-store/*

--- a/client/package.json
+++ b/client/package.json
@@ -54,6 +54,7 @@
             "blockchainExplorer.startFabricRuntime",
             "blockchainExplorer.stopFabricRuntime",
             "blockchainExplorer.restartFabricRuntime",
+            "blockchainExplorer.teardownFabricRuntime",
             "blockchainExplorer.toggleFabricRuntimeDevMode",
             "blockchainExplorer.editConnectionEntry"
         ]
@@ -194,6 +195,11 @@
                 "category": "IBM Blockchain Platform"
             },
             {
+                "command": "blockchainExplorer.teardownFabricRuntime",
+                "title": "Teardown Fabric Runtime",
+                "category": "IBM Blockchain Platform"
+            },
+            {
                 "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
                 "title": "Toggle Development Mode",
                 "category": "IBM Blockchain Platform"
@@ -219,6 +225,9 @@
                 },
                 {
                     "command": "blockchainExplorer.restartFabricRuntime"
+                },
+                {
+                    "command": "blockchainExplorer.teardownFabricRuntime"
                 },
                 {
                     "command": "blockchainExplorer.toggleFabricRuntimeDevMode"
@@ -265,6 +274,10 @@
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-stopped"
                 },
                 {
+                    "command": "blockchainExplorer.startFabricRuntime",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-removed"
+                },
+                {
                     "command": "blockchainExplorer.stopFabricRuntime",
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
                 },
@@ -273,12 +286,24 @@
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
                 },
                 {
+                    "command": "blockchainExplorer.teardownFabricRuntime",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
+                },
+                {
+                    "command": "blockchainExplorer.teardownFabricRuntime",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-stopped"
+                },
+                {
                     "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-started"
                 },
                 {
                     "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
                     "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-stopped"
+                },
+                {
+                    "command": "blockchainExplorer.toggleFabricRuntimeDevMode",
+                    "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item-removed"
                 },
                 {
                     "command": "blockchainAPackageExplorer.deleteSmartContractPackageEntry",

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -370,4 +370,13 @@ export class UserInputUtil {
             vscode.window.showErrorMessage(error.message);
         }
     }
+
+    public static async showConfirmationWarningMessage(prompt: string): Promise<boolean> {
+        const reallyDoIt: vscode.MessageItem = await vscode.window.showWarningMessage(prompt, { title: 'Yes' }, { title: 'No' });
+        if (!reallyDoIt) {
+            return false;
+        }
+        return reallyDoIt.title === 'Yes';
+    }
+
 }

--- a/client/src/commands/teardownFabricRuntime.ts
+++ b/client/src/commands/teardownFabricRuntime.ts
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { UserInputUtil, IBlockchainQuickPickItem } from './UserInputUtil';
+import { RuntimeTreeItem } from '../explorer/model/RuntimeTreeItem';
+import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
+import { FabricRuntime } from '../fabric/FabricRuntime';
+
+export async function teardownFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Promise<void> {
+    let runtime: FabricRuntime;
+    if (!runtimeTreeItem) {
+        const chosenRuntime: IBlockchainQuickPickItem<FabricRuntime> = await UserInputUtil.showRuntimeQuickPickBox('Select the Fabric runtime to teardown');
+        if (!chosenRuntime) {
+           return;
+        }
+
+        runtime = chosenRuntime.data;
+    } else {
+        runtime = runtimeTreeItem.getRuntime();
+    }
+
+    const reallyDoIt: boolean = await UserInputUtil.showConfirmationWarningMessage(`All world state and ledger data for the Fabric runtime ${runtime.getName()} will be destroyed. Do you want to continue?`);
+    if (!reallyDoIt) {
+        return;
+    }
+
+    await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token) => {
+        progress.report({ message: `Tearing down Fabric runtime ${runtime.getName()}` });
+        const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
+        await runtime.teardown(outputAdapter);
+    });
+}

--- a/client/src/docker/Docker.ts
+++ b/client/src/docker/Docker.ts
@@ -52,6 +52,16 @@ export class Docker {
         return info.NetworkSettings.Ports;
     }
 
+    public async doesVolumeExist(volumeID: string): Promise<boolean> {
+        try {
+            const volume: Dockerode.Volume = this.docker.getVolume(volumeID);
+            await volume.inspect();
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     public async isContainerRunning(containerID: string): Promise<boolean> {
         try {
             const container: Dockerode.Container = this.docker.getContainer(containerID);

--- a/client/src/explorer/model/RuntimeTreeItem.ts
+++ b/client/src/explorer/model/RuntimeTreeItem.ts
@@ -57,6 +57,7 @@ export class RuntimeTreeItem extends ConnectionTreeItem {
 
     private async updateProperties() {
         const busy: boolean = this.runtime.isBusy();
+        const created: boolean = await this.runtime.isCreated();
         const running: boolean = await this.runtime.isRunning();
         const developmentMode: boolean = this.runtime.isDevelopmentMode();
         let newLabel: string = this.name + '  ';
@@ -89,7 +90,11 @@ export class RuntimeTreeItem extends ConnectionTreeItem {
                 title: '',
                 arguments: [this]
             };
-            newContextLabel = 'blockchain-runtime-item-stopped';
+            if (created) {
+                newContextLabel = 'blockchain-runtime-item-stopped';
+            } else {
+                newContextLabel = 'blockchain-runtime-item-removed';
+            }
         }
         if (developmentMode) {
             newLabel += '  ∞';

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -44,6 +44,7 @@ import { ChannelTreeItem } from './explorer/model/ChannelTreeItem';
 import { instantiateSmartContract} from './commands/instantiateCommand';
 import { editConnectionCommand} from './commands/editConnectionCommand';
 import { ConnectionPropertyTreeItem } from './explorer/model/ConnectionPropertyTreeItem';
+import { teardownFabricRuntime } from './commands/teardownFabricRuntime';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -115,6 +116,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.startFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => startFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.stopFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => stopFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.restartFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => restartFabricRuntime(runtimeTreeItem)));
+    context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.teardownFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => teardownFabricRuntime(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.toggleFabricRuntimeDevMode', (runtimeTreeItem?: RuntimeTreeItem) => toggleFabricRuntimeDevMode(runtimeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainAPackageExplorer.deleteSmartContractPackageEntry', (project) => deleteSmartContractPackage(project)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.installSmartContractEntry', (peerTreeItem?: PeerTreeItem) => installSmartContract(peerTreeItem)));

--- a/client/test/commands/teardownFabricRuntime.test.ts
+++ b/client/test/commands/teardownFabricRuntime.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as myExtension from '../../src/extension';
+import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegistry';
+import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
+import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { TestUtil } from '../TestUtil';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+chai.should();
+
+// tslint:disable no-unused-expression
+describe('teardownFabricRuntime', () => {
+
+    let sandbox: sinon.SinonSandbox;
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtime: FabricRuntime;
+    let runtimeTreeItem: RuntimeTreeItem;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeConnectionsConfig();
+        await TestUtil.storeRuntimesConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreConnectionsConfig();
+        await TestUtil.restoreRuntimesConfig();
+    });
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        await ExtensionUtil.activateExtension();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('local_fabric');
+        runtime = runtimeManager.get('local_fabric');
+        const provider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+        const children: BlockchainTreeItem[] = await provider.getChildren();
+        runtimeTreeItem = children.find((child: BlockchainTreeItem) => child instanceof RuntimeTreeItem) as RuntimeTreeItem;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    it('should teardown a Fabric runtime specified by right clicking the tree', async () => {
+        const warningStub: sinon.SinonStub = sandbox.stub(UserInputUtil, 'showConfirmationWarningMessage').resolves(true);
+        const teardownStub: sinon.SinonStub = sandbox.stub(runtime, 'teardown').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.teardownFabricRuntime', runtimeTreeItem);
+        warningStub.should.have.been.calledOnce;
+        teardownStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+    it('should teardown a Fabric runtime specified by selecting it from the quick pick', async () => {
+        const quickPickStub: sinon.SinonStub = sandbox.stub(UserInputUtil, 'showRuntimeQuickPickBox').resolves({label: 'local_fabric', data: FabricRuntimeManager.instance().get('local_fabric')});
+        const warningStub: sinon.SinonStub = sandbox.stub(UserInputUtil, 'showConfirmationWarningMessage').resolves(true);
+        const teardownStub: sinon.SinonStub = sandbox.stub(runtime, 'teardown').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.teardownFabricRuntime');
+        quickPickStub.should.have.been.calledOnce;
+        warningStub.should.have.been.calledOnce;
+        teardownStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+    it('should handle cancel from choosing runtime', async () => {
+        const quickPickStub: sinon.SinonStub = sandbox.stub(UserInputUtil, 'showRuntimeQuickPickBox').resolves();
+        const teardownStub: sinon.SinonStub = sandbox.stub(runtime, 'teardown').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.teardownFabricRuntime');
+        quickPickStub.should.have.been.calledOnce;
+        teardownStub.should.not.have.been.called;
+    });
+
+    it('should handle cancel from confirmation message', async () => {
+        const warningStub: sinon.SinonStub = sandbox.stub(UserInputUtil, 'showConfirmationWarningMessage').resolves(false);
+        const teardownStub: sinon.SinonStub = sandbox.stub(runtime, 'teardown').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.teardownFabricRuntime', runtimeTreeItem);
+        warningStub.should.have.been.calledOnce;
+        teardownStub.should.not.have.been.called;
+    });
+
+});

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -233,55 +233,56 @@ describe('userInputUtil', () => {
             });
         });
 
-        describe('showFolderOptions', () => {
-            it('should show add to workspace in quickpick box', async () => {
-                quickPickStub.resolves(UserInputUtil.ADD_TO_WORKSPACE);
-                const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
-                result.should.equal(UserInputUtil.ADD_TO_WORKSPACE);
+    });
 
-                quickPickStub.should.have.been.calledWith(sinon.match.any, {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Choose how to open the project'
-                });
-            });
+    describe('showFolderOptions', () => {
+        it('should show add to workspace in quickpick box', async () => {
+            quickPickStub.resolves(UserInputUtil.ADD_TO_WORKSPACE);
+            const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
+            result.should.equal(UserInputUtil.ADD_TO_WORKSPACE);
 
-            it('should show open in current window in quickpick box', async () => {
-                quickPickStub.resolves(UserInputUtil.OPEN_IN_CURRENT_WINDOW);
-                const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
-                result.should.equal(UserInputUtil.OPEN_IN_CURRENT_WINDOW);
-
-                quickPickStub.should.have.been.calledWith(sinon.match.any, {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Choose how to open the project'
-                });
-            });
-
-            it('should show open in new window in quickpick box', async () => {
-                quickPickStub.resolves(UserInputUtil.OPEN_IN_NEW_WINDOW);
-                const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
-                result.should.equal(UserInputUtil.OPEN_IN_NEW_WINDOW);
-
-                quickPickStub.should.have.been.calledWith(sinon.match.any, {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Choose how to open the project'
-                });
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Choose how to open the project'
             });
         });
 
-        describe('showPeerQuickPickBox', () => {
-            it('should show the peer names', async () => {
-                quickPickStub.resolves('myPeerOne');
-                const result: string = await UserInputUtil.showPeerQuickPickBox('Choose a peer');
-                result.should.equal('myPeerOne');
-            });
+        it('should show open in current window in quickpick box', async () => {
+            quickPickStub.resolves(UserInputUtil.OPEN_IN_CURRENT_WINDOW);
+            const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
+            result.should.equal(UserInputUtil.OPEN_IN_CURRENT_WINDOW);
 
-            it('should handle no connection', async () => {
-                getConnectionStub.returns(null);
-                await UserInputUtil.showPeerQuickPickBox('Choose a peer').should.be.rejectedWith(`No connection to a blockchain found`);
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Choose how to open the project'
             });
+        });
+
+        it('should show open in new window in quickpick box', async () => {
+            quickPickStub.resolves(UserInputUtil.OPEN_IN_NEW_WINDOW);
+            const result: string = await UserInputUtil.showFolderOptions('Choose how to open the project');
+            result.should.equal(UserInputUtil.OPEN_IN_NEW_WINDOW);
+
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Choose how to open the project'
+            });
+        });
+    });
+
+    describe('showPeerQuickPickBox', () => {
+        it('should show the peer names', async () => {
+            quickPickStub.resolves('myPeerOne');
+            const result: string = await UserInputUtil.showPeerQuickPickBox('Choose a peer');
+            result.should.equal('myPeerOne');
+        });
+
+        it('should handle no connection', async () => {
+            getConnectionStub.returns(null);
+            await UserInputUtil.showPeerQuickPickBox('Choose a peer').should.be.rejectedWith(`No connection to a blockchain found`);
         });
     });
 
@@ -616,4 +617,25 @@ describe('userInputUtil', () => {
             errorStub.should.have.been.calledWith('error opening file');
         });
     });
+
+    describe('showConfirmationWarningMessage', () => {
+        it('should return true if the user clicks yes', async () => {
+            const warningStub: sinon.SinonStub = mySandBox.stub(vscode.window, 'showWarningMessage').resolves({ title: 'Yes' });
+            await UserInputUtil.showConfirmationWarningMessage('hello world').should.eventually.be.true;
+            warningStub.should.have.been.calledWithExactly('hello world', { title: 'Yes' }, { title: 'No' });
+        });
+
+        it('should return true if the user clicks no', async () => {
+            const warningStub: sinon.SinonStub = mySandBox.stub(vscode.window, 'showWarningMessage').resolves({ title: 'No' });
+            await UserInputUtil.showConfirmationWarningMessage('hello world').should.eventually.be.false;
+            warningStub.should.have.been.calledWithExactly('hello world', { title: 'Yes' }, { title: 'No' });
+        });
+
+        it('should return true if the user dismisses the message', async () => {
+            const warningStub: sinon.SinonStub = mySandBox.stub(vscode.window, 'showWarningMessage').resolves();
+            await UserInputUtil.showConfirmationWarningMessage('hello world').should.eventually.be.false;
+            warningStub.should.have.been.calledWithExactly('hello world', { title: 'Yes' }, { title: 'No' });
+        });
+    });
+
 });

--- a/client/test/explorer/model/RuntimeTreeItem.test.ts
+++ b/client/test/explorer/model/RuntimeTreeItem.test.ts
@@ -81,7 +81,30 @@ describe('RuntimeTreeItem', () => {
 
     describe('#constructor', () => {
 
+        it('should have the right properties for a runtime that is not created', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(false);
+            sandbox.stub(runtime, 'isBusy').returns(false);
+            sandbox.stub(runtime, 'isRunning').resolves(false);
+            const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', new FabricConnectionRegistryEntry({
+                name: 'myRuntime',
+                managedRuntime: true,
+                connectionProfilePath: 'myPath',
+                identities: [{certificatePath: 'myCert', privateKeyPath: 'myKey'}]
+            }), vscode.TreeItemCollapsibleState.None);
+            await new Promise((resolve) => {
+                setTimeout(resolve, 0);
+            });
+            treeItem.label.should.equal('myRuntime  ○');
+            treeItem.command.should.deep.equal({
+                command: 'blockchainExplorer.startFabricRuntime',
+                title: '',
+                arguments: [treeItem]
+            });
+            treeItem.contextValue.should.equal('blockchain-runtime-item-removed');
+        });
+
         it('should have the right properties for a runtime that is not running', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
             const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', new FabricConnectionRegistryEntry({
@@ -103,6 +126,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
 
@@ -116,6 +140,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should animate the label for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
 
@@ -134,6 +159,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that is running', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(true);
             const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', connection, vscode.TreeItemCollapsibleState.None);
@@ -150,6 +176,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that becomes busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
@@ -176,6 +203,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should animate the label for a runtime that becomes busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
@@ -200,6 +228,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that stops being busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             const isBusyStub: sinon.SinonStub = sandbox.stub(runtime, 'isBusy');
             isBusyStub.returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
@@ -226,6 +255,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that is not running in development mode', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isDevelopmentMode').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(false);
@@ -244,6 +274,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should have the right properties for a runtime that is running in development mode', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isDevelopmentMode').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(false);
             sandbox.stub(runtime, 'isRunning').resolves(true);
@@ -261,6 +292,7 @@ describe('RuntimeTreeItem', () => {
         });
 
         it('should report errors animating the label for a runtime that is busy', async () => {
+            sandbox.stub(runtime, 'isCreated').returns(true);
             sandbox.stub(runtime, 'isBusy').returns(true);
             sandbox.stub(runtime, 'isRunning').resolves(false);
             const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(provider, 'myRuntime', new FabricConnectionRegistryEntry({

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -83,6 +83,7 @@ describe('Extension Tests', () => {
             'blockchainExplorer.startFabricRuntime',
             'blockchainExplorer.stopFabricRuntime',
             'blockchainExplorer.restartFabricRuntime',
+            'blockchainExplorer.teardownFabricRuntime',
             'blockchainExplorer.toggleFabricRuntimeDevMode',
             'blockchainAPackageExplorer.deleteSmartContractPackageEntry',
             'blockchainExplorer.installSmartContractEntry',
@@ -112,6 +113,7 @@ describe('Extension Tests', () => {
             'onCommand:blockchainExplorer.startFabricRuntime',
             'onCommand:blockchainExplorer.stopFabricRuntime',
             'onCommand:blockchainExplorer.restartFabricRuntime',
+            'onCommand:blockchainExplorer.teardownFabricRuntime',
             'onCommand:blockchainExplorer.toggleFabricRuntimeDevMode',
             'onCommand:blockchainExplorer.editConnectionEntry'
         ]);


### PR DESCRIPTION
- Add Docker volumes for persisting Fabric runtime data
- Remove "down" (delete containers) from start script
- Ensure start script can be run multiple times by only creating channel if it doesn't exist
- Delete volumes during a "teardown"
- Add new "Teardown Fabric runtime" command 

Design is covered in issue #190 

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>