### PR TITLE
Moved test file to functionalTests directory in smart contract project 

### DIFF
--- a/client/test/commands/testSmartContractCommands.test.ts
+++ b/client/test/commands/testSmartContractCommands.test.ts
@@ -64,6 +64,7 @@ describe('testSmartContractCommand', () => {
     let fakeConnectionDetails: {connectionProfilePath: string, certificatePath: string, privateKeyPath: string};
     let fakeRuntimeConnectionDetails: {connectionProfile: object, certificatePath: string, privateKeyPath: string};
     let smartContractName: string;
+    let smartContractLabel: string;
     const rootPath: string = path.dirname(__dirname);
     let testFileDir: string;
     let mockDocumentStub: any;
@@ -71,6 +72,9 @@ describe('testSmartContractCommand', () => {
     let mockEditBuilder: any;
     let mockEditBuilderReplaceSpy: sinon.SinonSpy;
     let mockTextEditor: any;
+    let findFilesStub: sinon.SinonStub;
+    let readFileStub: sinon.SinonStub;
+    let workspaceFoldersStub: sinon.SinonStub;
 
     before(async () => {
         await TestUtil.setupTests();
@@ -134,7 +138,8 @@ describe('testSmartContractCommand', () => {
             channel = allChildren[0] as ChannelTreeItem;
             chaincodes = channel.chaincodes;
             instantiatedSmartContract = chaincodes[0] as ChainCodeTreeItem;
-            smartContractName = instantiatedSmartContract.label;
+            smartContractLabel = instantiatedSmartContract.label;
+            smartContractName = instantiatedSmartContract.name;
             // Document editor stubs
             testFileDir = path.join(rootPath, '..', 'data', 'smartContractTests');
             mockDocumentStub = {
@@ -158,6 +163,11 @@ describe('testSmartContractCommand', () => {
             openTextDocumentStub = mySandBox.stub(vscode.workspace, 'openTextDocument').resolves(mockDocumentStub);
             showTextDocumentStub = mySandBox.stub(vscode.window, 'showTextDocument').resolves(mockTextEditor);
             getDirPathStub = mySandBox.stub(UserInputUtil, 'getDirPath').resolves(testFileDir);
+            const packageJSONPath: string = path.join(testFileDir, 'package.json');
+            findFilesStub = mySandBox.stub(vscode.workspace, 'findFiles').resolves([vscode.Uri.file(packageJSONPath)]);
+            const smartContractNameBuffer: Buffer = Buffer.from(`{"name": "${smartContractName}"}`);
+            readFileStub = mySandBox.stub(fs, 'readFile').resolves(smartContractNameBuffer);
+            workspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').resolves([{name: 'wagonwheeling'}]);
 
         });
 
@@ -170,7 +180,7 @@ describe('testSmartContractCommand', () => {
             showTextDocumentStub.should.have.been.called;
             const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
             templateData.should.not.equal('');
-            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(smartContractLabel).should.be.true;
             templateData.includes(fakeMetadataFunctions[0]).should.be.true;
             templateData.includes(fakeMetadataFunctions[1]).should.be.true;
             templateData.includes(fakeMetadataFunctions[2]).should.be.true;
@@ -240,6 +250,29 @@ describe('testSmartContractCommand', () => {
             errorSpy.should.not.have.been.called;
         });
 
+        it('should show an error message if the user has no workspaces open', async () => {
+            workspaceFoldersStub.resolves([]);
+
+            await testSmartContract(instantiatedSmartContract);
+            errorSpy.should.have.been.calledWith(`Smart contract project ${smartContractName} is not open in workspace`);
+        });
+
+        it('should show an error message if it fails to determine the workspace folders', async () => {
+            workspaceFoldersStub.rejects({message: 'piecarambra!'});
+
+            await testSmartContract(instantiatedSmartContract);
+            findFilesStub.should.not.have.been.called;
+            errorSpy.should.have.been.calledWith('Error determining workspace folders: piecarambra!');
+        });
+
+        it('should show an error message if the smart contract project isnt open in the workspace', async () => {
+            const incorrectBuffer: Buffer = Buffer.from(`{"name": "double_decker"}`);
+            readFileStub.resolves(incorrectBuffer);
+
+            await testSmartContract(instantiatedSmartContract);
+            errorSpy.should.have.been.calledWith(`Smart contract project ${smartContractName} is not open in workspace`);
+        });
+
         it('should handle errors with running getMetaData by showing an error message to the user', async () => {
             fabricClientConnectionMock.getMetadata.rejects({message: 'some error'});
 
@@ -264,7 +297,7 @@ describe('testSmartContractCommand', () => {
 
             await testSmartContract(instantiatedSmartContract);
             showTestFileOverwriteQuickPickStub.should.have.been.called;
-            openTextDocumentStub.should.not.have.been.called;
+            mySandBox.stub(fs, 'ensureFile').should.not.have.been.called;
             errorSpy.should.not.have.been.called;
         });
 
@@ -274,7 +307,7 @@ describe('testSmartContractCommand', () => {
 
             await testSmartContract(instantiatedSmartContract);
             showTestFileOverwriteQuickPickStub.should.have.been.called;
-            openTextDocumentStub.should.not.have.been.called;
+            mySandBox.stub(fs, 'ensureFile').should.not.have.been.called;
             errorSpy.should.not.have.been.called;
         });
 
@@ -288,7 +321,7 @@ describe('testSmartContractCommand', () => {
             showTextDocumentStub.should.have.been.called;
             const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
             templateData.should.not.equal('');
-            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(smartContractLabel).should.be.true;
             templateData.includes(fakeMetadataFunctions[0]).should.be.true;
             templateData.includes(fakeMetadataFunctions[1]).should.be.true;
             templateData.includes(fakeMetadataFunctions[2]).should.be.true;
@@ -304,11 +337,12 @@ describe('testSmartContractCommand', () => {
             pathExistsStub.onCall(1).resolves(true);
             pathExistsStub.callThrough();
             const showTestFileOverwriteQuickPickStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showTestFileOverwriteQuickPick').resolves(UserInputUtil.GENERATE_NEW_TEST_FILE);
-            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}-copy1.test.js`);
+            const testFilePath: string = path.join(testFileDir, 'functionalTests', `${smartContractLabel}-copy1.test.js`);
+            const testUri: vscode.Uri = vscode.Uri.file(testFilePath);
 
             await testSmartContract(instantiatedSmartContract);
             showTestFileOverwriteQuickPickStub.should.have.been.called;
-            openTextDocumentStub.should.have.been.calledWith(testFilePath);
+            openTextDocumentStub.should.have.been.calledWith(testUri.fsPath);
             showTextDocumentStub.should.have.been.called;
             const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
             templateData.should.not.equal('');
@@ -332,14 +366,15 @@ describe('testSmartContractCommand', () => {
         it('should handle errors writing data to the file', async () => {
             mySandBox.stub(fs, 'pathExists').resolves(false);
             mySandBox.stub(fs, 'ensureFile').resolves();
-            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}.test.js`);
+            const testFilePath: string = path.join(testFileDir, 'functionalTests', `${smartContractLabel}.test.js`);
+            const testUri: vscode.Uri = vscode.Uri.file(testFilePath);
             mockTextEditor.edit.resolves(false);
 
             await testSmartContract(instantiatedSmartContract);
             openTextDocumentStub.should.have.been.called;
             showTextDocumentStub.should.have.been.called;
             mockDocumentSaveSpy.should.not.have.been.called;
-            errorSpy.should.have.been.calledWith('Error editing test file: ' + testFilePath);
+            errorSpy.should.have.been.calledWith('Error editing test file: ' + testUri.fsPath);
             fsRemoveStub.should.have.been.called;
         });
 
@@ -370,11 +405,12 @@ describe('testSmartContractCommand', () => {
         it('should not show error for removing non-existent test file', async () => {
             mockTextEditor.edit.resolves(false);
             fsRemoveStub.rejects({message: 'ENOENT: no such file or directory'});
-            const testFilePath: string = path.join(testFileDir, 'test', smartContractName, `${smartContractName}.test.js`);
+            const testFilePath: string = path.join(testFileDir, 'functionalTests', `${smartContractLabel}.test.js`);
+            const testUri: vscode.Uri = vscode.Uri.file(testFilePath);
 
             await testSmartContract(instantiatedSmartContract);
             mySandBox.stub(fs, 'pathExists').should.not.have.been.called;
-            errorSpy.should.have.been.calledOnceWith('Error editing test file: ' + testFilePath);
+            errorSpy.should.have.been.calledOnceWith('Error editing test file: ' + testUri.fsPath);
             fsRemoveStub.should.have.been.called;
         });
 
@@ -436,7 +472,8 @@ describe('testSmartContractCommand', () => {
             channel = allChildren[0] as ChannelTreeItem;
             chaincodes = channel.chaincodes;
             instantiatedSmartContract = chaincodes[0] as ChainCodeTreeItem;
-            smartContractName = instantiatedSmartContract.label;
+            smartContractLabel = instantiatedSmartContract.label;
+            smartContractName = instantiatedSmartContract.name;
             // Document editor stubs
             testFileDir = path.join(rootPath, '..', 'data', 'smartContractTests');
             mockDocumentStub = {
@@ -459,22 +496,23 @@ describe('testSmartContractCommand', () => {
             mockTextEditor.edit.resolves(true);
             openTextDocumentStub = mySandBox.stub(vscode.workspace, 'openTextDocument').resolves(mockDocumentStub);
             showTextDocumentStub = mySandBox.stub(vscode.window, 'showTextDocument').resolves(mockTextEditor);
-            getDirPathStub = mySandBox.stub(UserInputUtil, 'getDirPath');
+            getDirPathStub = mySandBox.stub(UserInputUtil, 'getDirPath').resolves(testFileDir);
             ensureFileStub = mySandBox.stub(fs, 'ensureFile');
             writeFileSyncStub = mySandBox.stub(fs, 'writeFileSync');
+            const packageJSONPath: string = path.join(testFileDir, 'package.json');
+            findFilesStub = mySandBox.stub(vscode.workspace, 'findFiles').resolves([vscode.Uri.file(packageJSONPath)]);
+            const smartContractNameBuffer: Buffer = Buffer.from(`{"name": "${smartContractName}"}`);
+            readFileStub = mySandBox.stub(fs, 'readFile').resolves(smartContractNameBuffer);
+            workspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').resolves([{name: 'wagonwheeling'}]);
 
         });
 
         it('should generate a copy of the connection profile if the connection is a runtime', async () => {
-            const testConnectonProfilePath: string = path.join(testFileDir, 'test', smartContractName, 'connection.json');
+            const testConnectonProfilePath: string = path.join(testFileDir, 'test', smartContractLabel, 'connection.json');
             const connectionProfileToString: string = JSON.stringify(fakeRuntimeConnectionDetails.connectionProfile, null, 4);
-            getDirPathStub.onFirstCall().resolves(testFileDir);
-            ensureFileStub.onFirstCall().resolves();
-            writeFileSyncStub.onFirstCall().resolves();
-            const testFilePath: string = path.join(testFileDir, smartContractName, `${smartContractName}.test.js`);
-            getDirPathStub.onSecondCall().resolves(testFilePath);
+            ensureFileStub.resolves();
+            writeFileSyncStub.resolves();
             mySandBox.stub(fs, 'pathExists').resolves(false);
-            ensureFileStub.onSecondCall().resolves();
 
             await testSmartContract(instantiatedSmartContract);
             writeFileSyncStub.should.have.been.calledWith(testConnectonProfilePath, connectionProfileToString);
@@ -482,7 +520,7 @@ describe('testSmartContractCommand', () => {
             showTextDocumentStub.should.have.been.called;
             const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
             templateData.should.not.equal('');
-            templateData.includes(smartContractName).should.be.true;
+            templateData.includes(smartContractLabel).should.be.true;
             templateData.includes(fakeMetadataFunctions[0]).should.be.true;
             templateData.includes(fakeMetadataFunctions[1]).should.be.true;
             templateData.includes(fakeMetadataFunctions[2]).should.be.true;
@@ -493,12 +531,10 @@ describe('testSmartContractCommand', () => {
         });
 
         it('should handle errors with copying the connection profile if the connection is a runtime', async () => {
-            getDirPathStub.onFirstCall().resolves(testFileDir);
-            ensureFileStub.onFirstCall().resolves();
-            writeFileSyncStub.onFirstCall().rejects({message: 'some error'});
+            ensureFileStub.resolves();
+            writeFileSyncStub.rejects({message: 'some error'});
 
             await testSmartContract(instantiatedSmartContract);
-            getDirPathStub.should.have.been.calledOnce;
             errorSpy.should.have.been.calledWith('Error writing runtime connection profile: some error');
         });
 


### PR DESCRIPTION
- Requires the user to have the smart contract project open in their workspace, errors if they don't
- Covers some of the points in #262 
- Also cleaned up parts of the runtime connection tests

Signed-off-by: heatherlp <heatherpollard0@gmail.com>