### PR TITLE
Swallow errors getting smart contract metadata (resolves #532)

### DIFF
--- a/client/src/logging/OutputAdapter.ts
+++ b/client/src/logging/OutputAdapter.ts
@@ -17,7 +17,8 @@ export enum LogType {
     ERROR = 'ERROR',
     INFO = 'INFO',
     IMPORTANT = 'IMPORTANT',
-    YEOMAN = 'YEOMAN'
+    YEOMAN = 'YEOMAN',
+    WARNING = 'WARNING'
 }
 
 export interface OutputAdapter {

--- a/client/src/util/MetadataUtil.ts
+++ b/client/src/util/MetadataUtil.ts
@@ -72,11 +72,7 @@ export class MetadataUtil {
                 outputAdapter.log(LogType.ERROR, `No metadata returned. Please ensure this smart contract is developed using the programming model delivered in Hyperledger Fabric v1.4+ for JavaScript and TypeScript`);
             }
         } catch (error) {
-            if (error.message.includes(`You've asked to invoke a function that does not exist`) ) {
-                outputAdapter.log(LogType.ERROR, `Error getting metadata for smart contract ${instantiatedChaincodeName}, please ensure this smart contract is depending on at least fabric-contract@1.4.0`);
-            } else {
-                outputAdapter.log(LogType.ERROR, `Error getting metadata for smart contract ${instantiatedChaincodeName}: ${error.message}`);
-            }
+            outputAdapter.log(LogType.WARNING, null, `Could not get metadata for smart contract ${instantiatedChaincodeName}. The smart contract may not have been developed with the programming model delivered in Hyperledger Fabric v1.4+ for JavaScript and TypeScript. Error: ${error.message}`);
         }
 
         return contractsMap;


### PR DESCRIPTION
Ignore any errors getting smart contract metadata - we no longer care about pre Fabric v1.4.0 "GA" versions of smart contracts, and the current code logs errors for Go and Java chaincodes which won't ever have any metadata.

Log the error as a warning though (not via a popup), just so we can figure out why no metadata is available.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>