### PR TITLE
Allow package command to accept name and version (contributes to #616)

### DIFF
--- a/client/src/debug/FabricDebugConfigurationProvider.ts
+++ b/client/src/debug/FabricDebugConfigurationProvider.ts
@@ -65,7 +65,7 @@ export class FabricDebugConfigurationProvider implements vscode.DebugConfigurati
                 newVersion = config.env.CORE_CHAINCODE_ID_NAME.split(':')[1];
             }
 
-            const newPackage: PackageRegistryEntry = await vscode.commands.executeCommand(ExtensionCommands.PACKAGE_SMART_CONTRACT, folder, newVersion) as PackageRegistryEntry;
+            const newPackage: PackageRegistryEntry = await vscode.commands.executeCommand(ExtensionCommands.PACKAGE_SMART_CONTRACT, folder, null, newVersion) as PackageRegistryEntry;
             if (!newPackage) {
                 // package command failed
                 return;

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -180,7 +180,7 @@ export async function registerCommands(context: vscode.ExtensionContext): Promis
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.DELETE_GATEWAY, (gateway: GatewayTreeItem) => deleteGateway(gateway)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.ADD_GATEWAY_IDENTITY, (gateway: GatewayTreeItem) => addGatewayIdentity(gateway)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.CREATE_SMART_CONTRACT_PROJECT, createSmartContractProject));
-    context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.PACKAGE_SMART_CONTRACT, (workspace?: vscode.WorkspaceFolder, version?: string) => packageSmartContract(workspace, version)));
+    context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.PACKAGE_SMART_CONTRACT, (workspace?: vscode.WorkspaceFolder, overrideName?: string, overrideVersion?: string) => packageSmartContract(workspace, overrideName, overrideVersion)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.REFRESH_PACKAGES, () => blockchainPackageExplorerProvider.refresh()));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.REFRESH_LOCAL_OPS, (element: BlockchainTreeItem) => blockchainRuntimeExplorerProvider.refresh(element)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.START_FABRIC, () => startFabricRuntime()));

--- a/client/test/debug/FabricDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricDebugConfigurationProvider.test.ts
@@ -108,7 +108,7 @@ describe('FabricDebugConfigurationProvider', () => {
             packageEntry.name = 'banana';
             packageEntry.version = 'vscode-13232112018';
             packageEntry.path = path.join('myPath');
-            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any).resolves(packageEntry);
+            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any, sinon.match.any).resolves(packageEntry);
             commandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT, null, sinon.match.any).resolves({
                 name: 'test-package@0.0.1',
                 path: 'some/path',
@@ -305,7 +305,7 @@ describe('FabricDebugConfigurationProvider', () => {
         });
 
         it('should handle errors with packaging', async () => {
-            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any).resolves();
+            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any, sinon.match.any).resolves();
 
             const logSpy: sinon.SinonSpy = mySandbox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
             const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
@@ -335,7 +335,7 @@ describe('FabricDebugConfigurationProvider', () => {
         });
 
         it('should handle errors with installing', async () => {
-            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any).rejects({message: 'some error'});
+            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any, sinon.match.any).rejects({message: 'some error'});
 
             const logSpy: sinon.SinonSpy = mySandbox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
             const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);


### PR DESCRIPTION
Currently the package command allows you to override the version (via internal API), but not to override the name and version. We need to enable this in order to support debugging of Go and Java smart contracts where both the name and version will be passed in from the debugger.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>