### PR TITLE
Added option to generate copy of test file

### DIFF
--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -45,6 +45,7 @@ export class UserInputUtil {
     static readonly BROWSE_LABEL: string = '📁 Browse';
     static readonly EDIT_LABEL: string = '✎ Edit in User Settings';
     static readonly INSTALL_INSTANTIATE_LABEL: string = 'Install and Instantiate a new smart contract from a package';
+    static readonly GENERATE_NEW_TEST_FILE: string = 'Generate new test file';
 
     public static showConnectionQuickPickBox(prompt: string, showManagedRuntimes?: boolean): Thenable<IBlockchainQuickPickItem<FabricConnectionRegistryEntry> | undefined> {
         const connections: Array<FabricConnectionRegistryEntry> = FabricConnectionRegistry.instance().getAll();
@@ -425,6 +426,18 @@ export class UserInputUtil {
         };
 
         return vscode.window.showQuickPick(quickPickItems, quickPickOptions);
+    }
+
+    public static async showTestFileOverwriteQuickPick(prompt: string): Promise<string | undefined> {
+        const options: Array<string> = [this.YES, this.NO, this.GENERATE_NEW_TEST_FILE];
+        const quickPickOptions: vscode.QuickPickOptions = {
+            ignoreFocusOut: false,
+            canPickMany: false,
+            placeHolder: prompt
+        };
+
+        return vscode.window.showQuickPick(options, quickPickOptions);
+
     }
 
 }

--- a/client/test/commands/testSmartContractCommands.test.ts
+++ b/client/test/commands/testSmartContractCommands.test.ts
@@ -253,26 +253,56 @@ describe('testSmartContractCommand', () => {
             await testSmartContract(instantiatedSmartContract);
             mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
             errorSpy.should.have.been.calledWith('Error creating template data: some error');
-            fsRemoveStub.should.have.been.called;
         });
 
         it('should not overwrite an existing test file if the user says no', async () => {
             mySandBox.stub(fs, 'pathExists').resolves(true);
-            const showQuickPickYesNoStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showQuickPickYesNo').resolves(UserInputUtil.NO);
+            const showTestFileOverwriteQuickPickStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showTestFileOverwriteQuickPick').resolves(UserInputUtil.NO);
 
             await testSmartContract(instantiatedSmartContract);
-            showQuickPickYesNoStub.should.have.been.called;
+            showTestFileOverwriteQuickPickStub.should.have.been.called;
+            openTextDocumentStub.should.not.have.been.called;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should not overwrite an existing test file if the user cancels the overwrite quick pick box', async () => {
+            mySandBox.stub(fs, 'pathExists').resolves(true);
+            const showTestFileOverwriteQuickPickStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showTestFileOverwriteQuickPick').resolves(undefined);
+
+            await testSmartContract(instantiatedSmartContract);
+            showTestFileOverwriteQuickPickStub.should.have.been.called;
             openTextDocumentStub.should.not.have.been.called;
             errorSpy.should.not.have.been.called;
         });
 
         it('should overwrite an existing test file if the user says yes', async () => {
             mySandBox.stub(fs, 'pathExists').resolves(true);
-            const showQuickPickYesNoStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showQuickPickYesNo').resolves(UserInputUtil.YES);
+            const showTestFileOverwriteQuickPickStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showTestFileOverwriteQuickPick').resolves(UserInputUtil.YES);
 
             await testSmartContract(instantiatedSmartContract);
-            showQuickPickYesNoStub.should.have.been.called;
+            showTestFileOverwriteQuickPickStub.should.have.been.called;
             openTextDocumentStub.should.have.been.called;
+            showTextDocumentStub.should.have.been.called;
+            const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
+            templateData.should.not.equal('');
+            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(fakeMetadataFunctions[0]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[1]).should.be.true;
+            templateData.includes(fakeMetadataFunctions[2]).should.be.true;
+            errorSpy.should.not.have.been.called;
+        });
+
+        it('should generate a copy of the test file if the user tells it to', async () => {
+            const pathExistsStub: sinon.SinonStub = mySandBox.stub(fs, 'pathExists');
+            pathExistsStub.onCall(0).resolves(true);
+            pathExistsStub.onCall(1).resolves(true);
+            pathExistsStub.callThrough();
+            const showTestFileOverwriteQuickPickStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showTestFileOverwriteQuickPick').resolves(UserInputUtil.GENERATE_NEW_TEST_FILE);
+            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}-copy1.test.js`);
+
+            await testSmartContract(instantiatedSmartContract);
+            showTestFileOverwriteQuickPickStub.should.have.been.called;
+            openTextDocumentStub.should.have.been.calledWith(testFilePath);
             showTextDocumentStub.should.have.been.called;
             const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
             templateData.should.not.equal('');
@@ -320,22 +350,26 @@ describe('testSmartContractCommand', () => {
             reporterStub.should.have.been.calledWith('testSmartContractCommand');
         });
 
-        it('should handle errors when attempting to remove created test directory', async () => {
-            mySandBox.stub(ejs, 'renderFile').yields({message: 'some error'}, null);
+        it('should handle errors when attempting to remove created test file', async () => {
+            mySandBox.stub(fs, 'ensureFile').rejects();
             fsRemoveStub.rejects({message: 'some other error'});
 
             await testSmartContract(instantiatedSmartContract);
             mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
-            errorSpy.should.have.been.calledWith('Error removing test command directory: some other error');
+            errorSpy.should.have.been.calledWith('Error removing test file: some other error');
+            fsRemoveStub.should.have.been.called;
+            openTextDocumentStub.should.not.have.been.called;
         });
 
-        it('should not show error for removing non-existent test directory', async () => {
-            mySandBox.stub(ejs, 'renderFile').yields({message: 'some error'}, null);
+        it('should not show error for removing non-existent test file', async () => {
+            mockTextEditor.edit.resolves(false);
             fsRemoveStub.rejects({message: 'ENOENT: no such file or directory'});
+            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}.test.js`);
 
             await testSmartContract(instantiatedSmartContract);
             mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
-            errorSpy.should.have.been.calledWith('Error creating template data: some error');
+            errorSpy.should.have.been.calledOnceWith('Error editing test file: ' + testFilePath);
+            fsRemoveStub.should.have.been.called;
         });
 
     });
@@ -457,7 +491,6 @@ describe('testSmartContractCommand', () => {
             await testSmartContract(instantiatedSmartContract);
             getDirPathStub.should.have.been.calledOnce;
             errorSpy.should.have.been.calledWith('Error writing runtime connection profile: some error');
-            fsRemoveStub.should.have.been.called;
         });
 
     });

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -706,4 +706,43 @@ describe('userInputUtil', () => {
         });
     });
 
+    describe('showTestFileOverwriteQuickPick', () => {
+        it('should show yes in the showTestFileOverwriteQuickPick box', async () => {
+            quickPickStub.resolves(UserInputUtil.YES);
+            const result: string = await UserInputUtil.showTestFileOverwriteQuickPick('Would you like a twix?');
+            result.should.equal(UserInputUtil.YES);
+
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: false,
+                canPickMany: false,
+                placeHolder: 'Would you like a twix?'
+            });
+        });
+
+        it('should show no in the showTestFileOverwriteQuickPick box', async () => {
+            quickPickStub.resolves(UserInputUtil.NO);
+            const result: string = await UserInputUtil.showTestFileOverwriteQuickPick('Is it lunchtime yet?');
+            result.should.equal(UserInputUtil.NO);
+
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: false,
+                canPickMany: false,
+                placeHolder: 'Is it lunchtime yet?'
+            });
+        });
+
+        it('should show generate copy in the showTestFileOverwriteQuickPick box', async () => {
+            quickPickStub.resolves(UserInputUtil.GENERATE_NEW_TEST_FILE);
+            const result: string = await UserInputUtil.showTestFileOverwriteQuickPick('What should I do next?');
+            result.should.equal(UserInputUtil.GENERATE_NEW_TEST_FILE);
+
+            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: false,
+                canPickMany: false,
+                placeHolder: 'What should I do next?'
+            });
+        });
+
+    });
+
 });


### PR DESCRIPTION
Covers last bullet point in #262 
If the test file is detected to already exist, allow the user to either: overwrite it, do nothing, or generate a copy, with another name

Signed-off-by: heatherlp <heatherpollard0@gmail.com>