### PR TITLE
Separate client and runtime connections (contributes to #776)

### DIFF
--- a/client/integrationTest/integrationTestUtil.ts
+++ b/client/integrationTest/integrationTestUtil.ts
@@ -29,7 +29,7 @@ import { PackageRegistry } from '../src/packages/PackageRegistry';
 import { ExtensionCommands } from '../ExtensionCommands';
 import { FabricWalletRegistryEntry } from '../src/fabric/FabricWalletRegistryEntry';
 import { FabricConnectionManager } from '../src/fabric/FabricConnectionManager';
-import { IFabricConnection } from '../src/fabric/IFabricConnection';
+import { IFabricClientConnection } from '../src/fabric/IFabricClientConnection';
 
 // tslint:disable no-unused-expression
 const should: Chai.Should = chai.should();
@@ -170,7 +170,7 @@ export class IntegrationTestUtil {
 
         await vscode.commands.executeCommand(ExtensionCommands.CONNECT, gatewayEntry);
 
-        const fabricConnection: IFabricConnection = FabricConnectionManager.instance().getConnection();
+        const fabricConnection: IFabricClientConnection = FabricConnectionManager.instance().getConnection();
         should.exist(fabricConnection);
     }
 

--- a/client/integrationTest/nodeTests/integrationNode.test.ts
+++ b/client/integrationTest/nodeTests/integrationNode.test.ts
@@ -27,7 +27,6 @@ import { TestUtil } from '../../test/TestUtil';
 import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
 import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
 import { FabricRuntime } from '../../src/fabric/FabricRuntime';
-import { IFabricConnection } from '../../src/fabric/IFabricConnection';
 import { MetadataUtil } from '../../src/util/MetadataUtil';
 import { IntegrationTestUtil } from '../integrationTestUtil';
 import { RuntimeTreeItem } from '../../src/explorer/runtimeOps/RuntimeTreeItem';
@@ -42,6 +41,7 @@ import { CommandUtil } from '../../src/util/CommandUtil';
 import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
 import { PackageRegistry } from '../../src/packages/PackageRegistry';
 import { GatewayTreeItem } from '../../src/explorer/model/GatewayTreeItem';
+import { IFabricClientConnection } from '../../src/fabric/IFabricClientConnection';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -361,7 +361,7 @@ describe('Integration Tests for Node Smart Contracts', () => {
 
                 await integrationTestUtil.packageSmartContract();
 
-                const fabricConnection: IFabricConnection = FabricConnectionManager.instance().getConnection();
+                const fabricConnection: IFabricClientConnection = FabricConnectionManager.instance().getConnection();
                 should.exist(fabricConnection);
 
                 const allPackages: Array<PackageRegistryEntry> = await PackageRegistry.instance().getAll();
@@ -470,7 +470,7 @@ describe('Integration Tests for Node Smart Contracts', () => {
         }
         openFileNameArray.includes(pathToTestFile).should.be.true;
         // Get the smart contract metadata
-        const connection: IFabricConnection = FabricConnectionManager.instance().getConnection();
+        const connection: IFabricClientConnection = FabricConnectionManager.instance().getConnection();
         const smartContractTransactionsMap: Map<string, string[]> = await MetadataUtil.getTransactionNames(connection, smartContractName, 'mychannel');
         let smartContractTransactionsArray: string[];
         let contractName: string = '';

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -19,7 +19,6 @@ import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
 import { PackageRegistry } from '../packages/PackageRegistry';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { FabricGatewayRegistryEntry } from '../fabric/FabricGatewayRegistryEntry';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { MetadataUtil } from '../util/MetadataUtil';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../logging/OutputAdapter';
@@ -31,6 +30,8 @@ import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
 import { FabricWalletRegistry } from '../fabric/FabricWalletRegistry';
 import { IFabricWallet } from '../fabric/IFabricWallet';
 import { FabricWalletGeneratorFactory } from '../fabric/FabricWalletGeneratorFactory';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
+import { IFabricClientConnection } from '../fabric/IFabricClientConnection';
 
 export interface IBlockchainQuickPickItem<T = undefined> extends vscode.QuickPickItem {
     data: T;
@@ -176,7 +177,7 @@ export class UserInputUtil {
     }
 
     public static async showPeerQuickPickBox(prompt: string): Promise<string | undefined> {
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const peerNames: Array<string> = connection.getAllPeerNames();
 
         const quickPickOptions: vscode.QuickPickOptions = {
@@ -189,7 +190,7 @@ export class UserInputUtil {
     }
 
     public static async showChaincodeAndVersionQuickPick(prompt: string, peers: Set<string>, contractName?: string, contractVersion?: string): Promise<IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }> | undefined> {
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const tempQuickPickItems: IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>[] = [];
 
         // Get all installed smart contracts
@@ -429,7 +430,7 @@ export class UserInputUtil {
 
     public static async showInstantiatedSmartContractsQuickPick(prompt: string, channelName?: string): Promise<IBlockchainQuickPickItem<{ name: string, channel: string, version: string }> | undefined> {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
         let channels: Array<string> = [];
         if (!channelName) {
@@ -485,7 +486,7 @@ export class UserInputUtil {
 
     public static async showTransactionQuickPick(prompt: string, chaincodeName: string, channelName: string): Promise<IBlockchainQuickPickItem<{ name: string, contract: string }> | undefined> {
         const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
-        const connection: IFabricConnection = fabricConnectionManager.getConnection();
+        const connection: IFabricClientConnection = fabricConnectionManager.getConnection();
 
         if (!connection) {
             VSCodeBlockchainOutputAdapter.instance().log(LogType.ERROR, 'No connection to a blockchain found');
@@ -524,7 +525,7 @@ export class UserInputUtil {
 
     public static async showInstallableSmartContractsQuickPick(prompt: string, peers: Set<string>): Promise<IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }> | undefined> {
         // Get connection
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
         const quickPickItems: IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>[] = [];
         // Get packaged contracts
@@ -626,7 +627,7 @@ export class UserInputUtil {
     }
 
     public static async showCertificateAuthorityQuickPickBox(prompt: string): Promise<string | undefined> {
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const caNameOption: string = connection.getCertificateAuthorityName();
         const caNames: string[] = [caNameOption];
 
@@ -758,7 +759,7 @@ export class UserInputUtil {
     }
 
     private static async getChannels(): Promise<Array<IBlockchainQuickPickItem<Set<string>>>> {
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
         const quickPickItems: Array<IBlockchainQuickPickItem<Set<string>>> = [];
         const peerNames: Array<string> = connection.getAllPeerNames();
@@ -780,7 +781,7 @@ export class UserInputUtil {
         return quickPickItems;
     }
 
-    private static async getInstalledContracts(connection: IFabricConnection, peers: Set<string>): Promise<IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>[]> {
+    private static async getInstalledContracts(connection: IFabricRuntimeConnection, peers: Set<string>): Promise<IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>[]> {
         const tempQuickPickItems: IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>[] = [];
         for (const peer of peers) {
             const chaincodes: Map<string, Array<string>> = await connection.getInstalledChaincode(peer);

--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -14,7 +14,6 @@
 'use strict';
 import * as vscode from 'vscode';
 import { UserInputUtil, IBlockchainQuickPickItem } from './UserInputUtil';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { FabricConnectionFactory } from '../fabric/FabricConnectionFactory';
 import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
 import { FabricGatewayRegistryEntry } from '../fabric/FabricGatewayRegistryEntry';
@@ -28,6 +27,7 @@ import { IFabricWalletGenerator } from '../fabric/IFabricWalletGenerator';
 import { FabricWalletGeneratorFactory } from '../fabric/FabricWalletGeneratorFactory';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
+import { IFabricClientConnection } from '../fabric/IFabricClientConnection';
 
 export async function connect(gatewayRegistryEntry: FabricGatewayRegistryEntry, identityName?: string): Promise<void> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -70,7 +70,7 @@ export async function connect(gatewayRegistryEntry: FabricGatewayRegistryEntry, 
         identityName = identityNames[0];
     }
 
-    let connection: IFabricConnection;
+    let connection: IFabricClientConnection;
     if (gatewayRegistryEntry.managedRuntime) {
 
         const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
@@ -85,14 +85,13 @@ export async function connect(gatewayRegistryEntry: FabricGatewayRegistryEntry, 
         }
 
         gatewayRegistryEntry.connectionProfilePath = await runtime.getConnectionProfilePath();
-        connection = FabricConnectionFactory.createFabricRuntimeConnection(runtime);
         runtimeData = 'managed runtime';
-    } else {
-        const connectionData: { connectionProfilePath: string } = {
-            connectionProfilePath: gatewayRegistryEntry.connectionProfilePath
-        };
-        connection = FabricConnectionFactory.createFabricClientConnection(connectionData);
     }
+
+    const connectionData: { connectionProfilePath: string } = {
+        connectionProfilePath: gatewayRegistryEntry.connectionProfilePath
+    };
+    connection = FabricConnectionFactory.createFabricClientConnection(connectionData);
 
     try {
         await connection.connect(wallet, identityName);

--- a/client/src/commands/createNewIdentityCommand.ts
+++ b/client/src/commands/createNewIdentityCommand.ts
@@ -18,11 +18,11 @@ import { CertificateAuthorityTreeItem } from '../explorer/runtimeOps/Certificate
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../logging/OutputAdapter';
 import { UserInputUtil } from './UserInputUtil';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { IFabricWallet } from '../fabric/IFabricWallet';
 import { FabricRuntime } from '../fabric/FabricRuntime';
 import { FabricConnectionFactory } from '../fabric/FabricConnectionFactory';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export async function createNewIdentity(certificateAuthorityTreeItem?: CertificateAuthorityTreeItem): Promise<void> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -53,7 +53,7 @@ export async function createNewIdentity(certificateAuthorityTreeItem?: Certifica
         return;
     }
 
-    let connection: IFabricConnection;
+    let connection: IFabricRuntimeConnection;
 
     try {
         const mspid: string = 'Org1MSP';

--- a/client/src/commands/installCommand.ts
+++ b/client/src/commands/installCommand.ts
@@ -17,12 +17,12 @@ import { IBlockchainQuickPickItem, UserInputUtil } from './UserInputUtil';
 import { PeerTreeItem } from '../explorer/runtimeOps/PeerTreeItem';
 import { BlockchainTreeItem } from '../explorer/model/BlockchainTreeItem';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../logging/OutputAdapter';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { VSCodeBlockchainDockerOutputAdapter } from '../logging/VSCodeBlockchainDockerOutputAdapter';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export async function installSmartContract(treeItem?: BlockchainTreeItem, peerNames?: Set<string>, chosenPackage?: PackageRegistryEntry): Promise<PackageRegistryEntry | boolean> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -70,7 +70,7 @@ export async function installSmartContract(treeItem?: BlockchainTreeItem, peerNa
 
         }
 
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
         const promises: Promise<string | void>[] = [];
         for (const peer of peerNames) {

--- a/client/src/commands/instantiateCommand.ts
+++ b/client/src/commands/instantiateCommand.ts
@@ -16,7 +16,6 @@ import * as vscode from 'vscode';
 import { IBlockchainQuickPickItem, UserInputUtil } from './UserInputUtil';
 import { ChannelTreeItem } from '../explorer/model/ChannelTreeItem';
 import { BlockchainTreeItem } from '../explorer/model/BlockchainTreeItem';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { Reporter } from '../util/Reporter';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
@@ -24,6 +23,7 @@ import { LogType } from '../logging/OutputAdapter';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { VSCodeBlockchainDockerOutputAdapter } from '../logging/VSCodeBlockchainDockerOutputAdapter';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export async function instantiateSmartContract(treeItem?: BlockchainTreeItem): Promise<void> {
 
@@ -110,7 +110,7 @@ export async function instantiateSmartContract(treeItem?: BlockchainTreeItem): P
         }, async (progress: vscode.Progress<{ message: string }>) => {
 
             progress.report({ message: 'Instantiating Smart Contract' });
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
             VSCodeBlockchainDockerOutputAdapter.instance().show();
             if (packageEntry) {

--- a/client/src/commands/testSmartContractCommand.ts
+++ b/client/src/commands/testSmartContractCommand.ts
@@ -19,7 +19,6 @@ import * as path from 'path';
 import * as os from 'os';
 import { UserInputUtil, IBlockchainQuickPickItem, LanguageQuickPickItem } from './UserInputUtil';
 import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { Reporter } from '../util/Reporter';
 import { CommandUtil } from '../util/CommandUtil';
@@ -29,6 +28,7 @@ import { MetadataUtil } from '../util/MetadataUtil';
 import { LogType } from '../logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
+import { IFabricClientConnection } from '../fabric/IFabricClientConnection';
 
 export async function testSmartContract(chaincode?: InstantiatedContractTreeItem): Promise<void> {
 
@@ -71,7 +71,7 @@ export async function testSmartContract(chaincode?: InstantiatedContractTreeItem
     console.log('testSmartContractCommand: chaincode to generate tests for is: ' + chaincodeLabel);
 
     // Get metadata
-    const connection: IFabricConnection = FabricConnectionManager.instance().getConnection();
+    const connection: IFabricClientConnection = FabricConnectionManager.instance().getConnection();
 
     const transactions: Map<string, any[]> = await MetadataUtil.getTransactions(connection, chaincodeName, channelName, true);
     if (transactions.size === 0) {

--- a/client/src/commands/upgradeCommand.ts
+++ b/client/src/commands/upgradeCommand.ts
@@ -14,7 +14,6 @@
 'use strict';
 import * as vscode from 'vscode';
 import { IBlockchainQuickPickItem, UserInputUtil } from './UserInputUtil';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { Reporter } from '../util/Reporter';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
@@ -24,6 +23,7 @@ import { ChannelTreeItem } from '../explorer/model/ChannelTreeItem';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { InstantiatedTreeItem } from '../explorer/model/InstantiatedTreeItem';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export async function upgradeSmartContract(treeItem?: BlockchainTreeItem): Promise<void> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -126,7 +126,7 @@ export async function upgradeSmartContract(treeItem?: BlockchainTreeItem): Promi
         }, async (progress: vscode.Progress<{message: string}>) => {
 
             progress.report({message: 'Upgrading Smart Contract'});
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
             if (packageEntry) {
                 // If the package has been installed as part of this command

--- a/client/src/debug/FabricDebugConfigurationProvider.ts
+++ b/client/src/debug/FabricDebugConfigurationProvider.ts
@@ -17,11 +17,11 @@ import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { FabricRuntime } from '../fabric/FabricRuntime';
 import * as dateFormat from 'dateformat';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { FabricGatewayRegistryEntry } from '../fabric/FabricGatewayRegistryEntry';
 import { LogType } from '../logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export abstract class FabricDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -125,7 +125,7 @@ export abstract class FabricDebugConfigurationProvider implements vscode.DebugCo
         connectionRegistry.managedRuntime = true;
 
         await vscode.commands.executeCommand(ExtensionCommands.CONNECT, connectionRegistry);
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         if (!connection) {
             // either the user cancelled or there was an error so don't carry on
             return [];

--- a/client/src/explorer/gatewayExplorer.ts
+++ b/client/src/explorer/gatewayExplorer.ts
@@ -15,7 +15,6 @@
 // tslint:disable max-classes-per-file
 'use strict';
 import * as vscode from 'vscode';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { ChannelTreeItem } from './model/ChannelTreeItem';
 import { BlockchainTreeItem } from './model/BlockchainTreeItem';
 import { GatewayTreeItem } from './model/GatewayTreeItem';
@@ -36,6 +35,7 @@ import { FabricGatewayRegistry } from '../fabric/FabricGatewayRegistry';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { InstantiatedContractTreeItem } from './model/InstantiatedContractTreeItem';
 import { InstantiatedTreeItem } from './runtimeOps/InstantiatedTreeItem';
+import { IFabricClientConnection } from '../fabric/IFabricClientConnection';
 
 export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProvider {
 
@@ -53,7 +53,7 @@ export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProv
     constructor() {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
 
-        FabricConnectionManager.instance().on('connected', async (connection: IFabricConnection) => {
+        FabricConnectionManager.instance().on('connected', async (connection: IFabricClientConnection) => {
             try {
                 await this.connect(connection);
             } catch (error) {
@@ -73,7 +73,7 @@ export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProv
         this._onDidChangeTreeData.fire(element);
     }
 
-    async connect(connection: IFabricConnection): Promise<void> {
+    async connect(connection: IFabricClientConnection): Promise<void> {
         console.log('connect', connection);
         // This controls which menu buttons appear
         await vscode.commands.executeCommand('setContext', 'blockchain-connected', true);
@@ -218,7 +218,7 @@ export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProv
         const tree: Array<InstantiatedTreeItem> = [];
 
         for (const instantiatedChaincode of channelTreeElement.chaincodes) {
-            const connection: IFabricConnection = await FabricConnectionManager.instance().getConnection();
+            const connection: IFabricClientConnection = await FabricConnectionManager.instance().getConnection();
             const contracts: Array<string> = await MetadataUtil.getContractNames(connection, instantiatedChaincode.name, channelTreeElement.label);
             if (!contracts) {
                 tree.push(new InstantiatedChaincodeTreeItem(this, instantiatedChaincode.name, channelTreeElement, instantiatedChaincode.version, vscode.TreeItemCollapsibleState.None, contracts, true));
@@ -238,7 +238,7 @@ export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProv
         console.log('createContractsTree', chainCodeElement);
         const tree: Array<any> = [];
         for (const contract of chainCodeElement.contracts) {
-            const connection: IFabricConnection = await FabricConnectionManager.instance().getConnection();
+            const connection: IFabricClientConnection = await FabricConnectionManager.instance().getConnection();
             const transactionNamesMap: Map<string, string[]> = await MetadataUtil.getTransactionNames(connection, chainCodeElement.name, chainCodeElement.channel.label);
             const transactionNames: string[] = transactionNamesMap.get(contract);
             if (contract === '' || chainCodeElement.contracts.length === 1) {
@@ -268,7 +268,7 @@ export class BlockchainGatewayExplorerProvider implements BlockchainExplorerProv
             console.log('createConnectedTree');
             const tree: Array<BlockchainTreeItem> = [];
 
-            const connection: IFabricConnection = await FabricConnectionManager.instance().getConnection();
+            const connection: IFabricClientConnection = await FabricConnectionManager.instance().getConnection();
             const gatewayRegistryEntry: FabricGatewayRegistryEntry = FabricConnectionManager.instance().getGatewayRegistryEntry();
             tree.push(new ConnectedTreeItem(this, `Connected via gateway: ${gatewayRegistryEntry.name}`, gatewayRegistryEntry, 0));
             tree.push(new ConnectedTreeItem(this, `Using ID: ${connection.identityName}`, gatewayRegistryEntry, 0));

--- a/client/src/explorer/runtimeOpsExplorer.ts
+++ b/client/src/explorer/runtimeOpsExplorer.ts
@@ -15,7 +15,6 @@
 // tslint:disable max-classes-per-file
 'use strict';
 import * as vscode from 'vscode';
-import { IFabricConnection } from '../fabric/IFabricConnection';
 import { PeerTreeItem } from './runtimeOps/PeerTreeItem';
 import { ChannelTreeItem } from './model/ChannelTreeItem';
 import { BlockchainTreeItem } from './model/BlockchainTreeItem';
@@ -42,6 +41,7 @@ import { MetadataUtil } from '../util/MetadataUtil';
 import { InstantiatedContractTreeItem } from './model/InstantiatedContractTreeItem';
 import { CertificateAuthorityTreeItem } from './runtimeOps/CertificateAuthorityTreeItem';
 import { OrdererTreeItem } from './runtimeOps/OrdererTreeItem';
+import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
 
 export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProvider {
 
@@ -168,7 +168,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
     private async createChannelMap(): Promise<Map<string, Array<string>>> {
         console.log('createChannelMap');
 
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const allPeerNames: Array<string> = connection.getAllPeerNames();
 
         const channelMap: Map<string, Array<string>> = new Map<string, Array<string>>();
@@ -236,7 +236,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
         const tree: Array<BlockchainTreeItem> = [];
 
         try {
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
             const allPeerNames: Array<string> = connection.getAllPeerNames();
 
             for (const peer of allPeerNames) {
@@ -268,7 +268,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
         const tree: Array<BlockchainTreeItem> = [];
 
         try {
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
             const channelMap: Map<string, Array<string>> = await this.createChannelMap();
             const channels: Array<string> = Array.from(channelMap.keys());
             for (const channel of channels) {
@@ -297,7 +297,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
         };
 
         try {
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
             const channelMap: Map<string, Array<string>> = await this.createChannelMap();
             const channels: Array<string> = Array.from(channelMap.keys());
             for (const channel of channels) {
@@ -327,7 +327,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
         const tree: Array<BlockchainTreeItem> = [];
         let command: vscode.Command;
         try {
-            const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+            const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
             const allPeerNames: Array<string> = connection.getAllPeerNames();
             for (const peer of allPeerNames) {
                 const chaincodes: Map<string, Array<string>> = await connection.getInstalledChaincode(peer);
@@ -353,7 +353,7 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
     }
 
     private async getOrderers(): Promise<Set<string>> {
-        const connection: IFabricConnection = await FabricRuntimeManager.instance().getConnection();
+        const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const ordererSet: Set<string> = await connection.getOrderers();
 
         return ordererSet;

--- a/client/src/fabric/FabricClientConnection.ts
+++ b/client/src/fabric/FabricClientConnection.ts
@@ -13,12 +13,12 @@
 */
 'use strict';
 import { OutputAdapter } from '../logging/OutputAdapter';
-import { IFabricConnection } from './IFabricConnection';
 import { FabricConnection } from './FabricConnection';
 import { FabricWallet } from './FabricWallet';
 import { ExtensionUtil } from '../util/ExtensionUtil';
+import { IFabricClientConnection } from './IFabricClientConnection';
 
-export class FabricClientConnection extends FabricConnection implements IFabricConnection {
+export class FabricClientConnection extends FabricConnection implements IFabricClientConnection {
 
     private connectionProfilePath: string;
 

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -16,7 +16,6 @@
 import * as Client from 'fabric-client';
 import * as ClientCA from 'fabric-ca-client';
 import { Gateway, Network, Contract, GatewayOptions, FileSystemWallet, IdentityInfo } from 'fabric-network';
-import { IFabricConnection } from './IFabricConnection';
 import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import * as fs from 'fs-extra';
 import { LogType, OutputAdapter } from '../logging/OutputAdapter';
@@ -25,7 +24,7 @@ import { FabricWallet } from './FabricWallet';
 import { URL } from 'url';
 import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
 
-export abstract class FabricConnection implements IFabricConnection {
+export abstract class FabricConnection {
 
     public identityName: string;
     public wallet: FabricWalletRegistryEntry;

--- a/client/src/fabric/FabricConnectionFactory.ts
+++ b/client/src/fabric/FabricConnectionFactory.ts
@@ -12,13 +12,14 @@
  * limitations under the License.
 */
 'use strict';
-import { IFabricConnection } from './IFabricConnection';
 import { FabricRuntime } from './FabricRuntime';
 import { OutputAdapter } from '../logging/OutputAdapter';
+import { IFabricClientConnection } from './IFabricClientConnection';
+import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
 
 export class FabricConnectionFactory {
 
-    public static createFabricClientConnection(connection: any, outputAdapter?: OutputAdapter): IFabricConnection {
+    public static createFabricClientConnection(connection: any, outputAdapter?: OutputAdapter): IFabricClientConnection {
         if (!this.clientConnection) {
             this.clientConnection = require('./FabricClientConnection');
         }
@@ -26,7 +27,7 @@ export class FabricConnectionFactory {
         return new (this.clientConnection).FabricClientConnection(connection, outputAdapter);
     }
 
-    public static createFabricRuntimeConnection(runtime: FabricRuntime, outputAdapter?: OutputAdapter): IFabricConnection {
+    public static createFabricRuntimeConnection(runtime: FabricRuntime, outputAdapter?: OutputAdapter): IFabricRuntimeConnection {
         if (!this.runtimeConnection) {
             this.runtimeConnection = require('./FabricRuntimeConnection');
         }

--- a/client/src/fabric/FabricConnectionManager.ts
+++ b/client/src/fabric/FabricConnectionManager.ts
@@ -12,10 +12,10 @@
  * limitations under the License.
 */
 
-import { IFabricConnection } from './IFabricConnection';
 import { EventEmitter } from 'events';
 import { FabricGatewayRegistryEntry } from './FabricGatewayRegistryEntry';
 import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
+import { IFabricClientConnection } from './IFabricClientConnection';
 
 export class FabricConnectionManager extends EventEmitter {
 
@@ -25,14 +25,14 @@ export class FabricConnectionManager extends EventEmitter {
 
     private static _instance: FabricConnectionManager = new FabricConnectionManager();
 
-    private connection: IFabricConnection;
+    private connection: IFabricClientConnection;
     private gatewayRegistryEntry: FabricGatewayRegistryEntry;
 
     private constructor() {
         super();
     }
 
-    public getConnection(): IFabricConnection {
+    public getConnection(): IFabricClientConnection {
         return this.connection;
     }
 
@@ -40,7 +40,7 @@ export class FabricConnectionManager extends EventEmitter {
         return this.gatewayRegistryEntry;
     }
 
-    public connect(connection: IFabricConnection, gatewayRegistryEntry: FabricGatewayRegistryEntry): void {
+    public connect(connection: IFabricClientConnection, gatewayRegistryEntry: FabricGatewayRegistryEntry): void {
         this.connection = connection;
         this.gatewayRegistryEntry = gatewayRegistryEntry;
         this.emit('connected', connection);

--- a/client/src/fabric/FabricRuntimeConnection.ts
+++ b/client/src/fabric/FabricRuntimeConnection.ts
@@ -17,8 +17,9 @@ import { FabricConnection } from './FabricConnection';
 import { FabricRuntime } from './FabricRuntime';
 import { OutputAdapter } from '../logging/OutputAdapter';
 import { FabricWallet } from '../fabric/FabricWallet';
+import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
 
-export class FabricRuntimeConnection extends FabricConnection {
+export class FabricRuntimeConnection extends FabricConnection implements IFabricRuntimeConnection {
 
     constructor(private runtime: FabricRuntime, outputAdapter?: OutputAdapter) {
         super(outputAdapter);

--- a/client/src/fabric/FabricRuntimeManager.ts
+++ b/client/src/fabric/FabricRuntimeManager.ts
@@ -15,12 +15,12 @@
 import * as vscode from 'vscode';
 import { FabricRuntime, FabricRuntimeState } from './FabricRuntime';
 import { FabricRuntimePorts } from './FabricRuntimePorts';
-import { IFabricConnection } from './IFabricConnection';
 import { FabricConnectionFactory } from './FabricConnectionFactory';
 import { IFabricWallet } from './IFabricWallet';
 import { FabricWalletGeneratorFactory } from './FabricWalletGeneratorFactory';
 import { VSCodeBlockchainDockerOutputAdapter } from '../logging/VSCodeBlockchainDockerOutputAdapter';
 import { IFabricWalletGenerator } from './IFabricWalletGenerator';
+import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
 
 export class FabricRuntimeManager {
 
@@ -36,14 +36,14 @@ export class FabricRuntimeManager {
 
     private runtime: FabricRuntime;
 
-    private connection: IFabricConnection;
+    private connection: IFabricRuntimeConnection;
 
-    private connectingPromise: Promise<IFabricConnection>;
+    private connectingPromise: Promise<IFabricRuntimeConnection>;
 
     private constructor() {
     }
 
-    public async getConnection(): Promise<IFabricConnection> {
+    public async getConnection(): Promise<IFabricRuntimeConnection> {
         if (this.connectingPromise) {
             return this.connectingPromise;
         }
@@ -52,7 +52,7 @@ export class FabricRuntimeManager {
             return this.connection;
         }
 
-        this.connectingPromise = this.getConnectionInner().then((connection: IFabricConnection) => {
+        this.connectingPromise = this.getConnectionInner().then((connection: IFabricRuntimeConnection) => {
             this.connectingPromise = undefined;
             return connection;
         });
@@ -189,7 +189,7 @@ export class FabricRuntimeManager {
         return ports;
     }
 
-    private async getConnectionInner(): Promise<IFabricConnection> {
+    private async getConnectionInner(): Promise<IFabricRuntimeConnection> {
         const identityName: string = 'Admin@org1.example.com';
         const mspid: string = 'Org1MSP';
         const enrollmentID: string = 'admin';
@@ -207,7 +207,7 @@ export class FabricRuntimeManager {
             }
         });
 
-        const connection: IFabricConnection = FabricConnectionFactory.createFabricRuntimeConnection(runtime);
+        const connection: IFabricRuntimeConnection = FabricConnectionFactory.createFabricRuntimeConnection(runtime);
         const fabricWalletGenerator: IFabricWalletGenerator = FabricWalletGeneratorFactory.createFabricWalletGenerator();
 
         // our secret wallet

--- a/client/src/fabric/IFabricClientConnection.ts
+++ b/client/src/fabric/IFabricClientConnection.ts
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+
+import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
+import { IFabricWallet } from './IFabricWallet';
+import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
+
+export interface IFabricClientConnection {
+
+    identityName: string;
+
+    wallet: FabricWalletRegistryEntry;
+
+    connect(wallet: IFabricWallet, identityName: string): Promise<void>;
+
+    disconnect(): void;
+
+    getAllPeerNames(): Array<string>;
+
+    getAllChannelsForPeer(peerName: string): Promise<Array<string>>;
+
+    getOrganizations(channelName: string): Promise<Array<string>>;
+
+    getCertificateAuthorityName(): string;
+
+    getInstalledChaincode(peerName: string): Promise<Map<string, Array<string>>>;
+
+    getInstantiatedChaincode(channelName: string): Promise<Array<{name: string, version: string}>>;
+
+    getOrderers(): Promise<Set<string>>;
+
+    installChaincode(packageRegistryEntry: PackageRegistryEntry, peerName: string): Promise<void>;
+
+    instantiateChaincode(chaincodeName: string, version: string, channel: string, fcn: string, args: Array<string>): Promise<void>;
+
+    upgradeChaincode(chaincodeName: string, version: string, channel: string, fcn: string, args: Array<string>): Promise<void>;
+
+    isIBPConnection(): boolean;
+
+    getMetadata(instantiatedChaincodeName: string, channel: string): Promise<any>;
+
+    submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string, evaluate?: boolean): Promise<string | undefined>;
+
+    enroll(enrollmentID: string, enrollmentSecret: string): Promise<{certificate: string, privateKey: string}>;
+
+    register(enrollmentID: string, affiliation: string): Promise<string>;
+}

--- a/client/src/fabric/IFabricRuntimeConnection.ts
+++ b/client/src/fabric/IFabricRuntimeConnection.ts
@@ -17,7 +17,7 @@ import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { IFabricWallet } from './IFabricWallet';
 import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
 
-export interface IFabricConnection {
+export interface IFabricRuntimeConnection {
 
     identityName: string;
 

--- a/client/src/util/MetadataUtil.ts
+++ b/client/src/util/MetadataUtil.ts
@@ -12,14 +12,14 @@
  * limitations under the License.
 */
 'use strict';
-import {IFabricConnection} from '../fabric/IFabricConnection';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../logging/OutputAdapter';
+import { IFabricClientConnection } from '../fabric/IFabricClientConnection';
 
 // Functions for parsing metadata object
 export class MetadataUtil {
 
-    public static async getTransactionNames(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string): Promise<Map<string, string[]> | null> {
+    public static async getTransactionNames(connection: IFabricClientConnection, instantiatedChaincodeName: string, channelName: string): Promise<Map<string, string[]> | null> {
         const metadataTransactions: Map<string, any[]> = await this.getTransactions(connection, instantiatedChaincodeName, channelName);
         if (!metadataTransactions) {
             return null;
@@ -36,7 +36,7 @@ export class MetadataUtil {
         return transactionNames;
     }
 
-    public static async getContractNames(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string): Promise<string[] | null> {
+    public static async getContractNames(connection: IFabricClientConnection, instantiatedChaincodeName: string, channelName: string): Promise<string[] | null> {
         const metadataTransactions: Map<string, any[]> = await this.getTransactions(connection, instantiatedChaincodeName, channelName);
         if (!metadataTransactions) {
             return null;
@@ -51,7 +51,7 @@ export class MetadataUtil {
 
     }
 
-    public static async getTransactions(connection: IFabricConnection, instantiatedChaincodeName: string, channelName: string, checkForEmpty?: boolean): Promise<Map<string, any[]> | null> {
+    public static async getTransactions(connection: IFabricClientConnection, instantiatedChaincodeName: string, channelName: string, checkForEmpty?: boolean): Promise<Map<string, any[]> | null> {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
 
         let metadataObj: any = {

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -21,7 +21,6 @@ import * as myExtension from '../../src/extension';
 import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 import { IdentityInfo } from 'fabric-network';
 import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
-import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
 import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
 import { TestUtil } from '../TestUtil';
 import { FabricGatewayRegistry } from '../../src/fabric/FabricGatewayRegistry';
@@ -66,7 +65,6 @@ describe('ConnectCommand', () => {
         let mySandBox: sinon.SinonSandbox;
         let rootPath: string;
         let mockConnection: sinon.SinonStubbedInstance<FabricClientConnection>;
-        let mockRuntimeConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
         let mockRuntime: sinon.SinonStubbedInstance<FabricRuntime>;
         let logSpy: sinon.SinonSpy;
         let connectionMultiple: FabricGatewayRegistryEntry;
@@ -84,11 +82,8 @@ describe('ConnectCommand', () => {
 
             mockConnection = sinon.createStubInstance(FabricClientConnection);
             mockConnection.connect.resolves();
-            mockRuntimeConnection = sinon.createStubInstance(FabricRuntimeConnection);
-            mockRuntimeConnection.connect.resolves();
 
             mySandBox.stub(FabricConnectionFactory, 'createFabricClientConnection').returns(mockConnection);
-            mySandBox.stub(FabricConnectionFactory, 'createFabricRuntimeConnection').returns(mockRuntimeConnection);
 
             rootPath = path.dirname(__dirname);
 
@@ -316,9 +311,9 @@ describe('ConnectCommand', () => {
             it('should connect to a managed runtime using a quick pick', async () => {
                 await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
 
-                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricRuntimeConnection));
+                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
-                mockRuntimeConnection.connect.should.have.been.calledOnceWithExactly(testFabricWallet, identity.label);
+                mockConnection.connect.should.have.been.calledOnceWithExactly(testFabricWallet, identity.label);
             });
 
             it('should connect to a managed runtime with multiple identities, using a quick pick', async () => {
@@ -329,9 +324,9 @@ describe('ConnectCommand', () => {
 
                 await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
 
-                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricRuntimeConnection));
+                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.called;
-                mockRuntimeConnection.connect.should.have.been.calledWith(testFabricWallet, testIdentityName);
+                mockConnection.connect.should.have.been.calledWith(testFabricWallet, testIdentityName);
             });
 
             it('should connect to a managed runtime from the tree', async () => {
@@ -341,9 +336,9 @@ describe('ConnectCommand', () => {
 
                 await vscode.commands.executeCommand(myConnectionItem.command.command, ...myConnectionItem.command.arguments);
 
-                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricRuntimeConnection));
+                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
-                mockRuntimeConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
+                mockConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
             });
 
             it('should start a stopped fabric runtime before connecting', async () => {
@@ -355,9 +350,9 @@ describe('ConnectCommand', () => {
 
                 choseGatewayQuickPick.should.have.been.calledOnce;
                 startCommandStub.should.have.been.calledWith(ExtensionCommands.START_FABRIC);
-                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricRuntimeConnection));
+                connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
-                mockRuntimeConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
+                mockConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
 
                 logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'connect');
                 logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Connecting to ${connection.name}`);
@@ -386,7 +381,7 @@ describe('ConnectCommand', () => {
                 await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
 
                 choseIdentityQuickPick.should.have.been.called;
-                mockRuntimeConnection.connect.should.not.have.been.called;
+                mockConnection.connect.should.not.have.been.called;
             });
 
         });

--- a/client/test/fabric/FabricRuntimeManager.test.ts
+++ b/client/test/fabric/FabricRuntimeManager.test.ts
@@ -18,13 +18,13 @@ import { FabricRuntime, FabricRuntimeState } from '../../src/fabric/FabricRuntim
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { TestUtil } from '../TestUtil';
 import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
-import { IFabricConnection } from '../../src/fabric/IFabricConnection';
 import { FabricConnectionFactory } from '../../src/fabric/FabricConnectionFactory';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { FabricWallet } from '../../src/fabric/FabricWallet';
 import { FabricWalletGenerator } from '../../src/fabric/FabricWalletGenerator';
 import * as vscode from 'vscode';
+import { IFabricRuntimeConnection } from '../../src/fabric/IFabricRuntimeConnection';
 
 const should: Chai.Should = chai.should();
 
@@ -69,7 +69,7 @@ describe('FabricRuntimeManager', () => {
             runtimeManager['connection'] = connection;
             runtimeManager['connectingPromise'] = undefined;
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             result.should.deep.equal(connection);
         });
 
@@ -95,7 +95,7 @@ describe('FabricRuntimeManager', () => {
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'Admin@org1.example.com', 'Org1MSP');
             gatewayWalletStub.importIdentity.should.have.been.calledWith('myCert', 'myKey', 'Admin@org1.example.com', 'Org1MSP');
@@ -125,7 +125,7 @@ describe('FabricRuntimeManager', () => {
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.not.have.been.called;
             gatewayWalletStub.importIdentity.should.have.been.calledWith('myCert', 'myKey', 'Admin@org1.example.com', 'Org1MSP');
@@ -154,7 +154,7 @@ describe('FabricRuntimeManager', () => {
             const createWalletStub: sinon.SinonStub = sandbox.stub(FabricWalletGenerator.instance(), 'createLocalWallet');
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
 
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'Admin@org1.example.com', 'Org1MSP');
@@ -195,7 +195,7 @@ describe('FabricRuntimeManager', () => {
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'Admin@org1.example.com', 'Org1MSP');
             gatewayWalletStub.importIdentity.should.have.been.calledWith('myCert', 'myKey', 'Admin@org1.example.com', 'Org1MSP');
@@ -231,7 +231,7 @@ describe('FabricRuntimeManager', () => {
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'Admin@org1.example.com', 'Org1MSP');
             gatewayWalletStub.importIdentity.should.have.been.calledWith('myCert', 'myKey', 'Admin@org1.example.com', 'Org1MSP');
@@ -268,7 +268,7 @@ describe('FabricRuntimeManager', () => {
             createWalletStub.withArgs('local_wallet-ops').resolves(runtimeWalletStub);
             createWalletStub.withArgs('local_wallet').resolves(gatewayWalletStub);
 
-            const result: IFabricConnection = await runtimeManager.getConnection();
+            const result: IFabricRuntimeConnection = await runtimeManager.getConnection();
             connection.connect.should.have.been.calledWith(runtimeWalletStub, 'Admin@org1.example.com');
             runtimeWalletStub.importIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'Admin@org1.example.com', 'Org1MSP');
             gatewayWalletStub.importIdentity.should.have.been.calledWith('myCert', 'myKey', 'Admin@org1.example.com', 'Org1MSP');


### PR DESCRIPTION
The work for #776 requires that the runtime connection and runtime ops view works very differently to how it works today, so the time has come to split client and runtime connections apart.

This is the first stage of the changes where we simply separate the interfaces and make sure the right code is using the right one. Further changes will come where the methods on each interface are cut down, and common code moved into the right place.

- Split IFabricConnection into IFabricClientConnection and IFabricRuntimeConnection
- Gateway tasks (submit, evaluate, generate tests, etc) use IFabricClientConnection
- Ops tasks (install, instantiate, upgrade, etc) use IFabricRuntimeConnection
- Update the connect command to always use IFabricClientConnection, even when connecting to the local Fabric

I started off with this change, then found that we need to do this and backed it out:

- Update the create identity command to use the runtime managers connection object, not create its own each time

This is because we have to switch to the admin identity, instead of the Admin@org1.example.com identity, in order to perform CA operations. Will remove that later when the admin identity can be used everywhere!

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>