### PR TITLE
workaround of pause before opening dialog

### DIFF
--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -301,7 +301,8 @@ export class UserInputUtil {
                 return;
             } else if (result === this.BROWSE_LABEL) {
                 // Browse file and get path
-
+                // see method comment for details of this workaround
+                await UserInputUtil.delayWorkaround(200);
                 const fileBrowser: vscode.Uri[] = await vscode.window.showOpenDialog({
                     canSelectFiles: true,
                     canSelectFolders: false,
@@ -379,4 +380,13 @@ export class UserInputUtil {
         return reallyDoIt.title === 'Yes';
     }
 
+    /** Delay for a set number of ms; this code is added in order to workaround the VSCode issue
+     * https://github.com/Microsoft/vscode/issues/52778
+     *
+     * See comment on this post for discussion.
+     * @param {number} ms milliseconds to pause for
+     */
+    public static delayWorkaround(ms: number): Promise<any> {
+      return new Promise((resolve: any): any => setTimeout(resolve, ms));
+    }
 }

--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -89,6 +89,9 @@ export async function createSmartContractProject(): Promise<void> {
         canSelectFolders: true,
         openLabel: 'Open'
     };
+
+    // see method comment for details of this workaround
+    await UserInputUtil.delayWorkaround(200);
     const folderSelect: vscode.Uri[] | undefined = await vscode.window.showOpenDialog(openDialogOptions);
     if (!folderSelect) {  // undefined if the user cancels the open dialog box
         return;

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -519,13 +519,13 @@ describe('userInputUtil', () => {
             const result: string = await UserInputUtil.browseEdit(placeHolder, 'connection');
 
             quickPickStub.should.have.been.calledWith([UserInputUtil.BROWSE_LABEL, UserInputUtil.EDIT_LABEL], { placeHolder });
-
             showOpenDialogStub.should.have.been.calledWith({
                 canSelectFiles: true,
                 canSelectFolders: false,
                 canSelectMany: false,
                 openLabel: 'Select'
             });
+
             result.should.equal('/some/path');
 
         });
@@ -638,4 +638,25 @@ describe('userInputUtil', () => {
         });
     });
 
+    describe('delayWorkaround', () => {
+      beforeEach(() => {
+          this.clock = sinon.useFakeTimers();
+      });
+
+      afterEach(() => {
+        this.clock.restore();
+      });
+
+      it('should delay for the specified time', async () => {
+          const isResolved: boolean = false;
+          const stub: sinon.SinonStub = mySandBox.stub();
+          const p: Promise<any> = UserInputUtil.delayWorkaround(2000).then(stub);
+          sinon.assert.notCalled(stub);
+
+          this.clock.tick(2300);
+          await p.should.be.eventually.fulfilled;
+          return sinon.assert.calledOnce(stub);
+      });
+
+    });
 });


### PR DESCRIPTION
Added a pause before opening the dialogs.  A workaround not solution - but in local testing it appears to be stable. 

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>