### PR TITLE
Sanitize the connection functions around node names (contributes to #776)

### DIFF
--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -627,8 +627,7 @@ export class UserInputUtil {
 
     public static async showCertificateAuthorityQuickPickBox(prompt: string): Promise<string | undefined> {
         const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
-        const caNameOption: string = connection.getCertificateAuthorityName();
-        const caNames: string[] = [caNameOption];
+        const caNames: string[] = connection.getAllCertificateAuthorityNames();
 
         const quickPickOptions: vscode.QuickPickOptions = {
             ignoreFocusOut: false,

--- a/client/src/explorer/runtimeOpsExplorer.ts
+++ b/client/src/explorer/runtimeOpsExplorer.ts
@@ -244,12 +244,14 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
             }
 
             // Push Certificate Authority tree item
-            const certificateAuthorityName: any = connection.getCertificateAuthorityName();
-            const caTreeItem: CertificateAuthorityTreeItem = new CertificateAuthorityTreeItem(this, certificateAuthorityName);
-            tree.push(caTreeItem);
+            const certificateAuthorityNames: Array<string> = connection.getAllCertificateAuthorityNames();
+            for (const certificateAuthorityName of certificateAuthorityNames) {
+                const caTreeItem: CertificateAuthorityTreeItem = new CertificateAuthorityTreeItem(this, certificateAuthorityName);
+                tree.push(caTreeItem);
+            }
 
-            const orderers: Set<string> = await this.getOrderers();
-            for (const orderer of orderers.keys()) {
+            const orderers: Array<string> = await this.getAllOrdererNames();
+            for (const orderer of orderers) {
                 tree.push(new OrdererTreeItem(this, orderer));
             }
 
@@ -347,9 +349,9 @@ export class BlockchainRuntimeExplorerProvider implements BlockchainExplorerProv
         return tree;
     }
 
-    private async getOrderers(): Promise<Set<string>> {
+    private async getAllOrdererNames(): Promise<Array<string>> {
         const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
-        const ordererSet: Set<string> = await connection.getOrderers();
+        const ordererSet: Array<string> = await connection.getAllOrdererNames();
 
         return ordererSet;
     }

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -81,11 +81,11 @@ export abstract class FabricConnection {
         return orgs;
     }
 
-    public getCertificateAuthorityName(): string {
+    public getAllCertificateAuthorityNames(): Array<string> {
         const client: Client = this.gateway.getClient();
         const certificateAuthority: any = client.getCertificateAuthority();
         const certificateAuthorityName: string = certificateAuthority.getCaName();
-        return certificateAuthorityName;
+        return [certificateAuthorityName];
     }
 
     public async getAllChannelsForPeer(peerName: string): Promise<Array<string>> {
@@ -361,7 +361,7 @@ export abstract class FabricConnection {
         return { certificate: enrollment.certificate, privateKey: enrollment.key.toBytes() };
     }
 
-    public async getOrderers(): Promise<Set<string>> {
+    public async getAllOrdererNames(): Promise<Array<string>> {
 
         const ordererSet: Set<string> = new Set();
         const allPeerNames: Array<string> = this.getAllPeerNames();
@@ -379,7 +379,7 @@ export abstract class FabricConnection {
             }
         }
 
-        return ordererSet;
+        return Array.from(ordererSet);
     }
 
     public async register(enrollmentID: string, affiliation: string): Promise<string> {

--- a/client/src/fabric/IFabricRuntimeConnection.ts
+++ b/client/src/fabric/IFabricRuntimeConnection.ts
@@ -33,13 +33,13 @@ export interface IFabricRuntimeConnection {
 
     getOrganizations(channelName: string): Promise<Array<string>>;
 
-    getCertificateAuthorityName(): string;
+    getAllCertificateAuthorityNames(): Array<string>;
 
     getInstalledChaincode(peerName: string): Promise<Map<string, Array<string>>>;
 
     getInstantiatedChaincode(channelName: string): Promise<Array<{name: string, version: string}>>;
 
-    getOrderers(): Promise<Set<string>>;
+    getAllOrdererNames(): Promise<Array<string>>;
 
     installChaincode(packageRegistryEntry: PackageRegistryEntry, peerName: string): Promise<void>;
 

--- a/client/test/commands/createNewIdentityCommand.test.ts
+++ b/client/test/commands/createNewIdentityCommand.test.ts
@@ -70,8 +70,8 @@ describe('createNewIdentityCommand', () => {
 
         mockFabricRuntimeConnection = sinon.createStubInstance(FabricRuntimeConnection);
         mockFabricRuntimeConnection.connect.resolves();
-        mockFabricRuntimeConnection.getCertificateAuthorityName.returns('ca.name');
-        mockFabricRuntimeConnection.getOrderers.resolves([]);
+        mockFabricRuntimeConnection.getAllCertificateAuthorityNames.returns('ca.name');
+        mockFabricRuntimeConnection.getAllOrdererNames.resolves([]);
         mockFabricRuntimeConnection.getAllPeerNames.returns([]);
         mockFabricRuntimeConnection.register.resolves('its a secret');
         mockFabricRuntimeConnection.enroll.resolves({

--- a/client/test/commands/installCommand.test.ts
+++ b/client/test/commands/installCommand.test.ts
@@ -76,7 +76,8 @@ describe('InstallCommand', () => {
             fabricRuntimeMock.connect.resolves();
             fabricRuntimeMock.installChaincode.resolves();
             fabricRuntimeMock.getInstalledChaincode.resolves(new Map<string, Array<string>>());
-            fabricRuntimeMock.getOrderers.resolves(new Set(['orderer1']));
+            fabricRuntimeMock.getAllOrdererNames.resolves(['orderer1']);
+            fabricRuntimeMock.getAllCertificateAuthorityNames.returns(['ca1']);
 
             const fabricRuntimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
             getRuntimeConnectionStub = mySandBox.stub(fabricRuntimeManager, 'getConnection').resolves((fabricRuntimeMock as any));

--- a/client/test/commands/userInputUtil.test.ts
+++ b/client/test/commands/userInputUtil.test.ts
@@ -23,7 +23,6 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
 import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
-import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
 import { PackageRegistry } from '../../src/packages/PackageRegistry';
 import * as fs from 'fs-extra';
@@ -35,6 +34,7 @@ import { FabricWalletRegistry } from '../../src/fabric/FabricWalletRegistry';
 import { FabricWallet } from '../../src/fabric/FabricWallet';
 import { FabricWalletGenerator } from '../../src/fabric/FabricWalletGenerator';
 import { ExtensionCommands } from '../../ExtensionCommands';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
 
 chai.use(sinonChai);
 const should: Chai.Should = chai.should();
@@ -54,7 +54,7 @@ describe('userInputUtil', () => {
     let walletEntryTwo: FabricWalletRegistryEntry;
 
     let getConnectionStub: sinon.SinonStub;
-    let fabricConnectionStub: sinon.SinonStubbedInstance<FabricClientConnection>;
+    let fabricConnectionStub: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
 
     const env: NodeJS.ProcessEnv = Object.assign({}, process.env);
 
@@ -146,7 +146,7 @@ describe('userInputUtil', () => {
         const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
         const fabricRuntimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
 
-        fabricConnectionStub = sinon.createStubInstance(FabricClientConnection);
+        fabricConnectionStub = sinon.createStubInstance(FabricRuntimeConnection);
         fabricConnectionStub.getAllPeerNames.returns(['myPeerOne', 'myPeerTwo']);
 
         fabricConnectionStub.getAllChannelsForPeer.withArgs('myPeerOne').resolves(['channelOne']);
@@ -158,7 +158,7 @@ describe('userInputUtil', () => {
         fabricConnectionStub.getInstalledChaincode.withArgs('myPeerOne').resolves(chaincodeMap);
         fabricConnectionStub.getInstalledChaincode.withArgs('myPeerTwo').resolves(new Map<string, Array<string>>());
         fabricConnectionStub.getInstantiatedChaincode.withArgs('channelOne').resolves([{ name: 'biscuit-network', channel: 'channelOne', version: '0.0.1' }, { name: 'cake-network', channel: 'channelOne', version: '0.0.3' }]);
-        fabricConnectionStub.getCertificateAuthorityName.resolves('ca.example.cake.com');
+        fabricConnectionStub.getAllCertificateAuthorityNames.resolves('ca.example.cake.com');
 
         const chaincodeMapTwo: Map<string, Array<string>> = new Map<string, Array<string>>();
 

--- a/client/test/explorer/runtimeOpsExplorer.test.ts
+++ b/client/test/explorer/runtimeOpsExplorer.test.ts
@@ -240,7 +240,7 @@ describe('runtimeOpsExplorer', () => {
                     }
                 ]);
 
-                fabricConnection.getOrderers.resolves(new Set(['orderer1']));
+                fabricConnection.getAllOrdererNames.resolves(['orderer1']);
 
                 blockchainRuntimeExplorerProvider = myExtension.getBlockchainRuntimeExplorerProvider();
                 const fabricRuntimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
@@ -301,8 +301,8 @@ describe('runtimeOpsExplorer', () => {
                 channelTwo.label.should.equal('channelTwo');
             });
 
-            it('should show peers (nodes) correctly', async () => {
-                fabricConnection.getCertificateAuthorityName.returns('ca-name');
+            it('should show peers, certificate authorities, and orderer nodes correctly', async () => {
+                fabricConnection.getAllCertificateAuthorityNames.returns(['ca-name']);
 
                 allChildren = await blockchainRuntimeExplorerProvider.getChildren();
                 allChildren.length.should.equal(4);

--- a/client/test/fabric/FabricConnection.test.ts
+++ b/client/test/fabric/FabricConnection.test.ts
@@ -862,7 +862,7 @@ describe('FabricConnection', () => {
             fabricClientStub.getCertificateAuthority.returns({
                 getCaName: mySandBox.stub().returns('ca-name')
             });
-            fabricConnection.getCertificateAuthorityName().should.equal('ca-name');
+            fabricConnection.getAllCertificateAuthorityNames().should.deep.equal(['ca-name']);
         });
     });
     describe('getOrderers', () => {
@@ -887,9 +887,8 @@ describe('FabricConnection', () => {
             const getAllChannelsForPeer: sinon.SinonStub = mySandBox.stub(fabricConnection, 'getAllChannelsForPeer');
             getAllChannelsForPeer.withArgs('peerOne').resolves(['channel1']);
             getAllChannelsForPeer.withArgs('peerTwo').resolves(['channel2']);
-            const orderers: Set<string> = await fabricConnection.getOrderers();
-            orderers.has('orderer1').should.equal(true);
-            orderers.has('orderer2').should.equal(true);
+            const orderers: Array<string> = await fabricConnection.getAllOrdererNames();
+            orderers.should.deep.equal(['orderer1', 'orderer2']);
         });
     });
 


### PR DESCRIPTION
There are three different connection functions for returning the names of different types of nodes (getAllPeerNames, getCertificateAuthority, getOrderers), with three different return types (string[], string, Set<string>). Make these all string[] and give them all the same name (getAllThingNames).

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>