### PR TITLE
Add hidden command to generate tests for instantiated smart contracts

### DIFF
--- a/client/coverconfig.json
+++ b/client/coverconfig.json
@@ -5,7 +5,8 @@
   "ignorePatterns": [
       "**/node_modules/**",
       "**/test/**",
-      "**/out/**"
+      "**/out/**",
+      "templates/testSmartContractTemplate.ejs"
 
   ],
   "includePid": false,

--- a/client/package.json
+++ b/client/package.json
@@ -487,6 +487,7 @@
         "@fidm/x509": "1.1.3",
         "child-process-promise": "^2.2.1",
         "dockerode": "^2.5.5",
+        "ejs": "^2.6.1",
         "fs-extra": "^7.0.0",
         "home-dir": "1.0.0",
         "strip-ansi": "^4.0.0",
@@ -540,7 +541,8 @@
             "integrationTest/data",
             "integrationTest/tmp",
             "basic-network",
-            "CHANGELOG.md"
+            "CHANGELOG.md",
+            "templates/testSmartContractTemplate.ejs"
         ],
         "file_type_method": "EXCLUDE",
         "file_types": [

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -394,4 +394,35 @@ export class UserInputUtil {
     public static delayWorkaround(ms: number): Promise<any> {
       return new Promise((resolve: any): any => setTimeout(resolve, ms));
     }
+
+    public static async showInstantiatedSmartContractsQuickPick(prompt: string, channelName: string): Promise<IBlockchainQuickPickItem<{ name: string, channel: string, version: string }> | undefined>  {
+        const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+        const connection: IFabricConnection = fabricConnectionManager.getConnection();
+
+        if (!connection) {
+            vscode.window.showErrorMessage('No connection to a blockchain found');
+            return;
+        }
+
+        const instantiatedChaincodes: any[] = await connection.getInstantiatedChaincode(channelName); // returns array of objects
+        if (instantiatedChaincodes.length === 0) {
+            vscode.window.showInformationMessage('No instantiated chaincodes within connection');
+            return;
+        }
+
+        const quickPickItems: Array<IBlockchainQuickPickItem<{ name: string, channel: string, version: string }>> = [];
+        for (const chaincode of instantiatedChaincodes) {
+            const data: { name: string, channel: string, version: string } = {name: chaincode.name, channel: channelName, version: chaincode.version};
+            quickPickItems.push({label: `${chaincode.name}@${chaincode.version}`, data: data});
+        }
+
+        const quickPickOptions: vscode.QuickPickOptions = {
+            ignoreFocusOut: true,
+            canPickMany: false,
+            placeHolder: prompt
+        };
+
+        return vscode.window.showQuickPick(quickPickItems, quickPickOptions);
+    }
+
 }

--- a/client/src/commands/installCommand.ts
+++ b/client/src/commands/installCommand.ts
@@ -25,7 +25,7 @@ export async function installSmartContract(peerTreeItem?: PeerTreeItem, peerName
         if (!FabricConnectionManager.instance().getConnection()) {
             await vscode.commands.executeCommand('blockchainExplorer.connectEntry');
             if (!FabricConnectionManager.instance().getConnection()) {
-                // either the user cancelled or ther was an error so don't carry on
+                // either the user cancelled or there was an error so don't carry on
                 return;
             }
         }

--- a/client/src/commands/testSmartContractCommand.ts
+++ b/client/src/commands/testSmartContractCommand.ts
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import * as vscode from 'vscode';
+import * as fs from 'fs-extra';
+import * as ejs from 'ejs';
+import * as path from 'path';
+import { ChainCodeTreeItem } from '../explorer/model/ChainCodeTreeItem';
+import { UserInputUtil, IBlockchainQuickPickItem } from './UserInputUtil';
+import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
+import { IFabricConnection } from '../fabric/IFabricConnection';
+import { FabricRuntimeConnection } from '../fabric/FabricRuntimeConnection';
+import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
+import { Reporter } from '../util/Reporter';
+
+export async function testSmartContract(chaincode?: ChainCodeTreeItem): Promise<void> {
+    console.log('testSmartContractCommand', chaincode);
+
+    let chaincodeLabel: string;
+    let chosenChaincode: IBlockchainQuickPickItem<{ name: string, channel: string, version: string}>;
+    let chosenChannel: IBlockchainQuickPickItem<Set<string>>;
+    let channelName: string;
+    let chaincodeName: string;
+    let chaincodeVersion: string;
+
+    // If called from the command palette, ask for instantiated smart contract to test
+    if (!chaincode) {
+        if (!FabricConnectionManager.instance().getConnection()) {
+            // Connect if not already connected
+            await vscode.commands.executeCommand('blockchainExplorer.connectEntry');
+            if (!FabricConnectionManager.instance().getConnection()) {
+                // either the user cancelled or there was an error so don't carry on
+                return;
+            }
+        }
+        try {
+            // Ask for a channel
+            chosenChannel = await UserInputUtil.showChannelQuickPickBox('Please chose channel of instantiated smart contract to test');
+            if (!chosenChannel) {
+                return;
+            }
+            channelName = chosenChannel.label;
+        } catch (error) {
+            vscode.window.showErrorMessage(error.message);
+            return;
+        }
+
+        // Ask for instantiated smart contract on chosen channel
+        chosenChaincode = await UserInputUtil.showInstantiatedSmartContractsQuickPick('Please chose instantiated smart contract to test', channelName);
+        if (!chosenChaincode) {
+            return;
+        }
+        chaincodeLabel = chosenChaincode.label;
+        chaincodeName = chosenChaincode.data.name;
+        chaincodeVersion = chosenChaincode.data.version;
+
+    } else {
+        // Smart Contract selected from the tree item, so assign label and name
+        chaincodeLabel = chaincode.label;
+        chaincodeName = chaincode.name;
+        channelName = chaincode.channel.label;
+        chaincodeVersion = chaincode.version;
+    }
+    console.log('testSmartContractCommand: chaincode to generate tests for is: ' + chaincodeLabel);
+
+    // Get the metadata for the chosen instantiated smart contract
+    const connection: IFabricConnection = FabricConnectionManager.instance().getConnection();
+    let metadataObj: any;
+    try {
+        metadataObj = await connection.getMetadata(chaincodeName, channelName);
+    } catch (error) {
+        console.log('Error getting the metadata: ' + error);
+        vscode.window.showErrorMessage('Error getting metadata for smart contract: ' + error.message);
+        return;
+    }
+
+    // Get extension directory
+    const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
+    const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+    const testCommandDir: string = path.join(homeExtDir, 'test', chaincodeLabel);
+
+    // Get connection details for connection
+    const connectionDetails: {connectionProfile: object, certificatePath: string, privateKeyPath: string} | {connectionProfilePath: string, certificatePath: string, privateKeyPath: string} = await connection.getConnectionDetails();
+    let connectionProfilePath: string;
+    let certificatePath: string;
+    let privateKeyPath: string;
+
+    if (connection instanceof FabricRuntimeConnection) {
+        // connection profile is an object not a path, so write it to a file
+        const runtimeConnectionDetails: {connectionProfile: object, certificatePath: string, privateKeyPath: string} = connectionDetails as {connectionProfile: object, certificatePath: string, privateKeyPath: string};
+        const runtimeConnectionProfilePath: string = path.join(testCommandDir, 'connection.json');
+        const connectionProfile: string = JSON.stringify(runtimeConnectionDetails.connectionProfile, null, 4);
+        try {
+            await fs.ensureFile(runtimeConnectionProfilePath);
+            await fs.writeFileSync(runtimeConnectionProfilePath, connectionProfile);
+        } catch (error) {
+            vscode.window.showErrorMessage('Error writing runtime connection profile: ' + error.message);
+            await removeDirectory(testCommandDir);
+            return;
+        }
+        connectionProfilePath = runtimeConnectionProfilePath;
+        certificatePath = runtimeConnectionDetails.certificatePath;
+        privateKeyPath = runtimeConnectionDetails.privateKeyPath;
+    } else {
+        // Client connection, so connection details are all paths
+        const clientConnectionDetails: {connectionProfilePath: string, certificatePath: string, privateKeyPath: string} = connectionDetails as {connectionProfilePath: string, certificatePath: string, privateKeyPath: string};
+        connectionProfilePath = clientConnectionDetails.connectionProfilePath;
+        certificatePath = clientConnectionDetails.certificatePath;
+        privateKeyPath = clientConnectionDetails.privateKeyPath;
+    }
+
+    // Populate the template data
+    // TODO: Needs updating when the metadata is updated:
+    // tslint:disable-next-line
+    const smartContractFunctionsArray: string[] = metadataObj[""].functions;
+
+    const templateData: any = {
+        chaincodeLabel: chaincodeLabel,
+        functionNames: smartContractFunctionsArray,
+        connectionProfilePath: connectionProfilePath,
+        certificatePath: certificatePath,
+        privateKeyPath: privateKeyPath,
+        chaincodeName: chaincodeName,
+        chaincodeVersion: chaincodeVersion,
+        channelName: channelName
+    };
+    console.log('template data is: ');
+    console.log(templateData);
+
+    // Create data to write to file from template engine
+    const template: string = path.join(__dirname, '..', '..', '..', 'templates', 'testSmartContractTemplate.ejs');
+    let dataToWrite: string;
+    try {
+        dataToWrite = await createDataToWrite(template, templateData);
+    } catch (error) {
+        vscode.window.showErrorMessage('Error creating template data: ' + error.message);
+        await removeDirectory(testCommandDir);
+        return;
+    }
+
+    // Create the test file
+    const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
+    const testFile: string = path.join(testCommandDir, `${chaincodeLabel}.test.js`);
+    const testFileExists: boolean = await fs.pathExists(testFile);
+    if (testFileExists) {
+        // Ask the user if they want to overwrite existing test file
+        const overwriteTestFile: string = await UserInputUtil.showQuickPickYesNo(`Test file for selected smart contract already exists in workspace, overwrite it?`);
+        if (overwriteTestFile === UserInputUtil.NO) {
+            // Don't create test file, user doesn't want to overwrite existing, but tell them where it is:
+            outputAdapter.log(`Preserving test file for instantiated smart contract located here: ${testFile}`);
+            return;
+        }
+        outputAdapter.log(`Writing to Smart Contract test file: ${testFile}`);
+    } else {
+        // Test file doesn't already exist, so create it
+        try {
+            await fs.ensureFile(testFile);
+        } catch (error) {
+            console.log('Errored creating test file: ' + testFile);
+            vscode.window.showErrorMessage('Error creating test file: ' + error.message);
+            await removeDirectory(testCommandDir);
+            return;
+        }
+        outputAdapter.log(`Created Smart Contract test file: ${testFile}`);
+    }
+
+   // Open, show and write to test file
+    const document: vscode.TextDocument = await vscode.workspace.openTextDocument(testFile);
+
+    const showTextDocumentOptions: any = {
+        preserveFocus: true,
+        selection: new vscode.Range(1, 0, 3, 0) // TODO: get this to highlight comment when it's added
+    };
+    const textEditor: vscode.TextEditor = await vscode.window.showTextDocument(document, showTextDocumentOptions);
+
+    const lineCount: number = document.lineCount;
+    const textEditorResult: boolean = await textEditor.edit((editBuilder: vscode.TextEditorEdit) => {
+            editBuilder.replace(new vscode.Range(0, 0, lineCount, 0), dataToWrite);
+        });
+    if (!textEditorResult) {
+        vscode.window.showErrorMessage('Error editing test file: ' + testFile);
+        await removeDirectory(testCommandDir);
+        return;
+
+    }
+    await document.save();
+
+    Reporter.instance().sendTelemetryEvent('testSmartContractCommand');
+
+}
+
+async function createDataToWrite(template: string, templateData: any): Promise<any> {
+    console.log('TestSmartContractCommand: createDataToWrite using template file:', template);
+
+    const ejsOptions: ejs.Options = {
+        async: true,
+    };
+    return new Promise ( (resolve: any, reject: any): any => {
+        // TODO: promisify this?
+        ejs.renderFile(template, templateData, ejsOptions, (error: any, data: any) => {
+            if (error) {
+                reject(error);
+            } else {
+                resolve(data);
+            }
+         });
+    });
+}
+
+async function removeDirectory(dirToRemove: string): Promise<void> {
+    console.log('Something went wrong, so cleaning up and removing test directory:', dirToRemove);
+
+    try {
+        await fs.remove(dirToRemove);
+    } catch (error) {
+        if (!error.message.includes('ENOENT: no such file or directory')) {
+            vscode.window.showErrorMessage('Error removing test command directory: ' + error.message);
+            return;
+        }
+    }
+}

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -273,7 +273,7 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
         const channel: ChannelTreeItem = instantiatedChainCodesElement.channel;
 
         instantiatedChainCodesElement.chaincodes.forEach((instantiatedChaincode: { name: string, version: string}) => {
-            tree.push(new ChainCodeTreeItem(this, instantiatedChaincode.name + '@' + instantiatedChaincode.version, channel));
+            tree.push(new ChainCodeTreeItem(this, instantiatedChaincode.name, channel, instantiatedChaincode.version));
         });
 
         return tree;

--- a/client/src/explorer/model/ChainCodeTreeItem.ts
+++ b/client/src/explorer/model/ChainCodeTreeItem.ts
@@ -20,7 +20,7 @@ import { ChannelTreeItem } from './ChannelTreeItem';
 export class ChainCodeTreeItem extends BlockchainTreeItem {
     contextValue: string = 'blockchain-chaincode-item';
 
-    constructor(provider: BlockchainExplorerProvider, private readonly name: string, public readonly channel: ChannelTreeItem) {
-        super(provider, name, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly channel: ChannelTreeItem, public readonly version: string) {
+        super(provider, `${name}@${version}`, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/templates/testSmartContractTemplate.ejs
+++ b/client/templates/testSmartContractTemplate.ejs
@@ -1,0 +1,17 @@
+const assert = require('assert');
+
+describe('<%=chaincodeLabel%>' , () => {
+
+    before(() => {
+    });
+
+    after(async () => {
+    });
+
+    <% functionNames.forEach((functionName) => { %>
+    it('<%=functionName%>', () => {
+        assert.equal(true, true);
+    });
+    <% }) %>
+
+});

--- a/client/test/TestUtil.ts
+++ b/client/test/TestUtil.ts
@@ -57,7 +57,7 @@ export class TestUtil {
         try {
             await fs.remove(deletePath);
         } catch (error) {
-            if (!error.message.contains('ENOENT: no such file or directory')) {
+            if (!error.message.includes('ENOENT: no such file or directory')) {
                 throw error;
             }
         }

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -29,7 +29,6 @@ import { TestUtil } from '../TestUtil';
 import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
 import { Reporter } from '../../src/util/Reporter';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
-import * as yeoman from 'yeoman-environment';
 import * as util from 'util';
 
 // Defines a Mocha test suite to group tests of similar kind together

--- a/client/test/commands/editConnectionCommand.test.ts
+++ b/client/test/commands/editConnectionCommand.test.ts
@@ -13,7 +13,6 @@
 */
 'use strict';
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';

--- a/client/test/commands/testSmartContractCommands.test.ts
+++ b/client/test/commands/testSmartContractCommands.test.ts
@@ -1,0 +1,465 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as chai from 'chai';
+import * as ejs from 'ejs';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import { TestUtil } from '../TestUtil';
+import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
+import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import * as myExtension from '../../src/extension';
+import { FabricConnection } from '../../src/fabric/FabricConnection';
+import { ChannelTreeItem } from '../../src/explorer/model/ChannelTreeItem';
+import { Reporter } from '../../src/util/Reporter';
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
+import { ChainCodeTreeItem } from '../../src/explorer/model/ChainCodeTreeItem';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { testSmartContract } from '../../src/commands/testSmartContractCommand';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
+
+const should: Chai.Should = chai.should();
+chai.use(sinonChai);
+// tslint:disable no-unused-expression
+
+describe('testSmartContractCommand', () => {
+    let mySandBox: sinon.SinonSandbox;
+    let fabricClientConnectionMock: sinon.SinonStubbedInstance<FabricClientConnection>;
+    let fabricRuntimeConnectionMock: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
+    let executeCommandStub: sinon.SinonStub;
+    let errorSpy: sinon.SinonSpy;
+    let fsRemoveStub: sinon.SinonStub;
+    let reporterStub: sinon.SinonStub;
+    let getConnectionStub: sinon.SinonStub;
+    let showChannelQuickPickStub: sinon.SinonStub;
+    let showInstantiatedSmartContractsQuickPickStub: sinon.SinonStub;
+    let openTextDocumentStub: sinon.SinonStub;
+    let showTextDocumentStub: sinon.SinonStub;
+    let getDirPathStub: sinon.SinonStub;
+    let ensureFileStub: sinon.SinonStub;
+    let writeFileSyncStub: sinon.SinonStub;
+    let allChildren: Array<BlockchainTreeItem>;
+    let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
+    let fabricConnectionManager: FabricConnectionManager;
+    let channel: ChannelTreeItem;
+    let chaincodes: any[];
+    let instantiatedSmartContract: ChainCodeTreeItem;
+    let fakeMetadataFunctions: string[];
+    let fakeConnectionDetails: {connectionProfilePath: string, certificatePath: string, privateKeyPath: string};
+    let fakeRuntimeConnectionDetails: {connectionProfile: object, certificatePath: string, privateKeyPath: string};
+    let smartContractName: string;
+    const rootPath: string = path.dirname(__dirname);
+    let testFileDir: string;
+    let mockDocumentStub: any;
+    let mockDocumentSaveSpy: sinon.SinonSpy;
+    let mockEditBuilder: any;
+    let mockEditBuilderReplaceSpy: sinon.SinonSpy;
+    let mockTextEditor: any;
+
+    before(async () => {
+        await TestUtil.setupTests();
+    });
+
+    afterEach(async () => {
+        mySandBox.restore();
+        await vscode.commands.executeCommand('blockchainExplorer.disconnectEntry');
+        await TestUtil.deleteTestFiles(testFileDir);
+    });
+
+    describe('Generate tests for Fabric Client Connection instantiated smart contract', () => {
+
+        beforeEach(async () => {
+            mySandBox = sinon.createSandbox();
+            errorSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
+            reporterStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
+            fsRemoveStub = mySandBox.stub(fs, 'remove').resolves();
+            // ExecuteCommand stub
+            executeCommandStub = mySandBox.stub(vscode.commands, 'executeCommand');
+            executeCommandStub.withArgs('blockchainExplorer.connectEntry').resolves();
+            executeCommandStub.callThrough();
+            // Client Connection stubs
+            fakeMetadataFunctions  =  ['instantiate', 'wagonwheeling', 'transaction2'];
+            fakeConnectionDetails = {
+                connectionProfilePath: 'fakeConnectionProfilePath',
+                certificatePath: 'fakeCertificatePath',
+                privateKeyPath: 'fakePrivateKeyPath'
+            };
+            fabricClientConnectionMock = sinon.createStubInstance(FabricClientConnection);
+            fabricClientConnectionMock.connect.resolves();
+            fabricClientConnectionMock.instantiateChaincode.resolves();
+            fabricClientConnectionMock.getMetadata.resolves(JSON.parse('{"":{"functions":["instantiate","wagonwheeling","transaction2"]},"org.hyperledger.fabric":{"functions":["getMetaData"]}}'));
+            fabricClientConnectionMock.getConnectionDetails.resolves(fakeConnectionDetails);
+            fabricConnectionManager = FabricConnectionManager.instance();
+            getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricClientConnectionMock);
+            fabricClientConnectionMock.getAllPeerNames.returns(['peerOne']);
+            fabricClientConnectionMock.getAllChannelsForPeer.withArgs('peerOne').resolves(['myEnglishChannel']);
+            fabricClientConnectionMock.getInstantiatedChaincode.resolves([
+                {
+                    name: 'wagonwheel',
+                    version: '0.0.1',
+                    label: 'wagonwheel@0.0.1',
+                    channel: 'myEnglishChannel'
+                }
+            ]);
+            // UserInputUtil stubs
+            showChannelQuickPickStub = mySandBox.stub(UserInputUtil, 'showChannelQuickPickBox').resolves({
+                label: 'myEnglishChannel',
+                data: ['peerOne']
+            });
+
+            showInstantiatedSmartContractsQuickPickStub = mySandBox.stub(UserInputUtil, 'showInstantiatedSmartContractsQuickPick').withArgs(sinon.match.any, 'myEnglishChannel').resolves({
+                label: 'wagonwheel@0.0.1',
+                data: {name: 'wagonwheel', channel: 'myEnglishChannel', version: '0.0.1'}
+            });
+            // Explorer provider stuff
+            blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            blockchainNetworkExplorerProvider['connection'] = ((fabricClientConnectionMock as any) as FabricConnection);
+            allChildren = await blockchainNetworkExplorerProvider.getChildren();
+            channel = allChildren[0] as ChannelTreeItem;
+            chaincodes = channel.chaincodes;
+            instantiatedSmartContract = chaincodes[0] as ChainCodeTreeItem;
+            smartContractName = instantiatedSmartContract.label;
+            // Document editor stubs
+            testFileDir = path.join(rootPath, '..', 'data', 'smartContractTests');
+            mockDocumentStub = {
+                lineCount: 8,
+                save: (): any => {
+                    return Promise.resolve();
+                }
+            };
+            mockDocumentSaveSpy = mySandBox.spy(mockDocumentStub, 'save');
+            mockEditBuilder = {
+                replace: (): any => {
+                    return Promise.resolve();
+                }
+            };
+            mockEditBuilderReplaceSpy = mySandBox.spy(mockEditBuilder, 'replace');
+            mockTextEditor = {
+                edit: mySandBox.stub()
+            };
+            mockTextEditor.edit.yields(mockEditBuilder);
+            mockTextEditor.edit.resolves(true);
+            openTextDocumentStub = mySandBox.stub(vscode.workspace, 'openTextDocument').resolves(mockDocumentStub);
+            showTextDocumentStub = mySandBox.stub(vscode.window, 'showTextDocument').resolves(mockTextEditor);
+            getDirPathStub = mySandBox.stub(UserInputUtil, 'getDirPath').resolves(testFileDir);
+
+        });
+
+        it('should generate a test file for a selected instantiated smart contract', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').resolves();
+
+            await testSmartContract(instantiatedSmartContract);
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
+            templateData.should.not.equal('');
+            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(fakeMetadataFunctions[0]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[1]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[2]).should.be.true;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should ask the user for an instantiated smart contract to test if none selected', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').resolves();
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should connect if there is no connection', async () => {
+            getConnectionStub.onFirstCall().returns(null);
+            getConnectionStub.onSecondCall().returns(fabricClientConnectionMock);
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').resolves();
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.have.been.called;
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should handle connecting being cancelled', async () => {
+            getConnectionStub.returns(null);
+
+            await testSmartContract();
+            executeCommandStub.should.have.been.calledWith('blockchainExplorer.connectEntry');
+            showChannelQuickPickStub.should.not.have.been.called;
+        });
+
+        it('should do nothing if the user cancels selecting a channel', async () => {
+            showChannelQuickPickStub.resolves();
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.not.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should handle an error in asking for a channel', async () => {
+            showChannelQuickPickStub.rejects({message: 'some error'});
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('some error');
+        });
+
+        it('should do nothing if the user cancels selecting an instantiated smart contract', async () => {
+            showInstantiatedSmartContractsQuickPickStub.resolves();
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.have.been.called;
+            fabricClientConnectionMock.getMetadata.should.not.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should handle errors with running getMetaData by showing an error message to the user', async () => {
+            fabricClientConnectionMock.getMetadata.rejects({message: 'some error'});
+
+            await testSmartContract();
+            showChannelQuickPickStub.should.have.been.called;
+            showInstantiatedSmartContractsQuickPickStub.should.have.been.called;
+            fabricClientConnectionMock.getMetadata.should.have.been.called;
+            errorSpy.should.have.been.calledWith('Error getting metadata for smart contract: some error');
+        });
+
+        it('should handle errors with creating the template data', async () => {
+            mySandBox.stub(ejs, 'renderFile').yields({message: 'some error'}, null);
+
+            await testSmartContract(instantiatedSmartContract);
+            mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error creating template data: some error');
+            fsRemoveStub.should.have.been.called;
+        });
+
+        it('should not overwrite an existing test file if the user says no', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(true);
+            const showQuickPickYesNoStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showQuickPickYesNo').resolves(UserInputUtil.NO);
+
+            await testSmartContract(instantiatedSmartContract);
+            showQuickPickYesNoStub.should.have.been.called;
+            openTextDocumentStub.should.not.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should overwrite an existing test file if the user says yes', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(true);
+            const showQuickPickYesNoStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showQuickPickYesNo').resolves(UserInputUtil.YES);
+
+            await testSmartContract(instantiatedSmartContract);
+            showQuickPickYesNoStub.should.have.been.called;
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
+            templateData.should.not.equal('');
+            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(fakeMetadataFunctions[0]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[1]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[2]).should.be.true;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should show an error if it fails to create test file', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').rejects({message: 'some error'});
+
+            await testSmartContract(instantiatedSmartContract);
+            openTextDocumentStub.should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error creating test file: some error');
+            fsRemoveStub.should.have.been.called;
+        });
+
+        it('should handle errors writing data to the file', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').resolves();
+            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}.test.js`);
+            mockTextEditor.edit.resolves(false);
+
+            await testSmartContract(instantiatedSmartContract);
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            mockDocumentSaveSpy.should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error editing test file: ' + testFilePath);
+            fsRemoveStub.should.have.been.called;
+        });
+
+        it('should send a telemetry event for testSmartContract if the extension is for production', async () => {
+            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            mySandBox.stub(fs, 'ensureFile').resolves();
+
+            await testSmartContract(instantiatedSmartContract);
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            errorSpy.should.not.have.been.called;
+
+            reporterStub.should.have.been.calledWith('testSmartContractCommand');
+        });
+
+        it('should handle errors when attempting to remove created test directory', async () => {
+            mySandBox.stub(ejs, 'renderFile').yields({message: 'some error'}, null);
+            fsRemoveStub.rejects({message: 'some other error'});
+
+            await testSmartContract(instantiatedSmartContract);
+            mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error removing test command directory: some other error');
+        });
+
+        it('should not show error for removing non-existent test directory', async () => {
+            mySandBox.stub(ejs, 'renderFile').yields({message: 'some error'}, null);
+            fsRemoveStub.rejects({message: 'ENOENT: no such file or directory'});
+
+            await testSmartContract(instantiatedSmartContract);
+            mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error creating template data: some error');
+        });
+
+    });
+
+    describe('Generate tests for Fabric Runtime Connection instantiated smart contract', () => {
+
+        beforeEach(async () => {
+            mySandBox = sinon.createSandbox();
+            errorSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
+            reporterStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
+            fsRemoveStub = mySandBox.stub(fs, 'remove').resolves();
+            // ExecuteCommand stub
+            executeCommandStub = mySandBox.stub(vscode.commands, 'executeCommand');
+            executeCommandStub.withArgs('blockchainExplorer.connectEntry').resolves();
+            executeCommandStub.callThrough();
+            // Runtime Connection stubs
+            fakeMetadataFunctions = ['instantiate', 'doubledecking', 'transaction4'];
+            fakeRuntimeConnectionDetails = {
+                connectionProfile: {
+                    channels: {
+                        name: 'myChannelTunnel'
+                    },
+                    name: 'conga@network',
+                    version: '0.1.0',
+                    peers: ['peerThree']
+                },
+                certificatePath: 'fakeCertificatePath',
+                privateKeyPath: 'fakePrivateKeyPath'
+            };
+            fabricRuntimeConnectionMock = sinon.createStubInstance(FabricRuntimeConnection);
+            fabricRuntimeConnectionMock.connect.resolves();
+            fabricRuntimeConnectionMock.instantiateChaincode.resolves();
+            fabricRuntimeConnectionMock.getMetadata.resolves(JSON.parse('{"":{"functions":["instantiate","doubledecking","transaction4"]},"org.hyperledger.fabric":{"functions":["getMetaData"]}}'));
+            fabricRuntimeConnectionMock.getConnectionDetails.resolves(fakeRuntimeConnectionDetails);
+            fabricConnectionManager = FabricConnectionManager.instance();
+            getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricRuntimeConnectionMock);
+            fabricRuntimeConnectionMock.getAllPeerNames.returns(['peerThree']);
+            fabricRuntimeConnectionMock.getAllChannelsForPeer.withArgs('peerThree').resolves(['myChannelTunnel']);
+            fabricRuntimeConnectionMock.getInstantiatedChaincode.resolves([
+                {
+                    name: 'doubleDecker',
+                    version: '0.0.7',
+                    label: 'doubleDecker@0.0.7',
+                    channel: 'myChannelTunnel'
+                }
+            ]);
+            // UserInputUtil stubs
+            showChannelQuickPickStub = mySandBox.stub(UserInputUtil, 'showChannelQuickPickBox').resolves({
+                label: 'myChannelTunnel',
+                data: ['peerThree']
+            });
+
+            showInstantiatedSmartContractsQuickPickStub = mySandBox.stub(UserInputUtil, 'showInstantiatedSmartContractsQuickPick').withArgs(sinon.match.any, 'myChannelTunnel').resolves('doubleDecker@0.0.7');
+            // Explorer provider stuff
+            blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            blockchainNetworkExplorerProvider['connection'] = ((fabricRuntimeConnectionMock as any) as FabricConnection);
+            allChildren = await blockchainNetworkExplorerProvider.getChildren();
+            channel = allChildren[0] as ChannelTreeItem;
+            chaincodes = channel.chaincodes;
+            instantiatedSmartContract = chaincodes[0] as ChainCodeTreeItem;
+            smartContractName = instantiatedSmartContract.label;
+            // Document editor stubs
+            testFileDir = path.join(rootPath, '..', 'data', 'smartContractTests');
+            mockDocumentStub = {
+                lineCount: 8,
+                save: (): any => {
+                    return Promise.resolve();
+                }
+            };
+            mockDocumentSaveSpy = mySandBox.spy(mockDocumentStub, 'save');
+            mockEditBuilder = {
+                replace: (): any => {
+                    return Promise.resolve();
+                }
+            };
+            mockEditBuilderReplaceSpy = mySandBox.spy(mockEditBuilder, 'replace');
+            mockTextEditor = {
+                edit: mySandBox.stub()
+            };
+            mockTextEditor.edit.yields(mockEditBuilder);
+            mockTextEditor.edit.resolves(true);
+            openTextDocumentStub = mySandBox.stub(vscode.workspace, 'openTextDocument').resolves(mockDocumentStub);
+            showTextDocumentStub = mySandBox.stub(vscode.window, 'showTextDocument').resolves(mockTextEditor);
+            getDirPathStub = mySandBox.stub(UserInputUtil, 'getDirPath');
+            ensureFileStub = mySandBox.stub(fs, 'ensureFile');
+            writeFileSyncStub = mySandBox.stub(fs, 'writeFileSync');
+
+        });
+
+        it('should generate a copy of the connection profile if the connection is a runtime', async () => {
+            const testConnectonProfilePath: string = path.join(testFileDir, 'test', smartContractName, 'connection.json');
+            const connectionProfileToString: string = JSON.stringify(fakeRuntimeConnectionDetails.connectionProfile, null, 4);
+            getDirPathStub.onFirstCall().resolves(testFileDir);
+            ensureFileStub.onFirstCall().resolves();
+            writeFileSyncStub.onFirstCall().resolves();
+            const testFilePath: string = path.join(testFileDir, smartContractName, `${smartContractName}.test.js`);
+            getDirPathStub.onSecondCall().resolves(testFilePath);
+            mySandBox.stub(fs, 'pathExists').resolves(false);
+            ensureFileStub.onSecondCall().resolves();
+
+            await testSmartContract(instantiatedSmartContract);
+            writeFileSyncStub.should.have.been.calledWith(testConnectonProfilePath, connectionProfileToString);
+            openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
+            templateData.should.not.equal('');
+            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(fakeMetadataFunctions[0]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[1]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[2]).should.be.true;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should handle errors with copying the connection profile if the connection is a runtime', async () => {
+            getDirPathStub.onFirstCall().resolves(testFileDir);
+            ensureFileStub.onFirstCall().resolves();
+            writeFileSyncStub.onFirstCall().rejects({message: 'some error'});
+
+            await testSmartContract(instantiatedSmartContract);
+            getDirPathStub.should.have.been.calledOnce;
+            errorSpy.should.have.been.calledWith('Error writing runtime connection profile: some error');
+            fsRemoveStub.should.have.been.called;
+        });
+
+    });
+
+});

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -856,6 +856,7 @@ describe('BlockchainNetworkExplorer', () => {
                 instantiatedChainItemsOne[0].contextValue.should.equal('blockchain-chaincode-item');
                 instantiatedChainItemsOne[0].label.should.equal('biscuit-network@0.7');
                 instantiatedChainItemsOne[0].channel.should.equal(channelOne);
+                instantiatedChainItemsOne[0].version.should.equal('0.7');
 
                 const channelTwo: ChannelTreeItem = allChildren[1] as ChannelTreeItem;
 
@@ -871,6 +872,7 @@ describe('BlockchainNetworkExplorer', () => {
                 instantiatedChainItemsTwo[0].contextValue.should.equal('blockchain-chaincode-item');
                 instantiatedChainItemsTwo[0].label.should.equal('cake-network@0.10');
                 instantiatedChainItemsTwo[0].channel.should.equal(channelTwo);
+                instantiatedChainItemsTwo[0].version.should.equal('0.10');
             });
         });
     });


### PR DESCRIPTION
- Contributes towards #60 but doesn't include running the test file (as described in #62 #63 #64 #65) or a proper comment (#229 )  or connecting to connection with instantiated smart contract to test (#261)
- Test file sits in a ~/.fabric-vscode/test directory that the extension controls
- Command isn't visible, but there's another issue for that (#262 )
- Also fixed remove function in TestUtil as error.message.contains isn't right

Signed-off-by: heatherlp <heatherpollard0@gmail.com>