### PR TITLE
Handle case of no matching containers/images (resolves #582)

### DIFF
--- a/client/basic-network/teardown.sh
+++ b/client/basic-network/teardown.sh
@@ -14,7 +14,7 @@ docker-compose -f docker-compose.yml kill && docker-compose -f docker-compose.ym
 rm -f ~/.hfc-key-store/*
 
 # remove chaincode docker images
-docker rm -f $(docker ps -aq --filter "name=${COMPOSE_PROJECT_NAME}-*")
-docker rmi -f $(docker images -aq "${COMPOSE_PROJECT_NAME}-*")
+docker ps -aq --filter "name=${COMPOSE_PROJECT_NAME}-*" | xargs docker rm -f
+docker images -aq "${COMPOSE_PROJECT_NAME}-*" | xargs docker rmi -f
 
 # Your system is now clean


### PR DESCRIPTION
The teardown command fails if there are no matching containers or images (because of a partial teardown),  as we end up running `docker rm -f ` with no arguments.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>