### PR TITLE
Removed unnecessary outputAdapter.log call

### DIFF
--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -72,7 +72,7 @@ export async function createSmartContractProject(generator: string = 'fabric:con
 
     let smartContractLanguageOptions: string[];
     let smartContractLanguage: string;
-    outputAdapter.log(LogType.INFO, 'Getting smart contract languages...');
+    
     try {
         smartContractLanguageOptions = await getSmartContractLanguageOptionsWithProgress();
     } catch (error) {


### PR DESCRIPTION
The output from `outputAdapter.log()` is provided by `getSmartContractLanguageOptionsWithProgress ()`