### PR TITLE
Make use of new metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ You will need the following installed in order to use the extension:
 - [Docker version v17.06.2-ce or greater](https://www.docker.com/get-docker)
 - [Docker Compose v1.14.0 or greater](https://docs.docker.com/compose/install/)
 
+> ⚠ Please note: From version 0.1.0+, your smart contract package.json should depend on at least 1.4.0-beta2@fabric-contract. This is only required for smart contracts not created using version 0.1.0+ of this extension.
+
 If you are using Windows, you must also ensure the following:
 - Your version of Windows supports Hyper-V and Docker:
   - Windows 10 Enterprise, Pro, or Education with 1607 Anniversary Update or later

--- a/client/README.md
+++ b/client/README.md
@@ -18,6 +18,8 @@ You will need the following installed in order to use the extension:
 - [Docker version v17.06.2-ce or greater](https://www.docker.com/get-docker)
 - [Docker Compose v1.14.0 or greater](https://docs.docker.com/compose/install/)
 
+> ⚠ Please note: From version 0.1.0+, your smart contract package.json should depend on at least 1.4.0-beta2@fabric-contract. This is only required for smart contracts not created using version 0.1.0+ of this extension.
+
 If you are using Windows, you must also ensure the following:
 - Your version of Windows supports Hyper-V and Docker:
   - Windows 10 Enterprise, Pro, or Education with 1607 Anniversary Update or later

--- a/client/integrationTest/integration.test.ts
+++ b/client/integrationTest/integration.test.ts
@@ -41,6 +41,7 @@ import { CommandUtil } from '../src/util/CommandUtil';
 import { FabricConnectionManager } from '../src/fabric/FabricConnectionManager';
 import { IFabricConnection } from '../src/fabric/IFabricConnection';
 import { InstantiatedChaincodeTreeItem } from '../src/explorer/model/InstantiatedChaincodeTreeItem';
+import { MetadataUtil } from '../src/util/MetadataUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -283,13 +284,16 @@ describe('Integration Test', () => {
         await vscode.commands.executeCommand('blockchainExplorer.upgradeSmartContractEntry');
     }
 
-    async function submitTransaction(name: string, version: string, transaction: string, args: string): Promise<void> {
+    async function submitTransaction(name: string, version: string, transaction: string, args: string, contractName: string): Promise<void> {
         showInstantiatedSmartContractsStub.resolves({
             label: `${name}@${version}`,
             data: { name: name, channel: 'mychannel', version: version }
         });
 
-        showTransactionStub.resolves(transaction);
+        showTransactionStub.resolves({
+            label: `${contractName} - ${transaction}`,
+            data: { name: transaction, contract: contractName}
+        });
 
         inputBoxStub.withArgs('optional: What are the arguments to the function, (comma seperated)').resolves(args);
 
@@ -698,20 +702,24 @@ describe('Integration Test', () => {
                 openFileNameArray.includes(pathToTestFile).should.be.true;
                 // Get the smart contract metadata
                 const connection: IFabricConnection = FabricConnectionManager.instance().getConnection();
-                const metadataObj: any = await connection.getMetadata(smartContractName, 'mychannel');
-                // tslint:disable-next-line
-                const smartContractFunctionsArray: string[] = metadataObj[""].functions;
+                const smartContractTransactionsMap: Map<string, string[]> = await MetadataUtil.getTransactionNames(connection, smartContractName, 'mychannel');
+                let smartContractTransactionsArray: string[];
+                let contractName: string = '';
+                for (const name of smartContractTransactionsMap.keys()) {
+                    smartContractTransactionsArray = smartContractTransactionsMap.get(name);
+                    contractName = name;
+                }
 
                 // Check the test file was populated properly
                 testFileContents.includes(smartContractName).should.be.true;
                 testFileContents.startsWith('/*').should.be.true;
                 testFileContents.includes('gateway.connect').should.be.true;
                 testFileContents.includes('submitTransaction').should.be.true;
-                testFileContents.includes(smartContractFunctionsArray[0]).should.be.true;
-                testFileContents.includes(smartContractFunctionsArray[1]).should.be.true;
-                testFileContents.includes(smartContractFunctionsArray[2]).should.be.true;
+                testFileContents.includes(smartContractTransactionsArray[0]).should.be.true;
+                testFileContents.includes(smartContractTransactionsArray[1]).should.be.true;
+                testFileContents.includes(smartContractTransactionsArray[2]).should.be.true;
 
-                await submitTransaction(smartContractName, '0.0.1', 'transaction1', 'hello world');
+                await submitTransaction(smartContractName, '0.0.1', 'transaction1', 'hello world', contractName);
 
                 testRunResult.includes('success for transaction').should.be.true;
                 testRunResult.includes('1 passing').should.be.true;

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     ],
     "homepage": "https://www.ibm.com/blockchain",
     "license": "Apache-2.0",
-    "version": "0.0.8",
+    "version": "0.1.0",
     "publisher": "IBMBlockchain",
     "icon": "resources/blockchain_marketplace.png",
     "galleryBanner": {
@@ -32,7 +32,7 @@
         "Debuggers",
         "Other"
     ],
-    "generatorFabricVersion": "0.0.11",
+    "generatorFabricVersion": "0.0.12",
     "activationEvents": [
         "*"
     ],

--- a/client/src/explorer/model/ContractTreeItem.ts
+++ b/client/src/explorer/model/ContractTreeItem.ts
@@ -15,11 +15,12 @@
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
 import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
+import { InstantiatedChaincodeTreeItem } from './InstantiatedChaincodeTreeItem';
 
-export class TransactionTreeItem extends BlockchainTreeItem {
-    contextValue: string = 'blockchain-transaction-item';
+export class ContractTreeItem extends BlockchainTreeItem {
+    contextValue: string = 'blockchain-contract-item';
 
-    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly chaincodeName: string, public readonly channelName: string, public readonly contractName: string) {
-        super(provider, name, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly instantiatedChaincode: InstantiatedChaincodeTreeItem, public readonly transactions: Array<string>) {
+        super(provider, name, collapsibleState);
     }
 }

--- a/client/src/explorer/model/InstantiatedChaincodeTreeItem.ts
+++ b/client/src/explorer/model/InstantiatedChaincodeTreeItem.ts
@@ -20,7 +20,7 @@ import { ChannelTreeItem } from './ChannelTreeItem';
 export class InstantiatedChaincodeTreeItem extends BlockchainTreeItem {
     contextValue: string = 'blockchain-instantiated-chaincode-item';
 
-    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly channel: ChannelTreeItem, public readonly version: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly transactions: Array<string>) {
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly channel: ChannelTreeItem, public readonly version: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly contracts: string[]) {
         super(provider, `${name}@${version}`, collapsibleState);
     }
 }

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -18,7 +18,6 @@ import { Gateway, InMemoryWallet, X509WalletMixin, Network, Contract, GatewayOpt
 import { IFabricConnection } from './IFabricConnection';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import * as fs from 'fs-extra';
-
 import * as uuid from 'uuid/v4';
 import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
 
@@ -207,11 +206,14 @@ export abstract class FabricConnection implements IFabricConnection {
         const network: Network = await this.gateway.getNetwork(channel);
         const smartContract: Contract = network.getContract(instantiatedChaincodeName);
 
-        const metadataBuffer: Buffer = await smartContract.evaluateTransaction('org.hyperledger.fabric:getMetaData');
+        const metadataBuffer: Buffer = await smartContract.evaluateTransaction('org.hyperledger.fabric:GetMetadata');
         const metadataString: string = metadataBuffer.toString();
         let metadataObject: any = {
-            '': {
-                functions: []
+            contracts: {
+                '' : {
+                    name: '',
+                    transactions: [],
+                }
             }
         };
 
@@ -223,9 +225,9 @@ export abstract class FabricConnection implements IFabricConnection {
         return metadataObject;
     }
 
-    public async submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>): Promise<void> {
+    public async submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string): Promise<void> {
         const network: Network = await this.gateway.getNetwork(channel);
-        const smartContract: Contract = network.getContract(chaincodeName);
+        const smartContract: Contract = network.getContract(chaincodeName, namespace);
 
         await smartContract.submitTransaction(transactionName, ...args);
 

--- a/client/src/fabric/IFabricConnection.ts
+++ b/client/src/fabric/IFabricConnection.ts
@@ -41,5 +41,5 @@ export interface IFabricConnection {
 
     getMetadata(instantiatedChaincodeName: string, channel: string): Promise<any>;
 
-    submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>): Promise<void>;
+    submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string): Promise<void>;
 }

--- a/client/src/util/MetadataUtil.ts
+++ b/client/src/util/MetadataUtil.ts
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import {IFabricConnection} from '../fabric/IFabricConnection';
+import * as vscode from 'vscode';
+
+// Functions for parsing metadata object
+export class MetadataUtil {
+
+    public static async getTransactionNames(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string): Promise<Map<string, string[]>> {
+        const metadataTransactions: Map<string, any[]> = await this.getTransactions(connection, instantiatedChaincodeName, channelName);
+
+        const transactionNames: Map<string, string[]> = new Map();
+        for (const [name, transactionObj] of metadataTransactions) {
+            const transactions: string[] = [];
+            for (const transaction of transactionObj) {
+                transactions.push(transaction.name);
+            }
+            transactionNames.set(name, transactions);
+        }
+        return transactionNames;
+    }
+
+    public static async getContractNames(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string): Promise<string[]> {
+        const metadataTransactions: Map<string, any[]> = await this.getTransactions(connection, instantiatedChaincodeName, channelName);
+
+        const contractNames: string[] = [];
+        for (const name of metadataTransactions.keys()) {
+            contractNames.push(name);
+        }
+
+        return contractNames;
+
+    }
+
+    public static async getTransactions(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string, checkForEmpty?: boolean): Promise<Map<string, any[]>> {
+        let metadataObj: any = {
+            contracts: {
+                '' : {
+                    name: '',
+                    transactions: [],
+                }
+            }
+        };
+        const contractsMap: Map<string, any[]> = new Map();
+
+        try {
+            metadataObj = await connection.getMetadata(instantiatedChaincodeName, channelName);
+            const contractsObject: any = metadataObj.contracts;
+            Object.keys(contractsObject).forEach((key: string) => {
+                if (key !== 'org.hyperledger.fabric' && (contractsObject[key].transactions.length > 0)) {
+                    contractsMap.set(key, contractsObject[key].transactions);
+                }
+            });
+
+            if (checkForEmpty && (contractsMap.size === 0)) {
+                vscode.window.showErrorMessage(`No metadata returned. Please ensure this smart contract is developed using the programming model delivered in Hyperledger Fabric v1.4+ for JavaScript and TypeScript`);
+            }
+        } catch (error) {
+            if (error.message.includes(`You've asked to invoke a function that does not exist`) ) {
+                vscode.window.showErrorMessage(`Error getting metadata for smart contract ${instantiatedChaincodeName}, please ensure this smart contract is depending on at least fabric-contract@1.4.0-beta2`);
+            } else {
+                vscode.window.showErrorMessage(`Error getting metadata for smart contract ${instantiatedChaincodeName}: ${error.message}`);
+            }
+        }
+
+        return contractsMap;
+    }
+
+}

--- a/client/templates/jsTestSmartContractTemplate.ejs
+++ b/client/templates/jsTestSmartContractTemplate.ejs
@@ -23,7 +23,11 @@ const fabricNetwork = require('fabric-network');
 const yaml = require('js-yaml');
 const fs = require('fs-extra');
 
+<%_ if (contractName !== '') { _%>
+describe('<%=contractName%>-<%=chaincodeLabel%>' , () => {
+<%_ } else { _%>
 describe('<%=chaincodeLabel%>' , () => {
+<%_ } _%>
 
     const gateway = new fabricNetwork.Gateway();
     let connectionProfile;
@@ -63,24 +67,35 @@ describe('<%=chaincodeLabel%>' , () => {
     afterEach(async () => {
         gateway.disconnect();
     });
-
-    <% functionNames.forEach((functionName) => { %>
-    it('<%=functionName%>', async () => {
+<% transactions.forEach((transaction) => { %>
+    it('<%=transaction.name%>', async () => {
+        <%_ if (transaction.parameters && transaction.parameters.length > 0) { _%>
+        // TODO: populate transaction parameters
+            <%_ let params = []; _%>
+            <%_ transaction.parameters.forEach((parameter) => { _%>
+                <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>
+        const <%=parameter.name.replace(`"`,'')%>;
+            <%_ }) _%>
+        const args = [<%=params%>];
+        <%_ } else { _%>
         // TODO: Update with parameters of transaction
-        const args = '';
-        const response = await submitTransaction('<%=functionName%>', args); // Returns buffer of transcation return value
+        const args = [''];
+        <%_ } _%>
+
+        const response = await submitTransaction('<%=transaction.name%>', args); // Returns buffer of transaction return value
         // TODO: Update with return value of transaction
-        // assert.equal(response.toString(), undefined);
+        // assert.equal(JSON.parse(response.toString()), undefined);
     }).timeout(10000);
-    <% }) %>
-
+<% }) %>
     async function submitTransaction(functionName, args) {
-        //Send transaction
-
+        // Submit transaction
         const network = await gateway.getNetwork('<%=channelName%>');
+<%_ if (contractName !== '') { _%>
+        const contract = await network.getContract('<%=chaincodeName%>', '<%=contractName%>');
+<%_ } else { _%>
         const contract = await network.getContract('<%=chaincodeName%>');
-
-        const responseBuffer = await contract.submitTransaction(functionName, args);
+<%_ } _%>
+        const responseBuffer = await contract.submitTransaction(functionName, ...args);
         return responseBuffer;
     }
 

--- a/client/templates/tsTestSmartContractTemplate.ejs
+++ b/client/templates/tsTestSmartContractTemplate.ejs
@@ -23,7 +23,11 @@ import * as Client from 'fabric-client';
 import * as fabricNetwork from 'fabric-network';
 import * as fs from 'fs-extra';
 
+<%_ if (contractName !== '') { _%>
+describe('<%=contractName%>-<%=chaincodeLabel%>' , () => {
+<%_ } else { _%>
 describe('<%=chaincodeLabel%>' , () => {
+<%_ } _%>
 
     const gateway: fabricNetwork.Gateway = new fabricNetwork.Gateway();
     const fabricWallet: fabricNetwork.InMemoryWallet = new fabricNetwork.InMemoryWallet();
@@ -60,24 +64,39 @@ describe('<%=chaincodeLabel%>' , () => {
     afterEach(async () => {
         gateway.disconnect();
     });
-<%functionNames.forEach((functionName) => {%>
-    it('<%=functionName%>', async () => {
+<% transactions.forEach((transaction) => { %>
+    it('<%=transaction.name%>', async () => {
+        <%_ if (transaction.parameters && transaction.parameters.length > 0) { _%>
+        // TODO: populate transaction parameters
+            <%_ let params = []; _%>
+            <%_ transaction.parameters.forEach((parameter) => { _%>
+                <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>
+                <%_ if (parameter.schema && parameter.schema['type']) { _%>
+        const <%=parameter.name.replace(`"`,'')%>: <%=parameter.schema['type'].replace(`"`,'')%>;
+                <%_ } else { _%>
+        const <%=parameter.name.replace(`"`,'')%>;
+                <%_ } _%>    
+            <%_ }) _%>
+        const args: string[] = [<%=params%>];
+        <%_ } else { _%>
         // TODO: Update with parameters of transaction
-        const args: string = '';
-        const response: Buffer = await submitTransaction('<%=functionName%>', args);
+        const args: string[] = [''];
+        <%_ } _%>
+
+        const response: Buffer = await submitTransaction('<%=transaction.name%>', args);
         // submitTransaction returns buffer of transcation return value
         // TODO: Update with return value of transaction
         assert.equal(true, true);
-        // assert.equal(response.toString(), undefined);
+        // assert.equal(JSON.parse(response.toString()), undefined);
     }).timeout(10000);
-<%})%>
-    async function submitTransaction(functionName: string, args: string): Promise<Buffer> {
-        // Send transaction
+<% }) %>
+    async function submitTransaction(functionName: string, args: string[]): Promise<Buffer> {
+        // Submit transaction
 
         const network: fabricNetwork.Network = await gateway.getNetwork('<%=channelName%>');
         const contract: fabricNetwork.Contract = await network.getContract('<%=chaincodeName%>');
 
-        const responseBuffer: Buffer = await contract.submitTransaction(functionName, args);
+        const responseBuffer: Buffer = await contract.submitTransaction(functionName, ...args);
         return responseBuffer;
     }
 

--- a/client/test/commands/upgradeCommand.test.ts
+++ b/client/test/commands/upgradeCommand.test.ts
@@ -104,8 +104,11 @@ describe('UpgradeCommand', () => {
             fabricClientConnectionMock.getInstantiatedChaincode.resolves([{ name: 'biscuit-network', version: '0.0.1' }]);
 
             fabricClientConnectionMock.getMetadata.resolves({
-                '': {
-                    functions: []
+                contracts: {
+                    'my-contract' : {
+                        name: 'my-contract',
+                        transactions: [],
+                    }
                 }
             });
 

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -881,19 +881,103 @@ describe('userInputUtil', () => {
 
     describe('showTransactionQuickPick', () => {
         it('should get a list of transactions', async () => {
-            quickPickStub.resolves('transaction1');
-            fabricConnectionStub.getMetadata.returns({
-                '': [
-                    'instantiate',
-                    'transaction1'
-                ]
+            quickPickStub.resolves({
+                label: 'my-contract - transaction1',
+                data: { name: 'transaction1', contract: 'my-contract'}
+            });
+            fabricConnectionStub.getMetadata.resolves(
+                {
+                    contracts: {
+                        'my-contract' : {
+                            name: 'my-contract',
+                            transactions: [
+                                {
+                                    name: 'instantiate'
+                                },
+                                {
+                                    name: 'transaction1'
+                                }
+                            ],
+                        },
+                        'my-other-contract' : {
+                            name: 'my-other-contract',
+                            transactions: [
+                                {
+                                    name: 'upgrade'
+                                },
+                                {
+                                    name: 'transaction1'
+                                }
+                            ],
+                        },
+                        '' : {
+                            name: '',
+                            transactions: [
+                                {
+                                    name: 'init'
+                                },
+                                {
+                                    name: 'invoke'
+                                }
+                            ],
+                        }
+                    }
+                }
+            );
+
+            const result: IBlockchainQuickPickItem<{ name: string, contract: string }> = await UserInputUtil.showTransactionQuickPick('choose a transaction', 'mySmartContract', 'myChannel');
+
+            result.should.deep.equal({
+                label: 'my-contract - transaction1',
+                data: { name: 'transaction1', contract: 'my-contract'}
             });
 
-            const result: string = await UserInputUtil.showTransactionQuickPick('choose a transaction', 'mySmartContract', 'myChannel');
+            const quickPickArray: Array<IBlockchainQuickPickItem<{ name: string, contract: string }>> = [
+                {
+                    label: 'my-contract - instantiate',
+                    data: {
+                        name: 'instantiate',
+                        contract: 'my-contract'
+                    }
+                },
+                {
+                    label: 'my-contract - transaction1',
+                    data: {
+                        name: 'transaction1',
+                        contract: 'my-contract'
+                    }
+                },
+                {
+                    label: 'my-other-contract - upgrade',
+                    data: {
+                        name: 'upgrade',
+                        contract: 'my-other-contract'
+                    }
+                },
+                {
+                    label: 'my-other-contract - transaction1',
+                    data: {
+                        name: 'transaction1',
+                        contract: 'my-other-contract'
+                    }
+                },
+                {
+                    label: 'init',
+                    data: {
+                        name: 'init',
+                        contract: ''
+                    }
+                },
+                {
+                    label: 'invoke',
+                    data: {
+                        name: 'invoke',
+                        contract: ''
+                    }
+                }
+            ];
 
-            result.should.equal('transaction1');
-
-            quickPickStub.should.have.been.calledWith(['instantiate', 'transaction1'], {
+            quickPickStub.should.have.been.calledWith(quickPickArray, {
                 ignoreFocusOut: false,
                 canPickMany: false,
                 placeHolder: 'choose a transaction'

--- a/client/test/fabric/FabricConnection.test.ts
+++ b/client/test/fabric/FabricConnection.test.ts
@@ -15,7 +15,6 @@
 import { FabricConnection } from '../../src/fabric/FabricConnection';
 import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
 import * as path from 'path';
-
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
@@ -360,15 +359,15 @@ describe('FabricConnection', () => {
 
     describe('getMetadata', () => {
         it('should return the metadata for an instantiated smart contract', async () => {
-            const fakeMetaData: string = '{"":{"functions":["instantiate","wagonwheeling","transaction2"]},"org.hyperledger.fabric":{"functions":["getMetaData"]}}';
+            const fakeMetaData: string = '{"contracts":{"my-contract":{"name":"","contractInstance":{"name":""},"transactions":[{"name":"instantiate"},{"name":"wagonwheeling"},{"name":"transaction2"}],"info":{"title":"","version":""}},"org.hyperledger.fabric":{"name":"org.hyperledger.fabric","contractInstance":{"name":"org.hyperledger.fabric"},"transactions":[{"name":"GetMetadata"}],"info":{"title":"","version":""}}},"info":{"version":"0.0.2","title":"victoria_sponge"},"components":{"schemas":{}}}';
             const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
             fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
 
             const metadata: any = await fabricConnection.getMetadata('myChaincode', 'channelConga');
             // tslint:disable-next-line
-            const functionArray: string[] = metadata[""].functions;
+            const testFunction: string = metadata.contracts["my-contract"].transactions[1].name;
             // tslint:disable-next-line
-            functionArray.should.deep.equal(["instantiate", "wagonwheeling", "transaction2"]);
+            testFunction.should.equal("wagonwheeling");
         });
 
         it('should handle not getting any metadata', async () => {
@@ -378,17 +377,17 @@ describe('FabricConnection', () => {
 
             const metadata: any = await fabricConnection.getMetadata('myChaincode', 'channelConga');
             // tslint:disable-next-line
-            const functionArray: string[] = metadata[""].functions;
-            // tslint:disable-next-line
-            functionArray.should.deep.equal([]);
+            const testFunctions: string[] = metadata.contracts[""].transactions;
+            testFunctions.should.deep.equal([]);
         });
+
     });
 
     describe('submitTransaction', () => {
         it('should submit a transaction', async () => {
             fabricContractStub.submitTransaction.resolves();
 
-            await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2']);
+            await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
             fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
         });
     });

--- a/client/test/util/MetadataUtil.test.ts
+++ b/client/test/util/MetadataUtil.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
+import { MetadataUtil } from '../../src/util/MetadataUtil';
+
+const should: Chai.Should = chai.should();
+chai.use(sinonChai);
+
+// tslint:disable no-unused-expression
+describe('Metadata Util tests', () => {
+
+    let mySandBox: sinon.SinonSandbox;
+    let fabricClientConnectionMock: sinon.SinonStubbedInstance<FabricClientConnection>;
+    let fakeMetadata: any;
+    let transactionOne: any;
+    let transactionTwo: any;
+    let transactionThree: any;
+    let pancakeTransactionOne: any;
+    let pancakeTransactionTwo: any;
+    const transactionNames: Map<string, string[]> = new Map();
+    let errorSpy: sinon.SinonSpy;
+    const testMap: Map<string, any[]> = new Map();
+
+    beforeEach(() => {
+        mySandBox = sinon.createSandbox();
+        fabricClientConnectionMock = sinon.createStubInstance(FabricClientConnection);
+        fakeMetadata = {
+            contracts: {
+                'cake' : {
+                    name: 'cake',
+                    transactions: [
+                        {
+                            name: 'instantiate',
+                            parameters: [
+                                {
+                                    name: 'eggs',
+                                    schema: {
+                                        type: 'object'
+                                    }
+                                },
+                                {
+                                    name: 'sugar',
+                                },
+                                {
+                                    name: 'flour',
+                                    schema: {
+                                        type: 'boolean'
+                                    }
+                                },
+                                {
+                                    name: 'butter',
+                                }
+                            ]
+                        },
+                        {
+                            name: 'wagonwheeling',
+                            parameters: []
+                        },
+                        {
+                            name: 'transaction2'
+                        }
+                    ]
+                },
+                'pancake' : {
+                    name: 'pancake',
+                    transactions: [
+                        {
+                            name: 'upgrade',
+                            parameters: [
+                                {
+                                    name: 'flour',
+                                    schema: {
+                                        type: 'string'
+                                    }
+                                },
+                                {
+                                    name: 'eggs',
+                                },
+                            ]
+                        },
+                        {
+                            name: 'transaction2'
+                        }
+                    ]
+                },
+                'org.hyperledger.fabric' : {
+                    name: 'org.hyperledger.fabric',
+                    transactions: [
+                        {
+                            name: 'GetMetadata'
+                        }
+                    ]
+                }
+            }
+        };
+
+        transactionOne = fakeMetadata.contracts['cake'].transactions[0];
+        transactionTwo = fakeMetadata.contracts['cake'].transactions[1];
+        transactionThree = fakeMetadata.contracts['cake'].transactions[2];
+        pancakeTransactionOne = fakeMetadata.contracts['pancake'].transactions[0];
+        pancakeTransactionTwo = fakeMetadata.contracts['pancake'].transactions[1];
+        fabricClientConnectionMock.getMetadata.resolves(fakeMetadata);
+        transactionNames.set('cake', [transactionOne.name, transactionTwo.name, transactionThree.name]);
+        transactionNames.set('pancake', [pancakeTransactionOne.name, pancakeTransactionTwo.name]);
+        testMap.set('cake', [transactionOne, transactionTwo, transactionThree]);
+        testMap.set('pancake', [pancakeTransactionOne, pancakeTransactionTwo]);
+        errorSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
+    });
+
+    afterEach(() => {
+        mySandBox.restore();
+    });
+
+    it('should return the Transaction names', async () => {
+         const names: Map<string, string[]> = await MetadataUtil.getTransactionNames(fabricClientConnectionMock, 'chaincode', 'channel');
+         names.should.deep.equal(transactionNames);
+         errorSpy.should.not.have.been.called;
+    });
+
+    it('should return the Transaction objects', async () => {
+        const transactionsMap: Map<string, any[]> = await MetadataUtil.getTransactions(fabricClientConnectionMock, 'chaincode', 'channel', true);
+        transactionsMap.should.deep.equal(testMap);
+        errorSpy.should.not.have.been.called;
+    });
+
+    it('should handle calling metadata using out of date smart contract apis', async () => {
+        fabricClientConnectionMock.getMetadata.rejects({message: `You've asked to invoke a function that does not exist`});
+        const names: Map<string, string[]> = await MetadataUtil.getTransactionNames(fabricClientConnectionMock, 'chaincode', 'channel');
+        names.size.should.equal(0);
+        errorSpy.should.have.been.calledOnceWith(`Error getting metadata for smart contract chaincode, please ensure this smart contract is depending on at least fabric-contract@1.4.0-beta2`);
+    });
+
+    it('should handle error getting metadata', async () => {
+        fabricClientConnectionMock.getMetadata.rejects({message: `some error`});
+        const transactionsMap: Map<string, any[]> = await MetadataUtil.getTransactions(fabricClientConnectionMock, 'chaincode', 'channel');
+        transactionsMap.size.should.equal(0);
+        errorSpy.should.have.been.calledOnceWith(`Error getting metadata for smart contract chaincode: some error`);
+    });
+
+});


### PR DESCRIPTION
- Fixes #164 and #373 
- Also adds support for generating test files for multiple smart contracts defined in the metadata
- Also added `--save-dev` flag to npm install after generation of tests, as per requested by @mbwhite 
- Requires a new published version of generator-fabric with correct apis
- Should be delivered at the same time as publishing a new version (0.1.0) of this extension

Signed-off-by: heatherlp <heatherpollard0@gmail.com>