### PR TITLE
Clean up runtime gateway listing code (contributes to #776)

### DIFF
--- a/client/integrationTest/integrationTestUtil.ts
+++ b/client/integrationTest/integrationTestUtil.ts
@@ -30,6 +30,7 @@ import { ExtensionCommands } from '../ExtensionCommands';
 import { FabricWalletRegistryEntry } from '../src/fabric/FabricWalletRegistryEntry';
 import { FabricConnectionManager } from '../src/fabric/FabricConnectionManager';
 import { IFabricClientConnection } from '../src/fabric/IFabricClientConnection';
+import { FabricRuntimeManager } from '../src/fabric/FabricRuntimeManager';
 
 // tslint:disable no-unused-expression
 const should: Chai.Should = chai.should();
@@ -148,6 +149,7 @@ export class IntegrationTestUtil {
             gatewayEntry = new FabricGatewayRegistryEntry();
             gatewayEntry.name = name;
             gatewayEntry.managedRuntime = true;
+            gatewayEntry.connectionProfilePath = FabricRuntimeManager.instance().getRuntime().getConnectionProfilePath();
         }
 
         let walletEntry: FabricWalletRegistryEntry;

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -24,7 +24,6 @@ import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutput
 import { LogType } from '../logging/OutputAdapter';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { FabricGatewayRegistry } from '../fabric/FabricGatewayRegistry';
-import { FabricRuntime } from '../fabric/FabricRuntime';
 import { ParsedCertificate } from '../fabric/ParsedCertificate';
 import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
 import { FabricWalletRegistry } from '../fabric/FabricWalletRegistry';
@@ -65,9 +64,7 @@ export class UserInputUtil {
     static readonly ADD_CERT_KEY_OPTION: string = 'Enter paths to Certificate and Key files';
     static readonly ADD_ID_SECRET_OPTION: string = 'Select a gateway and provide an enrollment ID and secret';
 
-    public static showGatewayQuickPickBox(prompt: string, showManagedRuntime?: boolean): Thenable<IBlockchainQuickPickItem<FabricGatewayRegistryEntry> | undefined> {
-        const gateways: Array<FabricGatewayRegistryEntry> = FabricGatewayRegistry.instance().getAll();
-
+    public static async showGatewayQuickPickBox(prompt: string, showManagedRuntime?: boolean): Promise<IBlockchainQuickPickItem<FabricGatewayRegistryEntry> | undefined> {
         const quickPickOptions: vscode.QuickPickOptions = {
             ignoreFocusOut: false,
             canPickMany: false,
@@ -76,16 +73,13 @@ export class UserInputUtil {
 
         const allGateways: Array<FabricGatewayRegistryEntry> = [];
 
-        let connection: FabricGatewayRegistryEntry;
         if (showManagedRuntime) {
             // Allow users to choose local_fabric
-            const runtime: FabricRuntime = FabricRuntimeManager.instance().getRuntime();
-            connection = new FabricGatewayRegistryEntry();
-            connection.name = runtime.getName();
-            connection.managedRuntime = true;
-            allGateways.push(connection);
+            const runtimeGateways: Array<FabricGatewayRegistryEntry> = await FabricRuntimeManager.instance().getGatewayRegistryEntries();
+            allGateways.push(...runtimeGateways);
         }
 
+        const gateways: Array<FabricGatewayRegistryEntry> = FabricGatewayRegistry.instance().getAll();
         allGateways.push(...gateways);
 
         const gatewaysQuickPickItems: Array<IBlockchainQuickPickItem<FabricGatewayRegistryEntry>> = allGateways.map((gateway: FabricGatewayRegistryEntry) => {

--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -84,7 +84,6 @@ export async function connect(gatewayRegistryEntry: FabricGatewayRegistryEntry, 
             }
         }
 
-        gatewayRegistryEntry.connectionProfilePath = await runtime.getConnectionProfilePath();
         runtimeData = 'managed runtime';
     }
 

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -159,7 +159,7 @@ export class FabricRuntime extends EventEmitter {
         return connectionProfile;
     }
 
-    public async getConnectionProfilePath(): Promise<string> {
+    public getConnectionProfilePath(): string {
         const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
         const homeExtDir: string = UserInputUtil.getDirPath(extDir);
         const dir: string = path.join(homeExtDir, this.name);

--- a/client/src/fabric/FabricRuntimeManager.ts
+++ b/client/src/fabric/FabricRuntimeManager.ts
@@ -21,6 +21,7 @@ import { FabricWalletGeneratorFactory } from './FabricWalletGeneratorFactory';
 import { VSCodeBlockchainDockerOutputAdapter } from '../logging/VSCodeBlockchainDockerOutputAdapter';
 import { IFabricWalletGenerator } from './IFabricWalletGenerator';
 import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
+import { FabricGatewayRegistryEntry } from './FabricGatewayRegistryEntry';
 
 export class FabricRuntimeManager {
 
@@ -89,6 +90,16 @@ export class FabricRuntimeManager {
             this.runtime.developmentMode = false;
             await this.runtime.updateUserSettings();
         }
+    }
+
+    public async getGatewayRegistryEntries(): Promise<FabricGatewayRegistryEntry[]> {
+        const runtime: FabricRuntime = this.getRuntime();
+        const registryEntry: FabricGatewayRegistryEntry = new FabricGatewayRegistryEntry({
+            name: runtime.getName(),
+            managedRuntime: true,
+            connectionProfilePath: runtime.getConnectionProfilePath()
+        });
+        return [registryEntry];
     }
 
     private readRuntimeUserSettings(): any {

--- a/client/test/commands/UserInputUtil.test.ts
+++ b/client/test/commands/UserInputUtil.test.ts
@@ -40,7 +40,7 @@ chai.use(sinonChai);
 const should: Chai.Should = chai.should();
 
 // tslint:disable no-unused-expression
-describe('userInputUtil', () => {
+describe('UserInputUtil', () => {
 
     let mySandBox: sinon.SinonSandbox;
     let quickPickStub: sinon.SinonStub;
@@ -197,6 +197,8 @@ describe('userInputUtil', () => {
             const managedRuntime: FabricGatewayRegistryEntry = new FabricGatewayRegistryEntry();
             managedRuntime.name = 'local_fabric';
             managedRuntime.managedRuntime = true;
+            const connectionProfilePath: string = UserInputUtil.getDirPath('~/.fabric-vscode/local_fabric/connection.json');
+            managedRuntime.connectionProfilePath = connectionProfilePath;
 
             quickPickStub.resolves();
             await UserInputUtil.showGatewayQuickPickBox('Choose a gateway', true);

--- a/client/test/explorer/gatewayExplorer.test.ts
+++ b/client/test/explorer/gatewayExplorer.test.ts
@@ -229,6 +229,7 @@ describe('gatewayExplorer', () => {
                 mockRuntime.getName.returns('local_fabric');
                 mockRuntime.isBusy.returns(false);
                 mockRuntime.isRunning.resolves(true);
+                mockRuntime.getConnectionProfilePath.returns('connection.json');
                 mySandBox.stub(FabricRuntimeManager.instance(), 'getRuntime').returns(mockRuntime);
 
                 const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
@@ -240,6 +241,7 @@ describe('gatewayExplorer', () => {
                 const gateway: FabricGatewayRegistryEntry = new FabricGatewayRegistryEntry();
                 gateway.name = 'local_fabric';
                 gateway.managedRuntime = true;
+                gateway.connectionProfilePath = 'connection.json';
                 const myCommand: vscode.Command = {
                     command: ExtensionCommands.CONNECT,
                     title: '',

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -864,7 +864,7 @@ describe('FabricRuntime', () => {
     describe('#getConnectionProfilePath', () => {
 
         it('should get the runtime connection profile path', async () => {
-            const connectionPath: string = await runtime.getConnectionProfilePath();
+            const connectionPath: string = runtime.getConnectionProfilePath();
             connectionPath.should.equal(path.join(rootPath, '..', '..', 'out', 'data', 'local_fabric', 'connection.json'));
         });
 

--- a/client/test/fabric/FabricRuntimeManager.test.ts
+++ b/client/test/fabric/FabricRuntimeManager.test.ts
@@ -25,6 +25,8 @@ import { FabricWallet } from '../../src/fabric/FabricWallet';
 import { FabricWalletGenerator } from '../../src/fabric/FabricWalletGenerator';
 import * as vscode from 'vscode';
 import { IFabricRuntimeConnection } from '../../src/fabric/IFabricRuntimeConnection';
+import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
+import { UserInputUtil } from '../../src/commands/UserInputUtil';
 
 const should: Chai.Should = chai.should();
 
@@ -447,4 +449,18 @@ describe('FabricRuntimeManager', () => {
         });
 
     });
+
+    describe('#getGatewayRegistryEntries', () => {
+
+        it('should return an array of gateway registry entires', async () => {
+            const registryEntries: FabricGatewayRegistryEntry[] = await runtimeManager.getGatewayRegistryEntries();
+            registryEntries.should.have.lengthOf(1);
+            registryEntries[0].name.should.equal('local_fabric');
+            registryEntries[0].managedRuntime.should.be.true;
+            const connectionProfilePath: string = UserInputUtil.getDirPath('~/.fabric-vscode/local_fabric/connection.json');
+            registryEntries[0].connectionProfilePath.should.equal(connectionProfilePath);
+        });
+
+    });
+
 });


### PR DESCRIPTION
There is two sets of pretty much identical code in the extension that generates a fake list of gateway registry entries to represent the local Fabric gateway - bring this code into the Fabric runtime manager and call it from there. 

Since the local Fabric now has a connection profile path, all gateway registry entires (fake or not) are the same in that they have a name and a connection profile path - the only difference now is the managedRuntime flag.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>