### PR TITLE
Package fix for release

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -486,6 +486,7 @@
     },
     "dependencies": {
         "@fidm/x509": "1.1.3",
+        "ajv": "^5.5.2",
         "child-process-promise": "^2.2.1",
         "dateformat": "^3.0.3",
         "dockerode": "^2.5.5",


### PR DESCRIPTION
This is needed to fix the error we're hitting: `npm ERR! peer dep missing: ajv@^5.0.0, required by ajv-keywords@2.1.1`
Signed-off-by: Jake Turner <jaketurner25@live.com>