### PR TITLE
New Add Wallet Command (closes #705)

### DIFF
--- a/client/ExtensionCommands.ts
+++ b/client/ExtensionCommands.ts
@@ -50,6 +50,7 @@ export class ExtensionCommands {
 
     // WALLET VIEW
     static readonly REFRESH_WALLETS: string = 'walletExplorer.refreshEntry';
+    static readonly ADD_WALLET: string = 'walletExplorer.addWalletEntry';
 
     // NO VIEW
     static readonly OPEN_HOME_PAGE: string = 'extensionHome.open';

--- a/client/package.json
+++ b/client/package.json
@@ -73,6 +73,7 @@
             "aRuntimeOpsExplorer.upgradeSmartContractEntry",
             "aRuntimeOpsExplorer.createNewIdentityEntry",
             "walletExplorer.refreshEntry",
+            "walletExplorer.addWalletEntry",
             "extensionHome.open"
         ]
     },
@@ -330,6 +331,15 @@
                     "dark": "resources/dark/refresh.svg"
                 },
                 "category": "IBM Blockchain Platform"
+            },
+            {
+                "command": "walletExplorer.addWalletEntry",
+                "title": "Add Wallet",
+                "icon": {
+                    "light": "resources/light/add_light.svg",
+                    "dark": "resources/dark/add.svg"
+                },
+                "category": "IBM Blockchain Platform"
             }
         ],
         "menus": {
@@ -428,6 +438,11 @@
                 },
                 {
                     "command": "walletExplorer.refreshEntry",
+                    "when": "view == walletExplorer",
+                    "group": "navigation"
+                },
+                {
+                    "command": "walletExplorer.addWalletEntry",
                     "when": "view == walletExplorer",
                     "group": "navigation"
                 }

--- a/client/src/commands/addGatewayCommand.ts
+++ b/client/src/commands/addGatewayCommand.ts
@@ -13,7 +13,7 @@
 */
 'use strict';
 import * as vscode from 'vscode';
-import {UserInputUtil} from './UserInputUtil';
+import { UserInputUtil } from './UserInputUtil';
 import { ParsedCertificate } from '../fabric/ParsedCertificate';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../logging/OutputAdapter';

--- a/client/src/commands/addWalletCommand.ts
+++ b/client/src/commands/addWalletCommand.ts
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+'use strict';
+import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
+import { LogType } from '../logging/OutputAdapter';
+import { UserInputUtil } from './UserInputUtil';
+import * as vscode from 'vscode';
+import { FabricWalletRegistry } from '../fabric/FabricWalletRegistry';
+import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
+
+export async function addWallet(): Promise<void> {
+    const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
+    outputAdapter.log(LogType.INFO, undefined, 'addWallet');
+
+    try {
+        // Ask for wallet name
+        const walletName: string = await UserInputUtil.showInputBox('Enter a name for the wallet');
+        if (!walletName) {
+            // User cancelled dialog box
+            return Promise.resolve();
+        }
+        // TODO: correct user flows for different methods to add a wallet
+        // User has a wallet - get the path - ask them to browse for it
+        const quickPickItems: string[] = [UserInputUtil.BROWSE_LABEL];
+        const openDialogOptions: vscode.OpenDialogOptions = {
+            canSelectFiles: false,
+            canSelectFolders: true,
+            canSelectMany: false,
+            openLabel: 'Select',
+        };
+        const walletPath: string = await UserInputUtil.browseEdit('Enter a file path to a wallet directory', quickPickItems, openDialogOptions) as string;
+        if (!walletPath) {
+            // User cancelled dialog box
+            return Promise.resolve();
+        }
+
+        // Add the wallet to the registry
+        const fabricWalletRegistry: FabricWalletRegistry = FabricWalletRegistry.instance();
+        const fabricWalletRegistryEntry: FabricWalletRegistryEntry = new FabricWalletRegistryEntry();
+        fabricWalletRegistryEntry.name = walletName;
+        fabricWalletRegistryEntry.walletPath = walletPath;
+        await fabricWalletRegistry.add(fabricWalletRegistryEntry);
+
+        outputAdapter.log(LogType.SUCCESS, 'Successfully added a new wallet');
+
+    } catch (error) {
+        outputAdapter.log(LogType.ERROR, `Failed to add a new wallet: ${error.message}`, `Failed to add a new wallet: ${error.message}`);
+    }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -59,6 +59,7 @@ import { upgradeSmartContract } from './commands/upgradeCommand';
 import { openFabricRuntimeTerminal } from './commands/openFabricRuntimeTerminal';
 import { exportConnectionDetails } from './commands/exportConnectionDetailsCommand';
 import { createNewIdentity } from './commands/createNewIdentityCommand';
+import { addWallet } from './commands/addWalletCommand';
 import { LogType } from './logging/OutputAdapter';
 import { HomeView } from './webview/HomeView';
 import { SampleView } from './webview/SampleView';
@@ -212,6 +213,7 @@ export async function registerCommands(context: vscode.ExtensionContext): Promis
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.UPGRADE_SMART_CONTRACT, (instantiatedChainCodeTreeItem?: InstantiatedTreeItem) => upgradeSmartContract(instantiatedChainCodeTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.CREATE_NEW_IDENTITY, (certificateAuthorityTreeItem?: CertificateAuthorityTreeItem) => createNewIdentity(certificateAuthorityTreeItem)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.REFRESH_WALLETS, (element: BlockchainTreeItem) => blockchainWalletExplorerProvider.refresh(element)));
+    context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.ADD_WALLET, () => addWallet()));
 
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_HOME_PAGE, async () => await HomeView.openHomePage(context)));
     context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_SAMPLE_PAGE, async (repoName: string, sampleName: string) => await SampleView.openContractSample(context, repoName, sampleName)));

--- a/client/test/commands/addWalletCommand.test.ts
+++ b/client/test/commands/addWalletCommand.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import { TestUtil } from '../TestUtil';
+import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
+import { LogType } from '../../src/logging/OutputAdapter';
+import { UserInputUtil } from '../../src/commands/UserInputUtil';
+import { ExtensionCommands } from '../../ExtensionCommands';
+import { FabricWalletRegistry } from '../../src/fabric/FabricWalletRegistry';
+
+// tslint:disable no-unused-expression
+const should: Chai.Should = chai.should();
+chai.should();
+chai.use(sinonChai);
+
+describe('AddGatewayCommand', () => {
+    let mySandBox: sinon.SinonSandbox;
+    let logSpy: sinon.SinonSpy;
+    let showInputBoxStub: sinon.SinonStub;
+    let browseEditStub: sinon.SinonStub;
+    let walletName: string;
+
+    before(async () => {
+        await TestUtil.setupTests();
+        await TestUtil.storeWalletsConfig();
+    });
+
+    after(async () => {
+        await TestUtil.restoreWalletsConfig();
+    });
+
+    beforeEach(async () => {
+        mySandBox = sinon.createSandbox();
+        logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
+
+        await vscode.workspace.getConfiguration().update('fabric.wallets', [], vscode.ConfigurationTarget.Global);
+        showInputBoxStub = mySandBox.stub(vscode.window, 'showInputBox');
+        browseEditStub = mySandBox.stub(UserInputUtil, 'browseEdit');
+    });
+
+    afterEach(async () => {
+        mySandBox.restore();
+    });
+
+    it('should add a new wallet', async () => {
+        walletName = 'purpleWallet';
+        showInputBoxStub.resolves(walletName);
+        browseEditStub.resolves('/some/path');
+
+        await vscode.commands.executeCommand(ExtensionCommands.ADD_WALLET);
+
+        const wallets: Array<any> = vscode.workspace.getConfiguration().get('fabric.wallets');
+
+        wallets.length.should.equal(1);
+        wallets[0].should.deep.equal({
+            name: 'purpleWallet',
+            walletPath: '/some/path'
+        });
+        logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully added a new wallet');
+    });
+
+    it('should handle the user cancelling providing a wallet name', async () => {
+        showInputBoxStub.resolves();
+
+        await vscode.commands.executeCommand(ExtensionCommands.ADD_WALLET);
+        browseEditStub.should.not.have.been.called;
+        logSpy.should.not.have.been.calledWith(LogType.SUCCESS);
+    });
+
+    it('should handle the user cancelling providing a wallet path', async () => {
+        showInputBoxStub.resolves('test');
+        browseEditStub.resolves();
+
+        await vscode.commands.executeCommand(ExtensionCommands.ADD_WALLET);
+        logSpy.should.not.have.been.calledWith(LogType.SUCCESS);
+    });
+
+    it('should handle errors adding a new wallet', async () => {
+        const walletRegistryAddStub: sinon.SinonStub = mySandBox.stub(
+            FabricWalletRegistry.instance(), 'add').rejects( { message: 'something terrible has happened'});
+        showInputBoxStub.resolves('test');
+        browseEditStub.resolves('/some/path');
+
+        await vscode.commands.executeCommand(ExtensionCommands.ADD_WALLET);
+
+        const wallets: Array<any> = vscode.workspace.getConfiguration().get('fabric.wallets');
+        wallets.length.should.equal(0);
+        walletRegistryAddStub.should.have.been.calledOnce;
+        logSpy.should.have.been.calledWith(LogType.ERROR, 'Failed to add a new wallet: something terrible has happened', 'Failed to add a new wallet: something terrible has happened');
+    });
+
+});

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -106,6 +106,7 @@ describe('Extension Tests', () => {
             ExtensionCommands.UPGRADE_SMART_CONTRACT,
             ExtensionCommands.CREATE_NEW_IDENTITY,
             ExtensionCommands.REFRESH_WALLETS,
+            ExtensionCommands.ADD_WALLET,
             ExtensionCommands.OPEN_HOME_PAGE
         ]);
     });
@@ -145,6 +146,7 @@ describe('Extension Tests', () => {
             `onCommand:${ExtensionCommands.UPGRADE_SMART_CONTRACT}`,
             `onCommand:${ExtensionCommands.CREATE_NEW_IDENTITY}`,
             `onCommand:${ExtensionCommands.REFRESH_WALLETS}`,
+            `onCommand:${ExtensionCommands.ADD_WALLET}`,
             `onCommand:${ExtensionCommands.OPEN_HOME_PAGE}`,
             `onDebug`
         ]);


### PR DESCRIPTION
Added a new "Add Wallet" command with some basic functionality. Doesn't currently allow the user to select method for importing wallet, I wanted to add that after I've got the code in #640 

Signed-off-by: heatherlp <heatherpollard0@gmail.com>