### PR TITLE
Add JavaScript Test Runner as ext dependency

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -537,6 +537,9 @@
             }
         }
     },
+    "extensionPack": [
+        "legfrey.javascript-test-runner"
+    ],
     "license-check-and-add-config": {
         "folder": ".",
         "license": "LICENSE.txt",


### PR DESCRIPTION
For running the smart contract generated tests, contributes towards #62 

Had to use extensionPacks instead of dependencies (see here https://code.visualstudio.com/updates/v1_26#_extension-packs-revisited) so that travis woud know to install it


Signed-off-by: heatherlp <heatherpollard0@gmail.com>