### PR TITLE
Specify explicit container names instead of defaults (resolves #347)

### DIFF
--- a/client/basic-network/docker-compose.yml
+++ b/client/basic-network/docker-compose.yml
@@ -30,11 +30,13 @@ services:
       - ./crypto-config/peerOrganizations/org1.example.com/ca/:/etc/hyperledger/fabric-ca-server-config
       - ca.example.com:/etc/hyperledger/fabric-ca-server
     # VSCODE container_name: ca.example.com
+    container_name: ${COMPOSE_PROJECT_NAME}_ca.example.com
     networks:
       - basic
 
   orderer.example.com:
     # VSCODE container_name: orderer.example.com
+    container_name: ${COMPOSE_PROJECT_NAME}_orderer.example.com
     image: hyperledger/fabric-orderer:1.3.0
     environment:
       - ORDERER_GENERAL_LOGLEVEL=info
@@ -58,6 +60,7 @@ services:
 
   peer0.org1.example.com:
     # VSCODE container_name: peer0.org1.example.com
+    container_name: ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com
     image: hyperledger/fabric-peer:1.3.0
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
@@ -102,6 +105,7 @@ services:
 
   couchdb:
     # VSCODE container_name: couchdb
+    container_name: ${COMPOSE_PROJECT_NAME}_couchdb
     image: hyperledger/fabric-couchdb:0.4.13
     # Populate the COUCHDB_USER and COUCHDB_PASSWORD to set an admin user and password
     # for CouchDB.  This will prevent CouchDB from operating in an "Admin Party" mode.

--- a/client/basic-network/start.cmd
+++ b/client/basic-network/start.cmd
@@ -17,7 +17,7 @@ rem incase of errors when running later commands, issue export FABRIC_START_TIME
 set FABRIC_START_TIMEOUT=30
 for /L %%i in (1, 1, %FABRIC_START_TIMEOUT%) do (
     rem This command only works if the peer is up and running
-    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel list > NUL 2>&1
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com peer channel list > NUL 2>&1
     if errorlevel 1 (
         rem This is the closest thing that Windows has to the sleep command
         choice /t 1 /c x /d x /n > NUL
@@ -29,7 +29,11 @@ for /L %%i in (1, 1, %FABRIC_START_TIMEOUT%) do (
 :done
 echo Hyperledger Fabric started in %i% seconds
 
-rem Create the channel
-docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
-rem Join peer0.org1.example.com to the channel.
-docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com_1 peer channel join -b mychannel.block
+rem Check to see if the channel already exists
+docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com peer channel getinfo -c mychannel
+if errorlevel 1 (
+    rem Create the channel
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
+    rem Join peer0.org1.example.com to the channel.
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" %COMPOSE_PROJECT_NAME%_peer0.org1.example.com peer channel join -b mychannel.block
+)

--- a/client/basic-network/start.sh
+++ b/client/basic-network/start.sh
@@ -18,7 +18,7 @@ export FABRIC_START_TIMEOUT=30
 for i in $(seq 1 ${FABRIC_START_TIMEOUT})
 do
     # This command only works if the peer is up and running
-    if docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel list > /dev/null 2>&1
+    if docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com peer channel list > /dev/null 2>&1
     then
         # Peer now available
         break
@@ -30,10 +30,10 @@ done
 echo Hyperledger Fabric started in $i seconds
 
 # Check to see if the channel already exists
-if ! docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel getinfo -c mychannel
+if ! docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com peer channel getinfo -c mychannel
 then
     # Create the channel
-    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com peer channel create -o orderer.example.com:7050 -c mychannel -f /etc/hyperledger/configtx/channel.tx
     # Join peer0.org1.example.com to the channel.
-    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com_1 peer channel join -b mychannel.block
+    docker exec -e "CORE_PEER_LOCALMSPID=Org1MSP" -e "CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp" ${COMPOSE_PROJECT_NAME}_peer0.org1.example.com peer channel join -b mychannel.block
 fi

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -94,15 +94,15 @@ export class FabricRuntime extends EventEmitter {
     public async getConnectionProfile(): Promise<object> {
         const containerPrefix: string = this.docker.getContainerPrefix();
         const connectionProfile: any = basicNetworkConnectionProfile;
-        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_peer0.org1.example.com_1`);
+        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_peer0.org1.example.com`);
         const peerRequestHost: string = Docker.fixHost(peerPorts['7051/tcp'][0].HostIp);
         const peerRequestPort: string = peerPorts['7051/tcp'][0].HostPort;
         const peerEventHost: string = Docker.fixHost(peerPorts['7053/tcp'][0].HostIp);
         const peerEventPort: string = peerPorts['7053/tcp'][0].HostPort;
-        const ordererPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_orderer.example.com_1`);
+        const ordererPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_orderer.example.com`);
         const ordererHost: string = Docker.fixHost(ordererPorts['7050/tcp'][0].HostIp);
         const ordererPort: string = ordererPorts['7050/tcp'][0].HostPort;
-        const caPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_ca.example.com_1`);
+        const caPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_ca.example.com`);
         const caHost: string = Docker.fixHost(caPorts['7054/tcp'][0].HostIp);
         const caPort: string = caPorts['7054/tcp'][0].HostPort;
         connectionProfile.peers['peer0.org1.example.com'].url = `grpc://${peerRequestHost}:${peerRequestPort}`;
@@ -142,10 +142,10 @@ export class FabricRuntime extends EventEmitter {
     public async isRunning(): Promise<boolean> {
         const containerPrefix: string = this.docker.getContainerPrefix();
         const running: boolean[] = await Promise.all([
-            this.docker.isContainerRunning(`${containerPrefix}_peer0.org1.example.com_1`),
-            this.docker.isContainerRunning(`${containerPrefix}_orderer.example.com_1`),
-            this.docker.isContainerRunning(`${containerPrefix}_ca.example.com_1`),
-            this.docker.isContainerRunning(`${containerPrefix}_couchdb_1`)
+            this.docker.isContainerRunning(`${containerPrefix}_peer0.org1.example.com`),
+            this.docker.isContainerRunning(`${containerPrefix}_orderer.example.com`),
+            this.docker.isContainerRunning(`${containerPrefix}_ca.example.com`),
+            this.docker.isContainerRunning(`${containerPrefix}_couchdb`)
         ]);
         return !running.some((value: boolean) => value === false);
     }
@@ -161,7 +161,7 @@ export class FabricRuntime extends EventEmitter {
 
     public async getChaincodeAddress(): Promise<string> {
         const prefix: string = this.docker.getContainerPrefix();
-        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${prefix}_peer0.org1.example.com_1`);
+        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${prefix}_peer0.org1.example.com`);
         const peerRequestHost: string = Docker.fixHost(peerPorts['7052/tcp'][0].HostIp);
         const peerRequestPort: string = peerPorts['7052/tcp'][0].HostPort;
         return `${peerRequestHost}:${peerRequestPort}`;
@@ -169,7 +169,7 @@ export class FabricRuntime extends EventEmitter {
 
     public getPeerContainerName(): string {
         const prefix: string = this.docker.getContainerPrefix();
-        return `${prefix}_peer0.org1.example.com_1`;
+        return `${prefix}_peer0.org1.example.com`;
     }
 
     private setBusy(busy: boolean): void {

--- a/client/test/commands/openFabricRuntimeTerminal.test.ts
+++ b/client/test/commands/openFabricRuntimeTerminal.test.ts
@@ -88,7 +88,7 @@ describe('openFabricRuntimeTerminal', () => {
                 '-e',
                 'CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp',
                 '-ti',
-                'fabricvscodelocalfabric_peer0.org1.example.com_1',
+                'fabricvscodelocalfabric_peer0.org1.example.com',
                 'bash'
             ]
         );
@@ -109,7 +109,7 @@ describe('openFabricRuntimeTerminal', () => {
                 '-e',
                 'CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/users/Admin@org1.example.com/msp',
                 '-ti',
-                'fabricvscodelocalfabric_peer0.org1.example.com_1',
+                'fabricvscodelocalfabric_peer0.org1.example.com',
                 'bash'
             ]
         );

--- a/client/test/docker/Docker.test.ts
+++ b/client/test/docker/Docker.test.ts
@@ -53,7 +53,7 @@ describe('Docker', () => {
         mockPeerVolume = sinon.createStubInstance(VolumeImpl);
 
         const dockerodeStub: sinon.SinonStubbedInstance<Dockerode> = sandbox.createStubInstance(Dockerode);
-        dockerodeStub.getContainer.withArgs('fabricvscoderuntime1_peer0.org1.example.com_1').returns(mockPeerContainer);
+        dockerodeStub.getContainer.withArgs('fabricvscoderuntime1_peer0.org1.example.com').returns(mockPeerContainer);
         dockerodeStub.getVolume.withArgs('fabricvscoderuntime1_peer0.org1.example.com').returns(mockPeerVolume);
 
         docker = new Docker('runtime1');
@@ -89,7 +89,7 @@ describe('Docker', () => {
     describe('#getContainerPorts', () => {
         it('should get the ports for a container', async () => {
             const prefix: string = docker.getContainerPrefix();
-            const ports: ContainerPorts = await docker.getContainerPorts(`${prefix}_peer0.org1.example.com_1`);
+            const ports: ContainerPorts = await docker.getContainerPorts(`${prefix}_peer0.org1.example.com`);
             ports.should.deep.equal(mockPeerInspect.NetworkSettings.Ports);
         });
     });
@@ -115,21 +115,21 @@ describe('Docker', () => {
         it('should return true if container is running', async () => {
             const prefix: string = docker.getContainerPrefix();
 
-            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com_1`).should.eventually.be.true;
+            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com`).should.eventually.be.true;
         });
 
         it('should return false if the container does not exist', async () => {
             const prefix: string = docker.getContainerPrefix();
 
             mockPeerContainer.inspect.rejects(new Error('blah'));
-            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com_1`).should.eventually.be.false;
+            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com`).should.eventually.be.false;
         });
 
         it('should return false if the container is not running', async () => {
             const prefix: string = docker.getContainerPrefix();
 
             mockPeerInspect.State.Running = false;
-            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com_1`).should.eventually.be.false;
+            await docker.isContainerRunning(`${prefix}_peer0.org1.example.com`).should.eventually.be.false;
         });
     });
 });

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -163,10 +163,10 @@ describe('FabricRuntime', () => {
         };
         mockCouchContainer.inspect.resolves(mockCouchInspect);
         const getContainerStub: sinon.SinonStub = sandbox.stub(docker, 'getContainer');
-        getContainerStub.withArgs('fabricvscoderuntime1_peer0.org1.example.com_1').returns(mockPeerContainer);
-        getContainerStub.withArgs('fabricvscoderuntime1_orderer.example.com_1').returns(mockOrdererContainer);
-        getContainerStub.withArgs('fabricvscoderuntime1_ca.example.com_1').returns(mockCAContainer);
-        getContainerStub.withArgs('fabricvscoderuntime1_couchdb_1').returns(mockCouchContainer);
+        getContainerStub.withArgs('fabricvscoderuntime1_peer0.org1.example.com').returns(mockPeerContainer);
+        getContainerStub.withArgs('fabricvscoderuntime1_orderer.example.com').returns(mockOrdererContainer);
+        getContainerStub.withArgs('fabricvscoderuntime1_ca.example.com').returns(mockCAContainer);
+        getContainerStub.withArgs('fabricvscoderuntime1_couchdb').returns(mockCouchContainer);
         mockPeerVolume = sinon.createStubInstance(VolumeImpl);
         mockOrdererVolume = sinon.createStubInstance(VolumeImpl);
         mockCAVolume = sinon.createStubInstance(VolumeImpl);
@@ -707,7 +707,7 @@ describe('FabricRuntime', () => {
     describe('#getPeerContainerName', () => {
         it('should get the chaincode address', () => {
             const result: string = runtime.getPeerContainerName();
-            result.should.equal('fabricvscoderuntime1_peer0.org1.example.com_1');
+            result.should.equal('fabricvscoderuntime1_peer0.org1.example.com');
         });
     });
 


### PR DESCRIPTION
By specifying explicit container names in `docker-compose.yml`, we lose the `_1_<random_hash>` suffix, and don't need to hunt for the containers by some other means. Also, the `start.cmd` script is missing some changes from the `start.sh` script, so I've added those in.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>