### PR TITLE
Add test runner settings to run typescript tests

### DIFF
--- a/client/src/commands/testSmartContractCommand.ts
+++ b/client/src/commands/testSmartContractCommand.ts
@@ -229,6 +229,15 @@ export async function testSmartContract(chaincode?: InstantiatedChaincodeChildTr
         return;
     }
 
+    // If TypeScript, update JavaScript Test Runner user settings
+    if (testLanguage === 'TypeScript') {
+        const runnerArgs: string = vscode.workspace.getConfiguration().get('javascript-test-runner.additionalArgs') as string;
+        if (!runnerArgs || !runnerArgs.includes('-r ts-node/register')) {
+            // If the user has removed JavaScript Test Runner since generating tests, this update will silently fail
+            await vscode.workspace.getConfiguration().update('javascript-test-runner.additionalArgs', '-r ts-node/register', vscode.ConfigurationTarget.Global);
+        }
+    }
+
     Reporter.instance().sendTelemetryEvent('testSmartContractCommand');
 
 }

--- a/client/templates/jsTestSmartContractTemplate.ejs
+++ b/client/templates/jsTestSmartContractTemplate.ejs
@@ -1,7 +1,8 @@
 /*
 * Use this file for functional testing of your smart contract. 
-* Fill out the arguments and return values for a function and 
-* use a test runner to run these tests locally. 
+* Fill out the arguments and return values for a function and
+* use the CodeLens links above the transaction blocks to
+* invoke/submit transactions.
 * All transactions defined in your smart contract are used here 
 * to generate tests, including those functions that would 
 * normally only be used on instantiate and upgrade operations.
@@ -13,7 +14,7 @@
 /*
 * Generating this test file will also trigger an npm install 
 * in the smart contract project directory. This installs any
-* package dependencies, including fabric-network which is 
+* package dependencies, including fabric-network, which are 
 * required for this test file to be run locally. 
 */
 

--- a/client/templates/tsTestSmartContractTemplate.ejs
+++ b/client/templates/tsTestSmartContractTemplate.ejs
@@ -1,7 +1,8 @@
 /*
 * Use this file for functional testing of your smart contract.
 * Fill out the arguments and return values for a function and
-* use a test runner to run these tests locally.
+* use the CodeLens links above the transaction blocks to
+* invoke/submit transactions.
 * All transactions defined in your smart contract are used here
 * to generate tests, including those functions that would
 * normally only be used on instantiate and upgrade operations.
@@ -13,19 +14,19 @@
 /*
 * Generating this test file will also trigger an npm install
 * in the smart contract project directory. This installs any
-* package dependencies, including fabric-network which is
+* package dependencies, including fabric-network, which are
 * required for this test file to be run locally.
 */
 
 import * as assert from 'assert';
+import * as Client from 'fabric-client';
 import * as fabricNetwork from 'fabric-network';
 import * as fs from 'fs-extra';
-import * as Client from 'fabric-client';
 
 describe('<%=chaincodeLabel%>' , () => {
 
     const gateway: fabricNetwork.Gateway = new fabricNetwork.Gateway();
-    const wallet: fabricNetwork.InMemoryWallet = new fabricNetwork.InMemoryWallet();
+    const fabricWallet: fabricNetwork.InMemoryWallet = new fabricNetwork.InMemoryWallet();
     const identityName: string = '<%=chaincodeLabel%>';
     let client: Client;
 
@@ -40,17 +41,18 @@ describe('<%=chaincodeLabel%>' , () => {
         client = await Client.loadFromConfig(connectionProfilePath);
         const mspid: string = client.getMspid();
 
-        await wallet.import(identityName, fabricNetwork.X509WalletMixin.createIdentity(mspid, certificate, privateKey));
+        await fabricWallet.import(
+            identityName, fabricNetwork.X509WalletMixin.createIdentity(mspid, certificate, privateKey));
 
     });
 
     beforeEach(async () => {
         const connectOptions: fabricNetwork.InitOptions = {
-            wallet: wallet,
             identity: identityName,
+            wallet: fabricWallet,
         };
         connectOptions['discovery'] = {
-            asLocalhost: true
+            asLocalhost: true,
         };
         await gateway.connect(client, connectOptions);
     });
@@ -58,18 +60,17 @@ describe('<%=chaincodeLabel%>' , () => {
     afterEach(async () => {
         gateway.disconnect();
     });
-
-    <% functionNames.forEach((functionName) => { %>
+<%functionNames.forEach((functionName) => {%>
     it('<%=functionName%>', async () => {
         // TODO: Update with parameters of transaction
         const args: string = '';
-        const response: Buffer = await submitTransaction('<%=functionName%>', args); // Returns buffer of transcation return value
+        const response: Buffer = await submitTransaction('<%=functionName%>', args);
+        // submitTransaction returns buffer of transcation return value
         // TODO: Update with return value of transaction
         assert.equal(true, true);
         // assert.equal(response.toString(), undefined);
     }).timeout(10000);
-    <% }) %>
-
+<%})%>
     async function submitTransaction(functionName: string, args: string): Promise<Buffer> {
         // Send transaction
 


### PR DESCRIPTION
- Closes #62 
- Also found some linting failures when the typescript tests are generated, so fixing those and a comment. Wasn't able to fix "[tslint] object access via string literals is disallowed" for line 54 of tsTestSmartContractTemplate.ejs though :/
(Note: the vscode api controls how travis runs vscode/extension tests, so we can't force it to install another extension. I've raised this for that: https://github.com/Microsoft/vscode/issues/63631)

Signed-off-by: heatherlp <heatherpollard0@gmail.com>