### PR TITLE
Only show home page on activation once per version (resolves #503)

### DIFF
--- a/client/src/dependencies/DependencyManager.ts
+++ b/client/src/dependencies/DependencyManager.ts
@@ -39,8 +39,8 @@ export class DependencyManager {
 
     }
 
-    public hasNativeDependenciesInstalled(): boolean {
-        const packageJSON: any = ExtensionUtil.getPackageJSON();
+    public async hasNativeDependenciesInstalled(): Promise<boolean> {
+        const packageJSON: any = await this.getRawPackageJson();
         return packageJSON.activationEvents.length > 1;
     }
 

--- a/client/test/debug/FabricDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricDebugConfigurationProvider.test.ts
@@ -30,6 +30,7 @@ import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManage
 import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { ExtensionCommands } from '../../ExtensionCommands';
+import * as dateFormat from 'dateformat';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -53,10 +54,14 @@ describe('FabricDebugConfigurationProvider', () => {
         let readJsonStub: sinon.SinonStub;
         let registryEntry: FabricGatewayRegistryEntry;
         let getConnectionStub: sinon.SinonStub;
+        let date: Date;
+        let formattedDate: string;
 
         beforeEach(() => {
             mySandbox = sinon.createSandbox();
             clock = sinon.useFakeTimers({ toFake: ['Date'] });
+            date = new Date();
+            formattedDate = dateFormat(date, 'yyyymmddHHMM');
             fabricDebugConfig = new FabricDebugConfigurationProvider();
 
             runtimeStub = sinon.createStubInstance(FabricRuntime);
@@ -132,7 +137,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -148,7 +153,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['--peer.address', 'localhost:12345', 'start']
             });
         });
@@ -164,7 +169,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: path.join(path.sep, 'myPath', 'node_modules', '.bin', 'fabric-chaincode-node'),
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -180,7 +185,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: path.sep + 'myPath',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -195,7 +200,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -210,7 +215,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000', myProperty: 'myValue' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, myProperty: 'myValue' },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -240,7 +245,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', '127.0.0.1:54321']
             });
         });
@@ -255,7 +260,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['--myArgs', 'myValue', 'start', '--peer.address', '127.0.0.1:54321']
             });
         });
@@ -270,7 +275,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
         });
@@ -350,7 +355,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345'],
                 outFiles: [path.join(workspaceFolder.uri.fsPath, '**/*.js')]
             });
@@ -368,7 +373,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000'},
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`},
                 args: ['start', '--peer.address', 'localhost:12345']
             });
 
@@ -395,7 +400,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345'],
                 outFiles: [path.join(workspaceFolder.uri.fsPath, 'dist', '**/*.js')],
                 preLaunchTask: 'tsc: build - tsconfig.json'
@@ -422,7 +427,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345'],
                 outFiles: [path.join(workspaceFolder.uri.fsPath, '**/*.js')],
                 preLaunchTask: 'tsc: build - tsconfig.json'
@@ -449,7 +454,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345'],
                 outFiles: [path.join(workspaceFolder.uri.fsPath, 'dist', '**/*.js')],
                 preLaunchTask: 'tsc: build - tsconfig.json'
@@ -478,7 +483,7 @@ describe('FabricDebugConfigurationProvider', () => {
                 name: 'Launch Program',
                 program: 'myProgram',
                 cwd: 'myCwd',
-                env: { CORE_CHAINCODE_ID_NAME: 'mySmartContract:vscode-debug-197001010000' },
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
                 args: ['start', '--peer.address', 'localhost:12345'],
                 outFiles: ['cake', path.join(workspaceFolder.uri.fsPath, 'dist', '**/*.js')],
                 preLaunchTask: 'tsc: build - tsconfig.json'

--- a/client/test/dependencies/DependencyManager.test.ts
+++ b/client/test/dependencies/DependencyManager.test.ts
@@ -15,6 +15,7 @@ import * as fs from 'fs-extra';
 import * as vscode from 'vscode';
 
 import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
@@ -26,6 +27,7 @@ import { TestUtil } from '../TestUtil';
 import { LogType } from '../../src/logging/OutputAdapter';
 
 chai.should();
+chai.use(chaiAsPromised);
 chai.use(sinonChai);
 
 // tslint:disable no-unused-expression
@@ -47,20 +49,20 @@ describe('DependencyManager Tests', () => {
             mySandBox.restore();
         });
 
-        it('should return true if the dependencies are installed', () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({activationEvents: ['myActivationOne', 'myActivationTwo']});
+        it('should return true if the dependencies are installed', async () => {
+            mySandBox.stub(fs, 'readFile').resolves(JSON.stringify({activationEvents: ['myActivationOne', 'myActivationTwo']}));
 
             const dependencyManager: DependencyManager = DependencyManager.instance();
 
-            dependencyManager.hasNativeDependenciesInstalled().should.equal(true);
+            await dependencyManager.hasNativeDependenciesInstalled().should.eventually.equal(true);
         });
 
-        it('should return false if the dependencies are not installed', () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({activationEvents: ['*']});
+        it('should return false if the dependencies are not installed', async () => {
+            mySandBox.stub(fs, 'readFile').resolves(JSON.stringify({activationEvents: ['*']}));
 
             const dependencyManager: DependencyManager = DependencyManager.instance();
 
-            dependencyManager.hasNativeDependenciesInstalled().should.equal(false);
+            await dependencyManager.hasNativeDependenciesInstalled().should.eventually.equal(false);
         });
     });
 

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -53,6 +53,8 @@ describe('Extension Tests', () => {
     });
 
     beforeEach(async () => {
+        const extensionContext: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
+        await extensionContext.globalState.update(myExtension.EXTENSION_DATA_KEY, myExtension.DEFAULT_EXTENSION_DATA);
         mySandBox = sinon.createSandbox();
         if (runtimeManager.exists('local_fabric')) {
             await runtimeManager.delete('local_fabric');
@@ -61,6 +63,8 @@ describe('Extension Tests', () => {
     });
 
     afterEach(async () => {
+        const extensionContext: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
+        await extensionContext.globalState.update(myExtension.EXTENSION_DATA_KEY, myExtension.DEFAULT_EXTENSION_DATA);
         mySandBox.restore();
         if (runtimeManager.exists('local_fabric')) {
             await runtimeManager.delete('local_fabric');
@@ -318,7 +322,7 @@ describe('Extension Tests', () => {
         executeCommand.should.not.have.been.calledWith(ExtensionCommands.OPEN_HOME_PAGE);
     });
 
-    it('should open home page if disabled in settings', async () => {
+    it('should open home page if enabled in settings on first activation', async () => {
         await vscode.workspace.getConfiguration().update('extension.home.showOnStartup', true, vscode.ConfigurationTarget.Global);
 
         const executeCommand: sinon.SinonSpy = mySandBox.spy(vscode.commands, 'executeCommand');
@@ -328,6 +332,24 @@ describe('Extension Tests', () => {
         await myExtension.activate(context);
 
         executeCommand.should.have.been.calledWith(ExtensionCommands.OPEN_HOME_PAGE);
+    });
+
+    it('should not open home page if enabled in settings on second activation', async () => {
+        await vscode.workspace.getConfiguration().update('extension.home.showOnStartup', true, vscode.ConfigurationTarget.Global);
+
+        const executeCommand: sinon.SinonSpy = mySandBox.spy(vscode.commands, 'executeCommand');
+
+        const context: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
+
+        await myExtension.activate(context);
+
+        executeCommand.should.have.been.calledWith(ExtensionCommands.OPEN_HOME_PAGE);
+
+        executeCommand.resetHistory();
+
+        await myExtension.activate(context);
+
+        executeCommand.should.not.have.been.called;
     });
 
     it('should register and show sample page', async () => {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,8 @@
 		"rootDir": ".",
 		"outDir": "out",
 		"lib": [ "es2016" ],
-		"sourceMap": true
+		"sourceMap": true,
+		"resolveJsonModule": true
 	},
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
Quite a few changes in here:

- Store the current extension version and activation count in the global state; this is persisted across VSCode windows, VSCode restarts, and extension updates
- During activation, determine if the current extension version has changed since the last activation; this allows us to know if the extension has been updated
- If the extension has been updated, act as before - open the home page, and be noisy about the extension being activated (show the output panel)
- If the extension has not been updated, don't open the home page, and don't be noisy about the extension being activated (don't show the output panel)
- Always read the raw package.json file off the disk, to avoid VSCode's often cached one
- Fix the debug unit tests so they work in the USA

This results in the home page being shown once for each version published, unless they disable the home page via user settings. IMO this is enough to show the user once what's new and what's available via the home page.

The extension gets activated many times during normal usage; it gets activated when you open a new folder, or switch from a folder to a workspace, or a workspace to a folder. 

AFAIK there is no state that is only for the current VSCode process, so that we could show the home page again the next time they restart VSCode.

This is a Microsoft approved strategy for doing one time things, see: https://github.com/Microsoft/vscode/issues/34063

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>