### PR TITLE
Add Go debug configuration provider (resolves #616)

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -450,6 +450,185 @@
         },
         "debuggers": [
             {
+                "type": "fabric:go",
+                "label": "Debug a Hyperledger Fabric Smart Contract",
+                "runtime": "node",
+                "configurationAttributes": {
+                    "launch": {
+                        "required": [],
+                        "properties": {
+                            "program": {
+                                "type": "string",
+                                "description": "Path to the program folder (or any file within that folder) when in 'debug' or 'test' mode, and to the pre-built binary file to debug in 'exec' mode.",
+                                "default": "${workspaceFolder}"
+                            },
+                            "mode": {
+                                "enum": [
+                                    "auto",
+                                    "debug",
+                                    "remote",
+                                    "test",
+                                    "exec"
+                                ],
+                                "description": "One of 'auto', 'debug', 'remote', 'test', 'exec'.",
+                                "default": "auto"
+                            },
+                            "stopOnEntry": {
+                                "type": "boolean",
+                                "description": "Automatically stop program after launch.",
+                                "default": false
+                            },
+                            "args": {
+                                "type": "array",
+                                "description": "Command line arguments passed to the program.",
+                                "items": {
+                                    "type": "string"
+                                },
+                                "default": []
+                            },
+                            "showLog": {
+                                "type": "boolean",
+                                "description": "Show log output from the delve debugger.",
+                                "default": false
+                            },
+                            "cwd": {
+                                "type": "string",
+                                "description": "Workspace relative or absolute path to the working directory of the program being debugged. Default is the current workspace.",
+                                "default": "."
+                            },
+                            "env": {
+                                "type": "object",
+                                "description": "Environment variables passed to the program.",
+                                "default": {}
+                            },
+                            "buildFlags": {
+                                "type": "string",
+                                "description": "Build flags, to be passed to the Go compiler.",
+                                "default": ""
+                            },
+                            "init": {
+                                "type": "string",
+                                "description": "Init file, executed by the terminal client.",
+                                "default": ""
+                            },
+                            "remotePath": {
+                                "type": "string",
+                                "description": "If remote debugging, the path to the source code on the remote machine, if different from the local machine.",
+                                "default": ""
+                            },
+                            "port": {
+                                "type": "number",
+                                "description": "The port that the delve debugger will be listening on.",
+                                "default": 2345
+                            },
+                            "host": {
+                                "type": "string",
+                                "description": "The host name of the machine the delve debugger will be listening on.",
+                                "default": "127.0.0.1"
+                            },
+                            "trace": {
+                                "type": "string",
+                                "enum": [
+                                    "log",
+                                    "verbose",
+                                    "error"
+                                ],
+                                "default": "error",
+                                "description": "Various levels of logging shown in the debug console. When set to 'log' or 'verbose', the logs will also be written to a file."
+                            },
+                            "envFile": {
+                                "type": "string",
+                                "description": "Absolute path to a file containing environment variable definitions.",
+                                "default": "${workspaceFolder}/.env"
+                            },
+                            "backend": {
+                                "type": "string",
+                                "enum": [
+                                    "default",
+                                    "native",
+                                    "lldb"
+                                ],
+                                "description": "Backend used by delve. Only available in delve version 0.12.2 and above."
+                            },
+                            "output": {
+                                "type": "string",
+                                "description": "Output path for the binary of delve",
+                                "default": "debug"
+                            },
+                            "logOutput": {
+                                "type": "string",
+                                "enum": [
+                                    "debugger",
+                                    "gdbwire",
+                                    "lldbout",
+                                    "debuglineerr",
+                                    "rpc"
+                                ],
+                                "description": "Comma separated list of components that should produce debug output.",
+                                "default": "debugger"
+                            },
+                            "dlvLoadConfig": {
+                                "type": "object",
+                                "properties": {
+                                    "followPointers": {
+                                        "type": "boolean",
+                                        "description": "FollowPointers requests pointers to be automatically dereferenced",
+                                        "default": true
+                                    },
+                                    "maxVariableRecurse": {
+                                        "type": "number",
+                                        "description": "MaxVariableRecurse is how far to recurse when evaluating nested types",
+                                        "default": 1
+                                    },
+                                    "maxStringLen": {
+                                        "type": "number",
+                                        "description": "MaxStringLen is the maximum number of bytes read from a string",
+                                        "default": 64
+                                    },
+                                    "maxArrayValues": {
+                                        "type": "number",
+                                        "description": "MaxArrayValues is the maximum number of elements read from an array, a slice or a map",
+                                        "default": 64
+                                    },
+                                    "maxStructFields": {
+                                        "type": "number",
+                                        "description": "MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields",
+                                        "default": -1
+                                    }
+                                },
+                                "description": "LoadConfig describes to delve, how to load values from target's memory",
+                                "default": {
+                                    "followPointers": true,
+                                    "maxVariableRecurse": 1,
+                                    "maxStringLen": 64,
+                                    "maxArrayValues": 64,
+                                    "maxStructFields": -1
+                                }
+                            },
+                            "apiVersion": {
+                                "type": "number",
+                                "enum": [
+                                    1,
+                                    2
+                                ],
+                                "description": "Delve Api Version to use. Default value is 2.",
+                                "default": 2
+                            },
+                            "stackTraceDepth": {
+                                "type": "number",
+                                "description": "Maximum depth of stack trace collected from Delve",
+                                "default": 50
+                            },
+                            "showGlobalVariables": {
+                                "type": "boolean",
+                                "default": true,
+                                "description": "Boolean value to indicate whether global package variables should be shown in the variables pane or not."
+                            }
+                        }
+                    }
+                }
+            },
+            {
                 "type": "fabric:node",
                 "label": "Debug a Hyperledger Fabric Smart Contract",
                 "runtime": "node",
@@ -522,6 +701,11 @@
                 },
                 "initialConfigurations": [
                     {
+                        "type": "fabric:go",
+                        "request": "launch",
+                        "name": "Debug Smart Contract"
+                    },
+                    {
                         "type": "fabric:node",
                         "request": "launch",
                         "name": "Debug Smart Contract"
@@ -529,7 +713,16 @@
                 ],
                 "configurationSnippets": [
                     {
-                        "label": "Fabric Debug: Launch",
+                        "label": "Fabric Debug (Go): Launch",
+                        "description": "A new configuration for 'debugging' a smart contract.",
+                        "body": {
+                            "type": "fabric:go",
+                            "request": "launch",
+                            "name": "Debug Smart Contract"
+                        }
+                    },
+                    {
+                        "label": "Fabric Debug (Node.js): Launch",
                         "description": "A new configuration for 'debugging' a smart contract.",
                         "body": {
                             "type": "fabric:node",

--- a/client/src/debug/FabricGoDebugConfigurationProvider.ts
+++ b/client/src/debug/FabricGoDebugConfigurationProvider.ts
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { FabricDebugConfigurationProvider } from './FabricDebugConfigurationProvider';
+import { UserInputUtil } from '../commands/UserInputUtil';
+
+export class FabricGoDebugConfigurationProvider extends FabricDebugConfigurationProvider {
+
+    protected async getChaincodeName(folder: vscode.WorkspaceFolder | undefined): Promise<string> {
+        const name: string = await UserInputUtil.showInputBox('Enter a name for your Go package'); // Getting the specified name and package from the user
+        return name;
+    }
+
+    protected async resolveDebugConfigurationInner(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+        config.type = 'go';
+
+        if (!config.request) {
+            config.request = 'launch';
+        }
+
+        if (!config.mode) {
+            config.mode = 'auto';
+        }
+
+        if (!config.program) {
+            config.program = folder.uri.fsPath;
+        }
+
+        if (!config.cwd) {
+            config.cwd = folder.uri.fsPath;
+        }
+
+        if (!config.args) {
+            config.args = [];
+        }
+
+        if (!config.args.includes('--peer.address')) {
+            const peerAddress: string = await this.getChaincodeAddress();
+            config.args.push('--peer.address', peerAddress);
+        }
+
+        return config;
+    }
+
+}

--- a/client/src/debug/FabricNodeDebugConfigurationProvider.ts
+++ b/client/src/debug/FabricNodeDebugConfigurationProvider.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { FabricDebugConfigurationProvider } from './FabricDebugConfigurationProvider';
+import { ExtensionUtil } from '../util/ExtensionUtil';
+
+export class FabricNodeDebugConfigurationProvider extends FabricDebugConfigurationProvider {
+
+    protected async getChaincodeName(folder: vscode.WorkspaceFolder | undefined): Promise<string> {
+        const { name } = await ExtensionUtil.getContractNameAndVersion(folder);
+        return name;
+    }
+
+    protected async resolveDebugConfigurationInner(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
+        config.type = 'node';
+
+        if (!config.request) {
+            config.request = 'launch';
+        }
+
+        if (!config.program) {
+            config.program = path.join(folder.uri.fsPath, 'node_modules', '.bin', 'fabric-chaincode-node');
+        }
+
+        if (!config.cwd) {
+            config.cwd = folder.uri.fsPath;
+        }
+
+        if (!config.args) {
+            config.args = [];
+        }
+
+        if (!config.args.includes('start')) {
+            config.args.push('start');
+        }
+
+        if (!config.args.includes('--peer.address')) {
+            const peerAddress: string = await this.getChaincodeAddress();
+            config.args.push('--peer.address', peerAddress);
+        }
+
+        return config;
+    }
+
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -23,7 +23,6 @@ import { addGatewayIdentity } from './commands/addGatewayIdentityCommand';
 import { connect } from './commands/connectCommand';
 import { createSmartContractProject } from './commands/createSmartContractProjectCommand';
 import { packageSmartContract } from './commands/packageSmartContractCommand';
-
 import { VSCodeBlockchainOutputAdapter } from './logging/VSCodeBlockchainOutputAdapter';
 import { DependencyManager } from './dependencies/DependencyManager';
 import { TemporaryCommandRegistry } from './dependencies/TemporaryCommandRegistry';
@@ -43,7 +42,7 @@ import { editGatewayCommand } from './commands/editGatewayCommand';
 import { teardownFabricRuntime } from './commands/teardownFabricRuntime';
 import { exportSmartContractPackage } from './commands/exportSmartContractPackageCommand';
 import { PackageTreeItem } from './explorer/model/PackageTreeItem';
-import { FabricDebugConfigurationProvider } from './debug/FabricDebugConfigurationProvider';
+import { FabricNodeDebugConfigurationProvider } from './debug/FabricNodeDebugConfigurationProvider';
 import { FabricConnectionManager } from './fabric/FabricConnectionManager';
 import { PackageRegistryEntry } from './packages/PackageRegistryEntry';
 import { testSmartContract } from './commands/testSmartContractCommand';
@@ -53,7 +52,6 @@ import { upgradeSmartContract } from './commands/upgradeCommand';
 import { openFabricRuntimeTerminal } from './commands/openFabricRuntimeTerminal';
 import { exportConnectionDetails } from './commands/exportConnectionDetailsCommand';
 import { LogType } from './logging/OutputAdapter';
-
 import { HomeView } from './webview/HomeView';
 import { SampleView } from './webview/SampleView';
 import { BlockchainRuntimeExplorerProvider } from './explorer/BlockchainRuntimeExplorer';
@@ -64,6 +62,7 @@ import { ExtensionCommands } from '../ExtensionCommands';
 import { version as currentExtensionVersion } from '../package.json';
 import { InstantiatedContractTreeItem } from './explorer/model/InstantiatedContractTreeItem';
 import { InstantiatedTreeItem } from './explorer/model/InstantiatedTreeItem';
+import { FabricGoDebugConfigurationProvider } from './debug/FabricGoDebugConfigurationProvider';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -166,9 +165,10 @@ export async function registerCommands(context: vscode.ExtensionContext): Promis
 
     disposeExtension(context);
 
-    const provider: FabricDebugConfigurationProvider = new FabricDebugConfigurationProvider();
-    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('fabric:node', provider));
-    context.subscriptions.push(provider);
+    const goDebugProvider: FabricGoDebugConfigurationProvider = new FabricGoDebugConfigurationProvider();
+    const nodeDebugProvider: FabricNodeDebugConfigurationProvider = new FabricNodeDebugConfigurationProvider();
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('fabric:go', goDebugProvider));
+    context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('fabric:node', nodeDebugProvider));
 
     context.subscriptions.push(vscode.window.registerTreeDataProvider('blockchainExplorer', blockchainNetworkExplorerProvider));
     context.subscriptions.push(vscode.window.registerTreeDataProvider('blockchainARuntimeExplorer', blockchainRuntimeExplorerProvider));

--- a/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
+import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
+import { FabricGatewayRegistry } from '../../src/fabric/FabricGatewayRegistry';
+import { ExtensionCommands } from '../../ExtensionCommands';
+import * as dateFormat from 'dateformat';
+import { FabricGoDebugConfigurationProvider } from '../../src/debug/FabricGoDebugConfigurationProvider';
+import { UserInputUtil } from '../../src/commands/UserInputUtil';
+
+const should: Chai.Should = chai.should();
+chai.use(sinonChai);
+
+// tslint:disable no-unused-expression
+describe('FabricGoDebugConfigurationProvider', () => {
+
+    describe('resolveDebugConfiguration', () => {
+
+        let mySandbox: sinon.SinonSandbox;
+        let clock: sinon.SinonFakeTimers;
+        let fabricDebugConfig: FabricGoDebugConfigurationProvider;
+        let workspaceFolder: any;
+        let debugConfig: any;
+        let runtimeStub: sinon.SinonStubbedInstance<FabricRuntime>;
+        let findFilesStub: sinon.SinonStub;
+        let commandStub: sinon.SinonStub;
+        let packageEntry: PackageRegistryEntry;
+        let mockRuntimeConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
+        let readFileStub: sinon.SinonStub;
+        let readJsonStub: sinon.SinonStub;
+        let registryEntry: FabricGatewayRegistryEntry;
+        let getConnectionStub: sinon.SinonStub;
+        let date: Date;
+        let formattedDate: string;
+        let startDebuggingStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            mySandbox = sinon.createSandbox();
+            clock = sinon.useFakeTimers({ toFake: ['Date'] });
+            date = new Date();
+            formattedDate = dateFormat(date, 'yyyymmddHHMM');
+            fabricDebugConfig = new FabricGoDebugConfigurationProvider();
+
+            runtimeStub = sinon.createStubInstance(FabricRuntime);
+            runtimeStub.getName.returns('localfabric');
+            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
+            runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
+            runtimeStub.isRunning.resolves(true);
+            runtimeStub.isDevelopmentMode.returns(true);
+
+            registryEntry = new FabricGatewayRegistryEntry();
+            registryEntry.name = 'local_fabric';
+            registryEntry.connectionProfilePath = 'myPath';
+            registryEntry.managedRuntime = true;
+
+            mySandbox.stub(FabricRuntimeManager.instance(), 'get').returns(runtimeStub);
+            mySandbox.stub(FabricGatewayRegistry.instance(), 'get').returns(registryEntry);
+
+            workspaceFolder = {
+                name: 'myFolder',
+                uri: vscode.Uri.file('myPath')
+            };
+
+            readJsonStub = mySandbox.stub(fs, 'readJSON');
+            readFileStub = mySandbox.stub(fs, 'readFile').resolves(`{
+                "name": "mySmartContract",
+                "version": "0.0.1"
+            }`);
+
+            debugConfig = {
+                type: 'fabric:node',
+                name: 'Launch Program'
+            };
+
+            debugConfig.request = 'myLaunch';
+            debugConfig.program = 'myProgram';
+            debugConfig.cwd = 'myCwd';
+            debugConfig.args = ['--peer.address', 'localhost:12345'];
+            debugConfig.mode = 'auto';
+
+            findFilesStub = mySandbox.stub(vscode.workspace, 'findFiles').resolves([]);
+
+            commandStub = mySandbox.stub(vscode.commands, 'executeCommand');
+
+            packageEntry = new PackageRegistryEntry();
+            packageEntry.name = 'banana';
+            packageEntry.version = 'vscode-13232112018';
+            packageEntry.path = path.join('myPath');
+            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any).resolves(packageEntry);
+            commandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT, null, sinon.match.any).resolves({
+                name: 'test-package@0.0.1',
+                path: 'some/path',
+                version: '0.0.1'
+            });
+            commandStub.withArgs('blockchainExplorer.connectEntry', sinon.match.any);
+
+            mockRuntimeConnection = sinon.createStubInstance(FabricRuntimeConnection);
+            mockRuntimeConnection.connect.resolves();
+            mockRuntimeConnection.getAllPeerNames.resolves('peerOne');
+
+            getConnectionStub = mySandbox.stub(FabricRuntimeManager.instance(), 'getConnection').returns(mockRuntimeConnection);
+
+            startDebuggingStub = mySandbox.stub(vscode.debug, 'startDebugging');
+
+            mySandbox.stub(UserInputUtil, 'showInputBox').withArgs('Enter a name for your Go package').resolves('mySmartContract');
+        });
+
+        afterEach(() => {
+            clock.restore();
+            mySandbox.restore();
+        });
+
+        it('should create a debug configuration', async () => {
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should set mode if not set', async () => {
+
+            debugConfig.mode = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should set program if not set', async () => {
+
+            debugConfig.program = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: path.join(path.sep, 'myPath'),
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should add cwd if not set', async () => {
+
+            debugConfig.cwd = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: path.sep + 'myPath',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should add args if not defined', async () => {
+            debugConfig.args = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', '127.0.0.1:54321']
+            });
+        });
+
+        it('should add more args if some args exist', async () => {
+            debugConfig.args = ['--myArgs', 'myValue'];
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--myArgs', 'myValue', '--peer.address', '127.0.0.1:54321']
+            });
+        });
+
+        it('should add in request if not defined', async () => {
+            debugConfig.request = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'go',
+                mode: 'auto',
+                request: 'launch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345']
+            });
+        });
+
+    });
+
+});

--- a/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { FabricNodeDebugConfigurationProvider } from '../../src/debug/FabricNodeDebugConfigurationProvider';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
+import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
+import { FabricGatewayRegistry } from '../../src/fabric/FabricGatewayRegistry';
+import { ExtensionCommands } from '../../ExtensionCommands';
+import * as dateFormat from 'dateformat';
+
+const should: Chai.Should = chai.should();
+chai.use(sinonChai);
+
+// tslint:disable no-unused-expression
+describe('FabricNodeDebugConfigurationProvider', () => {
+
+    describe('resolveDebugConfiguration', () => {
+
+        let mySandbox: sinon.SinonSandbox;
+        let clock: sinon.SinonFakeTimers;
+        let fabricDebugConfig: FabricNodeDebugConfigurationProvider;
+        let workspaceFolder: any;
+        let debugConfig: any;
+        let runtimeStub: sinon.SinonStubbedInstance<FabricRuntime>;
+        let findFilesStub: sinon.SinonStub;
+        let commandStub: sinon.SinonStub;
+        let packageEntry: PackageRegistryEntry;
+        let mockRuntimeConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
+        let readFileStub: sinon.SinonStub;
+        let readJsonStub: sinon.SinonStub;
+        let registryEntry: FabricGatewayRegistryEntry;
+        let getConnectionStub: sinon.SinonStub;
+        let date: Date;
+        let formattedDate: string;
+        let startDebuggingStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            mySandbox = sinon.createSandbox();
+            clock = sinon.useFakeTimers({ toFake: ['Date'] });
+            date = new Date();
+            formattedDate = dateFormat(date, 'yyyymmddHHMM');
+            fabricDebugConfig = new FabricNodeDebugConfigurationProvider();
+
+            runtimeStub = sinon.createStubInstance(FabricRuntime);
+            runtimeStub.getName.returns('localfabric');
+            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
+            runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
+            runtimeStub.isRunning.resolves(true);
+            runtimeStub.isDevelopmentMode.returns(true);
+
+            registryEntry = new FabricGatewayRegistryEntry();
+            registryEntry.name = 'local_fabric';
+            registryEntry.connectionProfilePath = 'myPath';
+            registryEntry.managedRuntime = true;
+
+            mySandbox.stub(FabricRuntimeManager.instance(), 'get').returns(runtimeStub);
+            mySandbox.stub(FabricGatewayRegistry.instance(), 'get').returns(registryEntry);
+
+            workspaceFolder = {
+                name: 'myFolder',
+                uri: vscode.Uri.file('myPath')
+            };
+
+            readJsonStub = mySandbox.stub(fs, 'readJSON');
+            readFileStub = mySandbox.stub(fs, 'readFile').resolves(`{
+                "name": "mySmartContract",
+                "version": "0.0.1"
+            }`);
+
+            debugConfig = {
+                type: 'fabric:node',
+                name: 'Launch Program'
+            };
+
+            debugConfig.request = 'myLaunch';
+            debugConfig.program = 'myProgram';
+            debugConfig.cwd = 'myCwd';
+            debugConfig.args = ['start', '--peer.address', 'localhost:12345'];
+
+            findFilesStub = mySandbox.stub(vscode.workspace, 'findFiles').resolves([]);
+
+            commandStub = mySandbox.stub(vscode.commands, 'executeCommand');
+
+            packageEntry = new PackageRegistryEntry();
+            packageEntry.name = 'banana';
+            packageEntry.version = 'vscode-13232112018';
+            packageEntry.path = path.join('myPath');
+            commandStub.withArgs(ExtensionCommands.PACKAGE_SMART_CONTRACT, sinon.match.any, sinon.match.any).resolves(packageEntry);
+            commandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT, null, sinon.match.any).resolves({
+                name: 'test-package@0.0.1',
+                path: 'some/path',
+                version: '0.0.1'
+            });
+            commandStub.withArgs('blockchainExplorer.connectEntry', sinon.match.any);
+
+            mockRuntimeConnection = sinon.createStubInstance(FabricRuntimeConnection);
+            mockRuntimeConnection.connect.resolves();
+            mockRuntimeConnection.getAllPeerNames.resolves('peerOne');
+
+            getConnectionStub = mySandbox.stub(FabricRuntimeManager.instance(), 'getConnection').returns(mockRuntimeConnection);
+
+            startDebuggingStub = mySandbox.stub(vscode.debug, 'startDebugging');
+        });
+
+        afterEach(() => {
+            clock.restore();
+            mySandbox.restore();
+        });
+
+        it('should create a debug configuration', async () => {
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['start', '--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should add start arg if not in there', async () => {
+
+            debugConfig.args = ['--peer.address', 'localhost:12345'];
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--peer.address', 'localhost:12345', 'start']
+            });
+        });
+
+        it('should set program if not set', async () => {
+
+            debugConfig.program = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: path.join(path.sep, 'myPath', 'node_modules', '.bin', 'fabric-chaincode-node'),
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['start', '--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should add cwd if not set', async () => {
+
+            debugConfig.cwd = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: path.sep + 'myPath',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['start', '--peer.address', 'localhost:12345']
+            });
+        });
+
+        it('should add args if not defined', async () => {
+            debugConfig.args = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['start', '--peer.address', '127.0.0.1:54321']
+            });
+        });
+
+        it('should add more args if some args exist', async () => {
+            debugConfig.args = ['--myArgs', 'myValue'];
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'myLaunch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['--myArgs', 'myValue', 'start', '--peer.address', '127.0.0.1:54321']
+            });
+        });
+
+        it('should add in request if not defined', async () => {
+            debugConfig.request = null;
+
+            const config: vscode.DebugConfiguration = await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
+            should.equal(config, undefined);
+            startDebuggingStub.should.have.been.calledOnceWithExactly(sinon.match.any, {
+                type: 'node',
+                request: 'launch',
+                program: 'myProgram',
+                cwd: 'myCwd',
+                env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}` },
+                args: ['start', '--peer.address', 'localhost:12345']
+            });
+        });
+
+    });
+
+});


### PR DESCRIPTION
Add a new `fabric:go` debug launch type that allows you to debug a Go smart contract.

Separate the language independent parts of the existing debug code into a base class `FabricDebugConfigurationProvider`, and then rework the `fabric:node` debug code into `FabricNodeDebugConfigurationProvider`.

Also, I've changed the way we launch the debugger so that we cancel the current debugging session from our debug code by returning `undefined`, after we launch another debugging session with our resolved configuration. This works better than before because it means the Go/Node.js debug configuration providers actually run and resolve the configuration as well - which means we can remove all the tsconfig/out files stuff we have because they'll take care of it.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>