### PR TITLE
Clean up client and runtime connection interfaces (contributes to #776)

### DIFF
--- a/client/integrationTest/nodeTests/integrationNode.test.ts
+++ b/client/integrationTest/nodeTests/integrationNode.test.ts
@@ -42,6 +42,7 @@ import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
 import { PackageRegistry } from '../../src/packages/PackageRegistry';
 import { GatewayTreeItem } from '../../src/explorer/model/GatewayTreeItem';
 import { IFabricClientConnection } from '../../src/fabric/IFabricClientConnection';
+import { IFabricRuntimeConnection } from '../../src/fabric/IFabricRuntimeConnection';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -349,7 +350,10 @@ describe('Integration Tests for Node Smart Contracts', () => {
 
         ['JavaScript', 'TypeScript'].forEach((language: string) => {
 
-            it(`should create a ${language} smart contract, submit transactions, and generate tests`, async () => {
+            // Skipped; this isn't a valid test - it deploys to a remote Fabric using extension code, which is not possible. It also creates and
+            // opens the smart contract project, which also isn't valid in this scenario - it should be testing that you can do all of this by
+            // starting with the gateway connection and an instantiated smart contract.
+            it.skip(`should create a ${language} smart contract, submit transactions, and generate tests`, async () => {
                 const smartContractName: string = `my${language}SC3`;
 
                 await integrationTestUtil.createFabricConnection();
@@ -361,7 +365,7 @@ describe('Integration Tests for Node Smart Contracts', () => {
 
                 await integrationTestUtil.packageSmartContract();
 
-                const fabricConnection: IFabricClientConnection = FabricConnectionManager.instance().getConnection();
+                const fabricConnection: IFabricRuntimeConnection = null; // TODO, this is meant to be a remote Fabric and we can't deploy to it!
                 should.exist(fabricConnection);
 
                 const allPackages: Array<PackageRegistryEntry> = await PackageRegistry.instance().getAll();

--- a/client/src/explorer/runtimeOpsExplorer.ts
+++ b/client/src/explorer/runtimeOpsExplorer.ts
@@ -37,8 +37,6 @@ import { InstantiateCommandTreeItem } from './runtimeOps/InstantiateCommandTreeI
 import { InstallCommandTreeItem } from './runtimeOps/InstallCommandTreeItem';
 import { OrgTreeItem } from './runtimeOps/OrgTreeItem';
 import { ExtensionCommands } from '../../ExtensionCommands';
-import { MetadataUtil } from '../util/MetadataUtil';
-import { InstantiatedContractTreeItem } from './model/InstantiatedContractTreeItem';
 import { CertificateAuthorityTreeItem } from './runtimeOps/CertificateAuthorityTreeItem';
 import { OrdererTreeItem } from './runtimeOps/OrdererTreeItem';
 import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
@@ -305,12 +303,9 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
                 const peers: Array<string> = channelMap.get(channel);
                 const channelTreeItem: ChannelTreeItem = new ChannelTreeItem(this, channel, peers, chaincodes, vscode.TreeItemCollapsibleState.None);
                 for (const chaincode of chaincodes) {
-                    const transactions: Map<string, string[]> = await MetadataUtil.getTransactionNames(connection, chaincode.name, channel);
-                    if (!transactions) {
-                        tree.push(new InstantiatedChaincodeTreeItem(this, chaincode.name, channelTreeItem, chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
-                    } else {
-                        tree.push(new InstantiatedContractTreeItem(this, chaincode.name, channelTreeItem, chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
-                    }
+                    // Doesn't matter if this is a chaincode or a contract as this is the ops view, and
+                    // we shouldn't be exposing contracts or transaction functions in the ops view.
+                    tree.push(new InstantiatedChaincodeTreeItem(this, chaincode.name, channelTreeItem, chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
                 }
             }
         } catch (error) {

--- a/client/src/fabric/IFabricClientConnection.ts
+++ b/client/src/fabric/IFabricClientConnection.ts
@@ -13,7 +13,6 @@
 */
 'use strict';
 
-import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { IFabricWallet } from './IFabricWallet';
 import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
 
@@ -31,21 +30,7 @@ export interface IFabricClientConnection {
 
     getAllChannelsForPeer(peerName: string): Promise<Array<string>>;
 
-    getOrganizations(channelName: string): Promise<Array<string>>;
-
-    getCertificateAuthorityName(): string;
-
-    getInstalledChaincode(peerName: string): Promise<Map<string, Array<string>>>;
-
     getInstantiatedChaincode(channelName: string): Promise<Array<{name: string, version: string}>>;
-
-    getOrderers(): Promise<Set<string>>;
-
-    installChaincode(packageRegistryEntry: PackageRegistryEntry, peerName: string): Promise<void>;
-
-    instantiateChaincode(chaincodeName: string, version: string, channel: string, fcn: string, args: Array<string>): Promise<void>;
-
-    upgradeChaincode(chaincodeName: string, version: string, channel: string, fcn: string, args: Array<string>): Promise<void>;
 
     isIBPConnection(): boolean;
 
@@ -53,7 +38,4 @@ export interface IFabricClientConnection {
 
     submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string, evaluate?: boolean): Promise<string | undefined>;
 
-    enroll(enrollmentID: string, enrollmentSecret: string): Promise<{certificate: string, privateKey: string}>;
-
-    register(enrollmentID: string, affiliation: string): Promise<string>;
 }

--- a/client/src/fabric/IFabricRuntimeConnection.ts
+++ b/client/src/fabric/IFabricRuntimeConnection.ts
@@ -47,13 +47,8 @@ export interface IFabricRuntimeConnection {
 
     upgradeChaincode(chaincodeName: string, version: string, channel: string, fcn: string, args: Array<string>): Promise<void>;
 
-    isIBPConnection(): boolean;
-
-    getMetadata(instantiatedChaincodeName: string, channel: string): Promise<any>;
-
-    submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string, evaluate?: boolean): Promise<string | undefined>;
-
     enroll(enrollmentID: string, enrollmentSecret: string): Promise<{certificate: string, privateKey: string}>;
 
     register(enrollmentID: string, affiliation: string): Promise<string>;
+
 }

--- a/client/test/explorer/runtimeOpsExplorer.test.ts
+++ b/client/test/explorer/runtimeOpsExplorer.test.ts
@@ -39,7 +39,6 @@ import { OrgTreeItem } from '../../src/explorer/runtimeOps/OrgTreeItem';
 import { FabricRuntime } from '../../src/fabric/FabricRuntime';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { MetadataUtil } from '../../src/util/MetadataUtil';
-import { InstantiatedContractTreeItem } from '../../src/explorer/model/InstantiatedContractTreeItem';
 import { CertificateAuthorityTreeItem } from '../../src/explorer/runtimeOps/CertificateAuthorityTreeItem';
 import { OrdererTreeItem } from '../../src/explorer/runtimeOps/OrdererTreeItem';
 
@@ -460,14 +459,14 @@ describe('runtimeOpsExplorer', () => {
                 const contractTreeItems: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(allChildren[0]);
                 const instantiatedChaincodes: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(contractTreeItems[0]);
                 instantiatedChaincodes.length.should.equal(4);
-                const instantiatedChaincodeOne: InstantiatedContractTreeItem = instantiatedChaincodes[0] as InstantiatedContractTreeItem;
+                const instantiatedChaincodeOne: InstantiatedChaincodeTreeItem = instantiatedChaincodes[0] as InstantiatedChaincodeTreeItem;
                 instantiatedChaincodeOne.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
-                instantiatedChaincodeOne.contextValue.should.equal('blockchain-instantiated-contract-item');
+                instantiatedChaincodeOne.contextValue.should.equal('blockchain-instantiated-chaincode-item');
                 instantiatedChaincodeOne.label.should.equal('biscuit-network@0.7');
                 instantiatedChaincodeOne.tooltip.should.equal('Instantiated on: channelOne');
-                const instantiatedChaincodeTwo: InstantiatedContractTreeItem = instantiatedChaincodes[1] as InstantiatedContractTreeItem;
+                const instantiatedChaincodeTwo: InstantiatedChaincodeTreeItem = instantiatedChaincodes[1] as InstantiatedChaincodeTreeItem;
                 instantiatedChaincodeTwo.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
-                instantiatedChaincodeTwo.contextValue.should.equal('blockchain-instantiated-contract-item');
+                instantiatedChaincodeTwo.contextValue.should.equal('blockchain-instantiated-chaincode-item');
                 instantiatedChaincodeTwo.label.should.equal('cake-network@0.10');
                 instantiatedChaincodeTwo.tooltip.should.equal('Instantiated on: channelTwo');
                 const instantiatedChaincodeThree: InstantiatedChaincodeTreeItem = instantiatedChaincodes[2] as InstantiatedChaincodeTreeItem;


### PR DESCRIPTION
Remove client connection interface functions that are operational (install, instantiate, etc), and remove runtime connection interface functions that are not operational (submit transaction, get metadata, etc).

Had to clean up an integration test and some code in the Local Fabric Ops tree that tried to determine whether or not an instantiated chaincode uses the new programming model. It doesn't matter what kind of chaincode it is, as we don't show any detail, just the name, version, and the upgrade chaincode command.

This should ensure going forwards everyone uses the right type of connection for the right job.

The implementation still needs cleaning up and separating, but that will come in a subsequent PR.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>