### PR TITLE
UserInputUtil.getDirPath should be sync (contributes to #776)

### DIFF
--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -133,10 +133,9 @@ export class UserInputUtil {
      * @returns {String} Returns dir.
      *
      */
-    public static async getDirPath(dir: string): Promise<string> {
-
+    public static getDirPath(dir: string): string {
         if (dir.startsWith('~')) {
-            dir = await homeDir(dir.replace('~', ''));
+            dir = homeDir(dir.replace('~', ''));
         }
         return dir;
     }

--- a/client/src/commands/deleteGatewayCommand.ts
+++ b/client/src/commands/deleteGatewayCommand.ts
@@ -43,7 +43,7 @@ export async function deleteGateway(gatewayTreeItem: GatewayTreeItem): Promise<v
     }
 
     const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-    const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+    const homeExtDir: string = UserInputUtil.getDirPath(extDir);
     const gatewayPath: string = path.join(homeExtDir, gatewayRegistryEntry.name);
     await fs.remove(gatewayPath);
 

--- a/client/src/commands/importSmartContractPackageCommand.ts
+++ b/client/src/commands/importSmartContractPackageCommand.ts
@@ -42,7 +42,7 @@ export async function importSmartContractPackageCommand(): Promise<void> {
     try {
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
         const pkgDir: string = path.join(extDir, 'packages');
-        let resolvedPkgDir: string = await UserInputUtil.getDirPath(pkgDir);
+        let resolvedPkgDir: string = UserInputUtil.getDirPath(pkgDir);
         await fs.ensureDir(resolvedPkgDir);
 
         const packageName: string = path.basename(packagePath);

--- a/client/src/commands/packageSmartContractCommand.ts
+++ b/client/src/commands/packageSmartContractCommand.ts
@@ -39,7 +39,7 @@ export async function packageSmartContract(workspace?: vscode.WorkspaceFolder, o
         // Determine the directory that will contain the packages and ensure it exists.
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
         const pkgDir: string = path.join(extDir, 'packages');
-        resolvedPkgDir = await UserInputUtil.getDirPath(pkgDir);
+        resolvedPkgDir = UserInputUtil.getDirPath(pkgDir);
         await fs.ensureDir(resolvedPkgDir);
 
         // Choose the workspace directory.

--- a/client/src/fabric/FabricGatewayHelper.ts
+++ b/client/src/fabric/FabricGatewayHelper.ts
@@ -26,7 +26,7 @@ export class FabricGatewayHelper {
         try {
 
             const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-            const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+            const homeExtDir: string = UserInputUtil.getDirPath(extDir);
             const profileDirPath: string = path.join(homeExtDir, gatewayName);
             const profileExists: boolean = await fs.pathExists(profileDirPath);
 

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -161,7 +161,7 @@ export class FabricRuntime extends EventEmitter {
 
     public async getConnectionProfilePath(): Promise<string> {
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-        const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
         const dir: string = path.join(homeExtDir, this.name);
 
         return path.join(dir, 'connection.json');
@@ -243,7 +243,7 @@ export class FabricRuntime extends EventEmitter {
         const connectionProfile: string = JSON.stringify(connectionProfileObj, null, 4);
 
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-        const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
 
         if (!dir) {
             dir = path.join(homeExtDir, this.name);
@@ -265,7 +265,7 @@ export class FabricRuntime extends EventEmitter {
     public async deleteConnectionDetails(outputAdapter: OutputAdapter): Promise<void> {
 
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-        const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
         const runtimePath: string = path.join(homeExtDir, this.name);
         // TODO: hardcoded name
         const walletPath: string = path.join(homeExtDir, 'local_wallet');

--- a/client/src/fabric/FabricWalletGenerator.ts
+++ b/client/src/fabric/FabricWalletGenerator.ts
@@ -31,7 +31,7 @@ export class FabricWalletGenerator implements IFabricWalletGenerator {
     public async createLocalWallet(walletName: string): Promise<FabricWallet> {
 
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-        const homeExtDir: string = await UserInputUtil.getDirPath(extDir);
+        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
         const walletPath: string = path.join(homeExtDir, walletName);
         const walletExists: boolean = await fs.pathExists(walletPath);
 

--- a/client/src/packages/PackageRegistry.ts
+++ b/client/src/packages/PackageRegistry.ts
@@ -43,7 +43,7 @@ export class PackageRegistry {
         // Determine the directory that will contain the packages and ensure it exists.
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
         const pkgDir: string = path.join(extDir, 'packages');
-        const resolvedPkgDir: string = await UserInputUtil.getDirPath(pkgDir);
+        const resolvedPkgDir: string = UserInputUtil.getDirPath(pkgDir);
         await fs.ensureDir(resolvedPkgDir);
 
         // Read the list of files and process them.

--- a/client/test/commands/deleteGatewayCommand.test.ts
+++ b/client/test/commands/deleteGatewayCommand.test.ts
@@ -143,7 +143,7 @@ describe('DeleteGatewayCommand', () => {
                 data: FabricGatewayRegistry.instance().get('myGatewayC')
             });
 
-            const getDirPathStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'getDirPath').resolves('fabric-vscode');
+            const getDirPathStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'getDirPath').returns('fabric-vscode');
             const fsRemoveStub: sinon.SinonStub = mySandBox.stub(fs, 'remove').resolves();
 
             await vscode.commands.executeCommand(ExtensionCommands.DELETE_GATEWAY);

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -632,15 +632,15 @@ describe('userInputUtil', () => {
     });
 
     describe('getDirPath', () => {
-        it('should replace ~ with the users home directory', async () => {
+        it('should replace ~ with the users home directory', () => {
             const packageDirOriginal: string = '~/smartContractDir';
-            const packageDirNew: string = await UserInputUtil.getDirPath(packageDirOriginal);
+            const packageDirNew: string = UserInputUtil.getDirPath(packageDirOriginal);
             packageDirNew.should.not.contain('~');
         });
 
-        it('should not replace if not ~', async () => {
+        it('should not replace if not ~', () => {
             const packageDirOriginal: string = '/banana/smartContractDir';
-            const packageDirNew: string = await UserInputUtil.getDirPath(packageDirOriginal);
+            const packageDirNew: string = UserInputUtil.getDirPath(packageDirOriginal);
             packageDirNew.should.equal(packageDirOriginal);
         });
     });

--- a/client/test/fabric/FabricGatewayHelper.test.ts
+++ b/client/test/fabric/FabricGatewayHelper.test.ts
@@ -77,7 +77,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should copy a connection profile and do nothing if TLS certs are inline', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(true);
             readFileStub.onFirstCall().resolves(tlsPemJson);
             writeFileStub.resolves();
@@ -94,7 +94,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should copy a connection profile and ensure the destination directory exists', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.onFirstCall().resolves(tlsPemJson);
@@ -112,7 +112,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should copy a connection profile and change absolute paths', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.onFirstCall().resolves(tlsPathJson);
@@ -151,7 +151,7 @@ describe('FabricGatewayHelper', () => {
                 }
             };
             const stringifiedObject: string = JSON.stringify(connectionProfileObject);
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.resolves('CERT_HERE');
@@ -181,7 +181,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should copy a connection profile and change relative paths', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.onFirstCall().resolves(tlsPathJson);
@@ -203,7 +203,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should handle any errors thrown', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.resolves('CERT_HERE');
@@ -224,7 +224,7 @@ describe('FabricGatewayHelper', () => {
         });
 
         it('should copy a connection profile and change relative paths for a YAML file', async () => {
-            getDirPathStub.resolves('fabric-vscode');
+            getDirPathStub.returns('fabric-vscode');
             pathExistsStub.resolves(false);
             ensureDirStub.resolves();
             readFileStub.onFirstCall().resolves(yamlPathData);

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -200,7 +200,7 @@ describe('FabricRuntime', () => {
         getVolumeStub.withArgs('fabricvscodelocalfabric_logs').returns(mockLogsVolume);
 
         runtimeDir = path.join(rootPath, '..', 'data');
-        sandbox.stub(UserInputUtil, 'getDirPath').resolves(runtimeDir);
+        sandbox.stub(UserInputUtil, 'getDirPath').returns(runtimeDir);
         ensureFileStub = sandbox.stub(fs, 'ensureFileSync').resolves();
         writeFileStub = sandbox.stub(fs, 'writeFileSync').resolves();
         removeStub = sandbox.stub(fs, 'remove').resolves();

--- a/client/test/fabric/FabricWalletGenerator.test.ts
+++ b/client/test/fabric/FabricWalletGenerator.test.ts
@@ -36,7 +36,7 @@ describe('FabricWalletGenerator', () => {
         beforeEach(async () => {
             mySandBox = sinon.createSandbox();
 
-            mySandBox.stub(UserInputUtil, 'getDirPath').resolves(path.join(rootPath, '../../test/data/walletDir'));
+            mySandBox.stub(UserInputUtil, 'getDirPath').returns(path.join(rootPath, '../../test/data/walletDir'));
             ensureDirStub = mySandBox.stub(fs, 'ensureDir').resolves();
             pathExistsStub = mySandBox.stub(fs, 'pathExists');
         });


### PR DESCRIPTION
The `home-dir` module is not async (no callbacks, no promises), so our code that calls it does not need to be async either.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>