### PR TITLE
Move client/runtime conn specific code (contributes to #776)

### DIFF
--- a/client/src/fabric/FabricClientConnection.ts
+++ b/client/src/fabric/FabricClientConnection.ts
@@ -17,10 +17,12 @@ import { FabricConnection } from './FabricConnection';
 import { FabricWallet } from './FabricWallet';
 import { ExtensionUtil } from '../util/ExtensionUtil';
 import { IFabricClientConnection } from './IFabricClientConnection';
+import { Network, Contract } from 'fabric-network';
 
 export class FabricClientConnection extends FabricConnection implements IFabricClientConnection {
 
     private connectionProfilePath: string;
+    private networkIdProperty: boolean;
 
     constructor(connectionData: { connectionProfilePath: string, walletPath: string }, outputAdapter?: OutputAdapter) {
         super(outputAdapter);
@@ -30,6 +32,61 @@ export class FabricClientConnection extends FabricConnection implements IFabricC
     async connect(wallet: FabricWallet, identityName: string): Promise<void> {
         console.log('FabricClientConnection: connect');
         const connectionProfile: object = await ExtensionUtil.readConnectionProfile(this.connectionProfilePath);
+        this.networkIdProperty = (connectionProfile['x-networkId'] ? true : false);
         await this.connectInner(connectionProfile, wallet, identityName);
     }
+
+    public isIBPConnection(): boolean {
+        return this.networkIdProperty;
+    }
+
+    public async getMetadata(instantiatedChaincodeName: string, channel: string): Promise<any> {
+        const network: Network = await this.gateway.getNetwork(channel);
+        const smartContract: Contract = network.getContract(instantiatedChaincodeName);
+
+        let metadataBuffer: Buffer;
+        try {
+            metadataBuffer = await smartContract.evaluateTransaction('org.hyperledger.fabric:GetMetadata');
+        } catch (error) {
+            // This is the most likely case; smart contract does not support metadata.
+            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" returned an error: ${error.message}`);
+        }
+        const metadataString: string = metadataBuffer.toString();
+        if (!metadataString) {
+            // This is the unusual case; the function name is ignored, or accepted, but an empty string is returned.
+            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" did not return any metadata`);
+        }
+        try {
+            const metadataObject: any = JSON.parse(metadataBuffer.toString());
+
+            console.log('Metadata object is:', metadataObject);
+            return metadataObject;
+        } catch (error) {
+            // This is another unusual case; the function name is ignored, or accepted, but non-JSON data is returned.
+            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" did not return valid JSON metadata: ${error.message}`);
+        }
+    }
+
+    public async submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string, evaluate?: boolean): Promise<string | undefined> {
+        const network: Network = await this.gateway.getNetwork(channel);
+        const smartContract: Contract = network.getContract(chaincodeName, namespace);
+
+        let response: Buffer;
+        if (evaluate) {
+            response = await smartContract.evaluateTransaction(transactionName, ...args);
+        } else {
+            response = await smartContract.submitTransaction(transactionName, ...args);
+        }
+
+        if (response.buffer.byteLength === 0) {
+            // If the transaction returns no data
+            return undefined;
+        } else {
+            // Turn the response into a string
+            const result: any = response.toString('utf8');
+            return result;
+        }
+
+    }
+
 }

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -14,11 +14,8 @@
 'use strict';
 
 import * as Client from 'fabric-client';
-import * as ClientCA from 'fabric-ca-client';
-import { Gateway, Network, Contract, GatewayOptions, FileSystemWallet, IdentityInfo } from 'fabric-network';
-import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
-import * as fs from 'fs-extra';
-import { LogType, OutputAdapter } from '../logging/OutputAdapter';
+import { Gateway, GatewayOptions, FileSystemWallet, IdentityInfo } from 'fabric-network';
+import { OutputAdapter } from '../logging/OutputAdapter';
 import { ConsoleOutputAdapter } from '../logging/ConsoleOutputAdapter';
 import { FabricWallet } from './FabricWallet';
 import { URL } from 'url';
@@ -28,11 +25,10 @@ export abstract class FabricConnection {
 
     public identityName: string;
     public wallet: FabricWalletRegistryEntry;
+    protected outputAdapter: OutputAdapter;
+    protected gateway: Gateway = new Gateway();
 
     private mspid: string;
-    private gateway: Gateway = new Gateway();
-    private networkIdProperty: boolean;
-    private outputAdapter: OutputAdapter;
     private discoveryAsLocalhost: boolean;
     private discoveryEnabled: boolean;
 
@@ -43,10 +39,6 @@ export abstract class FabricConnection {
         } else {
             this.outputAdapter = outputAdapter;
         }
-    }
-
-    public isIBPConnection(): boolean {
-        return this.networkIdProperty;
     }
 
     public abstract async connect(wallet: FabricWallet, identityName: string): Promise<void>;
@@ -64,30 +56,6 @@ export abstract class FabricConnection {
         return peerNames;
     }
 
-    public getPeer(name: string): Client.Peer {
-        console.log('getPeer', name);
-        const allPeers: Array<Client.Peer> = this.getAllPeers();
-
-        return allPeers.find((peer: Client.Peer) => {
-            return peer.getName() === name;
-        });
-    }
-
-    public async getOrganizations(channelName: string): Promise<any[]> {
-        console.log('getOrganizations', channelName);
-        const network: Network = await this.gateway.getNetwork(channelName);
-        const channel: Client.Channel = network.getChannel();
-        const orgs: any[] = channel.getOrganizations();
-        return orgs;
-    }
-
-    public getAllCertificateAuthorityNames(): Array<string> {
-        const client: Client = this.gateway.getClient();
-        const certificateAuthority: any = client.getCertificateAuthority();
-        const certificateAuthorityName: string = certificateAuthority.getCaName();
-        return [certificateAuthorityName];
-    }
-
     public async getAllChannelsForPeer(peerName: string): Promise<Array<string>> {
         console.log('getAllChannelsForPeer', peerName);
         // TODO: update this when not just using admin
@@ -103,32 +71,6 @@ export abstract class FabricConnection {
         return channelNames.sort();
     }
 
-    public async getInstalledChaincode(peerName: string): Promise<Map<string, Array<string>>> {
-        console.log('getInstalledChaincode', peerName);
-        const installedChainCodes: Map<string, Array<string>> = new Map<string, Array<string>>();
-        const peer: Client.Peer = this.getPeer(peerName);
-        let chaincodeResponse: Client.ChaincodeQueryResponse;
-        try {
-            chaincodeResponse = await this.gateway.getClient().queryInstalledChaincodes(peer);
-        } catch (error) {
-            if (error.message && error.message.match(/access denied/)) {
-                // Not allowed to do this as we're probably not an administrator.
-                // This is probably not the end of the world, so return the empty map.
-                return installedChainCodes;
-            }
-            throw error;
-        }
-        chaincodeResponse.chaincodes.forEach((chaincode: Client.ChaincodeInfo) => {
-            if (installedChainCodes.has(chaincode.name)) {
-                installedChainCodes.get(chaincode.name).push(chaincode.version);
-            } else {
-                installedChainCodes.set(chaincode.name, [chaincode.version]);
-            }
-        });
-
-        return installedChainCodes;
-    }
-
     public async getInstantiatedChaincode(channelName: string): Promise<Array<{ name: string, version: string }>> {
         console.log('getInstantiatedChaincode');
         const instantiatedChaincodes: Array<any> = [];
@@ -141,256 +83,8 @@ export abstract class FabricConnection {
         return instantiatedChaincodes;
     }
 
-    public async installChaincode(packageRegistryEntry: PackageRegistryEntry, peerName: string): Promise<void> {
-        const peer: Client.Peer = this.getPeer(peerName);
-        const pkgBuffer: Buffer = await fs.readFile(packageRegistryEntry.path);
-        const installRequest: Client.ChaincodePackageInstallRequest = {
-            targets: [peer],
-            chaincodePackage: pkgBuffer,
-            txId: this.gateway.getClient().newTransactionID()
-        };
-        const response: Client.ProposalResponseObject = await this.gateway.getClient().installChaincode(installRequest);
-        const proposalResponse: Client.ProposalResponse | Error = response[0][0];
-        if (proposalResponse instanceof Error) {
-            throw proposalResponse;
-        } else if (proposalResponse.response.status !== 200) {
-            throw new Error(proposalResponse.response.message);
-        }
-    }
-
-    public async instantiateChaincode(name: string, version: string, channelName: string, fcn: string, args: Array<string>): Promise<any> {
-
-        const transactionId: Client.TransactionId = this.gateway.getClient().newTransactionID();
-        const instantiateRequest: Client.ChaincodeInstantiateUpgradeRequest = {
-            chaincodeId: name,
-            chaincodeVersion: version,
-            txId: transactionId,
-            fcn: fcn,
-            args: args
-        };
-
-        const network: Network = await this.gateway.getNetwork(channelName);
-        const channel: Client.Channel = network.getChannel();
-
-        const instantiatedChaincode: Array<any> = await this.getInstantiatedChaincode(channelName);
-
-        const foundChaincode: any = this.getChaincode(name, instantiatedChaincode);
-
-        let proposalResponseObject: Client.ProposalResponseObject;
-
-        let message: string;
-
-        if (foundChaincode) {
-            throw new Error('The name of the contract you tried to instantiate is already instantiated');
-        } else {
-            message = `Instantiating with function: '${fcn}' and arguments: '${args}'`;
-            this.outputAdapter.log(LogType.INFO, undefined, message);
-            proposalResponseObject = await channel.sendInstantiateProposal(instantiateRequest);
-        }
-
-        const contract: Contract = network.getContract(name);
-        const transaction: any = (contract as any).createTransaction('dummy');
-
-        const responses: any = transaction['_validatePeerResponses'](proposalResponseObject[0]);
-
-        const txId: any = transactionId.getTransactionID();
-        const eventHandlerOptions: any = (contract as any).getEventHandlerOptions();
-        const eventHandler: any = transaction['_createTxEventHandler'](txId, network, eventHandlerOptions);
-
-        if (!eventHandler) {
-            throw new Error('Failed to create an event handler');
-        }
-
-        await eventHandler.startListening();
-
-        const transactionRequest: Client.TransactionRequest = {
-            proposalResponses: proposalResponseObject[0] as Client.ProposalResponse[],
-            proposal: proposalResponseObject[1],
-            txId: transactionId
-        };
-
-        // Submit the endorsed transaction to the primary orderers.
-        const response: Client.BroadcastResponse = await network.getChannel().sendTransaction(transactionRequest);
-
-        if (response.status !== 'SUCCESS') {
-            const msg: string = `Failed to send peer responses for transaction ${transactionId.getTransactionID()} to orderer. Response status: ${response.status}`;
-            eventHandler.cancelListening();
-            throw new Error(msg);
-        }
-
-        await eventHandler.waitForEvents();
-        // return the payload from the invoked chaincode
-        let result: any = null;
-        if (responses && responses.validResponses[0].response.payload.length > 0) {
-            result = responses.validResponses[0].response.payload;
-        }
-
-        eventHandler.cancelListening();
-
-        return result;
-    }
-
     public disconnect(): void {
         this.gateway.disconnect();
-    }
-
-    public async getMetadata(instantiatedChaincodeName: string, channel: string): Promise<any> {
-        const network: Network = await this.gateway.getNetwork(channel);
-        const smartContract: Contract = network.getContract(instantiatedChaincodeName);
-
-        let metadataBuffer: Buffer;
-        try {
-            metadataBuffer = await smartContract.evaluateTransaction('org.hyperledger.fabric:GetMetadata');
-        } catch (error) {
-            // This is the most likely case; smart contract does not support metadata.
-            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" returned an error: ${error.message}`);
-        }
-        const metadataString: string = metadataBuffer.toString();
-        if (!metadataString) {
-            // This is the unusual case; the function name is ignored, or accepted, but an empty string is returned.
-            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" did not return any metadata`);
-        }
-        try {
-            const metadataObject: any = JSON.parse(metadataBuffer.toString());
-
-            console.log('Metadata object is:', metadataObject);
-            return metadataObject;
-        } catch (error) {
-            // This is another unusual case; the function name is ignored, or accepted, but non-JSON data is returned.
-            throw new Error(`Transaction function "org.hyperledger.fabric:GetMetadata" did not return valid JSON metadata: ${error.message}`);
-        }
-    }
-
-    public async submitTransaction(chaincodeName: string, transactionName: string, channel: string, args: Array<string>, namespace: string, evaluate?: boolean): Promise<string | undefined> {
-        const network: Network = await this.gateway.getNetwork(channel);
-        const smartContract: Contract = network.getContract(chaincodeName, namespace);
-
-        let response: Buffer;
-        if (evaluate) {
-            response = await smartContract.evaluateTransaction(transactionName, ...args);
-        } else {
-            response = await smartContract.submitTransaction(transactionName, ...args);
-        }
-
-        if (response.buffer.byteLength === 0) {
-            // If the transaction returns no data
-            return undefined;
-        } else {
-            // Turn the response into a string
-            const result: any = response.toString('utf8');
-            return result;
-        }
-
-    }
-
-    public async upgradeChaincode(name: string, version: string, channelName: string, fcn: string, args: Array<string>): Promise<any> {
-
-        const transactionId: Client.TransactionId = this.gateway.getClient().newTransactionID();
-        const upgradeRequest: Client.ChaincodeInstantiateUpgradeRequest = {
-            chaincodeId: name,
-            chaincodeVersion: version,
-            txId: transactionId,
-            fcn: fcn,
-            args: args
-        };
-
-        const network: Network = await this.gateway.getNetwork(channelName);
-        const channel: Client.Channel = network.getChannel();
-
-        const instantiatedChaincode: Array<any> = await this.getInstantiatedChaincode(channelName);
-
-        const foundChaincode: any = this.getChaincode(name, instantiatedChaincode);
-
-        let proposalResponseObject: Client.ProposalResponseObject;
-
-        let message: string;
-
-        if (foundChaincode) {
-            message = `Upgrading with function: '${fcn}' and arguments: '${args}'`;
-            this.outputAdapter.log(LogType.INFO, undefined, message);
-            proposalResponseObject = await channel.sendUpgradeProposal(upgradeRequest);
-        } else {
-            //
-            throw new Error('The contract you tried to upgrade with has no previous versions instantiated');
-        }
-
-        const contract: Contract = network.getContract(name);
-        const transaction: any = (contract as any).createTransaction('dummy');
-
-        const responses: any = transaction['_validatePeerResponses'](proposalResponseObject[0]);
-
-        const txId: any = transactionId.getTransactionID();
-        const eventHandlerOptions: any = (contract as any).getEventHandlerOptions();
-        const eventHandler: any = transaction['_createTxEventHandler'](txId, network, eventHandlerOptions);
-
-        if (!eventHandler) {
-            throw new Error('Failed to create an event handler');
-        }
-
-        await eventHandler.startListening();
-
-        const transactionRequest: Client.TransactionRequest = {
-            proposalResponses: proposalResponseObject[0] as Client.ProposalResponse[],
-            proposal: proposalResponseObject[1],
-            txId: transactionId
-        };
-
-        // Submit the endorsed transaction to the primary orderers.
-        const response: Client.BroadcastResponse = await network.getChannel().sendTransaction(transactionRequest);
-
-        if (response.status !== 'SUCCESS') {
-            const msg: string = `Failed to send peer responses for transaction ${transactionId.getTransactionID()} to orderer. Response status: ${response.status}`;
-            eventHandler.cancelListening();
-            throw new Error(msg);
-        }
-
-        await eventHandler.waitForEvents();
-        // return the payload from the invoked chaincode
-        let result: any = null;
-        if (responses && responses.validResponses[0].response.payload.length > 0) {
-            result = responses.validResponses[0].response.payload;
-        }
-
-        eventHandler.cancelListening();
-
-        return result;
-    }
-
-    public async enroll(enrollmentID: string, enrollmentSecret: string): Promise<{certificate: string, privateKey: string}> {
-        const enrollment: ClientCA.IEnrollResponse = await this.gateway.getClient().getCertificateAuthority().enroll({ enrollmentID, enrollmentSecret });
-        return { certificate: enrollment.certificate, privateKey: enrollment.key.toBytes() };
-    }
-
-    public async getAllOrdererNames(): Promise<Array<string>> {
-
-        const ordererSet: Set<string> = new Set();
-        const allPeerNames: Array<string> = this.getAllPeerNames();
-
-        for (const peer of allPeerNames) {
-            const channels: string[] = await this.getAllChannelsForPeer(peer);
-            for (const _channelName of channels) {
-
-                const channel: Client.Channel = await this.getChannel(_channelName);
-                const orderers: Client.Orderer[] = channel.getOrderers();
-
-                for (const orderer of orderers) {
-                    ordererSet.add(orderer.getName());
-                }
-            }
-        }
-
-        return Array.from(ordererSet);
-    }
-
-    public async register(enrollmentID: string, affiliation: string): Promise<string> {
-        const request: ClientCA.IRegisterRequest = {
-            enrollmentID: enrollmentID,
-            affiliation: affiliation,
-            role: 'client'
-        };
-        const registrar: Client.User = this.gateway.getCurrentIdentity();
-        const secret: string = await this.gateway.getClient().getCertificateAuthority().register(request, registrar);
-        return secret;
     }
 
     public async createChannelMap(): Promise<Map<string, Array<string>>> {
@@ -425,37 +119,7 @@ export abstract class FabricConnection {
         }
     }
 
-    public async getAllInstantiatedChaincodes(): Promise<Array<{name: string, version: string}>> {
-
-        try {
-            const channelMap: Map<string, Array<string>> = await this.createChannelMap();
-            const channels: Array<string> = Array.from(channelMap.keys());
-
-            const chaincodes: Array<{name: string, version: string}> = []; // We can change the array type if we need more detailed chaincodes in future
-
-            for (const channel of channels) {
-                const channelChaincodes: Array<{name: string, version: string}> = await this.getInstantiatedChaincode(channel); // Returns channel chaincodes
-                for (const chaincode of channelChaincodes) { // For each channel chaincodes, push it to the 'chaincodes' array if it doesn't exist
-
-                    const alreadyExists: boolean = chaincodes.some((_chaincode: {name: string, version: string}) => {
-                        return _chaincode.name === chaincode.name && _chaincode.version === chaincode.version;
-                    });
-                    if (!alreadyExists) {
-                        chaincodes.push(chaincode);
-                    }
-                }
-            }
-
-            return chaincodes;
-        } catch (error) {
-            throw new Error(`Could not get all instantiated chaincodes: ${error}`);
-        }
-
-    }
-
     protected async connectInner(connectionProfile: object, wallet: FileSystemWallet, identityName: string): Promise<void> {
-
-        this.networkIdProperty = (connectionProfile['x-networkId'] ? true : false);
 
         this.discoveryAsLocalhost = this.hasLocalhostURLs(connectionProfile);
         this.discoveryEnabled = !this.discoveryAsLocalhost;
@@ -478,6 +142,36 @@ export abstract class FabricConnection {
 
         // TODO: remove this?
         this.mspid = identity.mspId;
+    }
+
+    protected getPeer(name: string): Client.Peer {
+        console.log('getPeer', name);
+        const allPeers: Array<Client.Peer> = this.getAllPeers();
+
+        return allPeers.find((peer: Client.Peer) => {
+            return peer.getName() === name;
+        });
+    }
+
+    protected async getChannel(channelName: string): Promise<Client.Channel> {
+        console.log('getChannel', channelName);
+        const client: Client = this.gateway.getClient();
+        let channel: Client.Channel = client.getChannel(channelName, false);
+        if (channel) {
+            return channel;
+        }
+        channel = client.newChannel(channelName);
+        const peers: Client.Peer[] = this.getAllPeers();
+        let lastError: Error = new Error(`Could not discover information for channel ${channelName} from known peers`);
+        for (const target of peers) {
+            try {
+                await channel.initialize({ asLocalhost: this.discoveryAsLocalhost, discover: this.discoveryEnabled, target });
+                return channel;
+            } catch (error) {
+                lastError = error;
+            }
+        }
+        throw lastError;
     }
 
     private isLocalhostURL(url: string): boolean {
@@ -506,42 +200,9 @@ export abstract class FabricConnection {
         return urls.some((url: string) => this.isLocalhostURL(url));
     }
 
-    private async getChannel(channelName: string): Promise<Client.Channel> {
-        console.log('getChannel', channelName);
-        const client: Client = this.gateway.getClient();
-        let channel: Client.Channel = client.getChannel(channelName, false);
-        if (channel) {
-            return channel;
-        }
-        channel = client.newChannel(channelName);
-        const peers: Client.Peer[] = this.getAllPeers();
-        let lastError: Error = new Error(`Could not discover information for channel ${channelName} from known peers`);
-        for (const target of peers) {
-            try {
-                await channel.initialize({ asLocalhost: this.discoveryAsLocalhost, discover: this.discoveryEnabled, target });
-                return channel;
-            } catch (error) {
-                lastError = error;
-            }
-        }
-        throw lastError;
-    }
-
     private getAllPeers(): Array<Client.Peer> {
         console.log('getAllPeers');
 
         return this.gateway.getClient().getPeersForOrg(this.mspid);
-    }
-
-    /**
-     * Get a chaincode from a list of list of chaincode
-     * @param name {String} The name of the chaincode to find
-     * @param chaincodeArray {Array<any>} An array of chaincode to search
-     * @returns {any} Returns a chaincode from the given array where the name matches the users input
-     */
-    private getChaincode(name: string, chaincodeArray: Array<any>): any {
-        return chaincodeArray.find((chaincode: any) => {
-            return chaincode.name === name;
-        });
     }
 }

--- a/client/src/fabric/FabricRuntimeConnection.ts
+++ b/client/src/fabric/FabricRuntimeConnection.ts
@@ -15,9 +15,14 @@
 'use strict';
 import { FabricConnection } from './FabricConnection';
 import { FabricRuntime } from './FabricRuntime';
-import { OutputAdapter } from '../logging/OutputAdapter';
+import { OutputAdapter, LogType } from '../logging/OutputAdapter';
 import { FabricWallet } from '../fabric/FabricWallet';
 import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
+import { Network, Contract } from 'fabric-network';
+import * as Client from 'fabric-client';
+import * as ClientCA from 'fabric-ca-client';
+import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
+import * as fs from 'fs-extra';
 
 export class FabricRuntimeConnection extends FabricConnection implements IFabricRuntimeConnection {
 
@@ -30,4 +35,285 @@ export class FabricRuntimeConnection extends FabricConnection implements IFabric
         const connectionProfile: object = await this.runtime.getConnectionProfile();
         await this.connectInner(connectionProfile, wallet, identityName);
     }
+
+    public async getAllInstantiatedChaincodes(): Promise<Array<{name: string, version: string}>> {
+
+        try {
+            const channelMap: Map<string, Array<string>> = await this.createChannelMap();
+            const channels: Array<string> = Array.from(channelMap.keys());
+
+            const chaincodes: Array<{name: string, version: string}> = []; // We can change the array type if we need more detailed chaincodes in future
+
+            for (const channel of channels) {
+                const channelChaincodes: Array<{name: string, version: string}> = await this.getInstantiatedChaincode(channel); // Returns channel chaincodes
+                for (const chaincode of channelChaincodes) { // For each channel chaincodes, push it to the 'chaincodes' array if it doesn't exist
+
+                    const alreadyExists: boolean = chaincodes.some((_chaincode: {name: string, version: string}) => {
+                        return _chaincode.name === chaincode.name && _chaincode.version === chaincode.version;
+                    });
+                    if (!alreadyExists) {
+                        chaincodes.push(chaincode);
+                    }
+                }
+            }
+
+            return chaincodes;
+        } catch (error) {
+            throw new Error(`Could not get all instantiated chaincodes: ${error}`);
+        }
+
+    }
+
+    public async getOrganizations(channelName: string): Promise<any[]> {
+        console.log('getOrganizations', channelName);
+        const network: Network = await this.gateway.getNetwork(channelName);
+        const channel: Client.Channel = network.getChannel();
+        const orgs: any[] = channel.getOrganizations();
+        return orgs;
+    }
+
+    public getAllCertificateAuthorityNames(): Array<string> {
+        const client: Client = this.gateway.getClient();
+        const certificateAuthority: any = client.getCertificateAuthority();
+        const certificateAuthorityName: string = certificateAuthority.getCaName();
+        return [certificateAuthorityName];
+    }
+
+    public async getInstalledChaincode(peerName: string): Promise<Map<string, Array<string>>> {
+        console.log('getInstalledChaincode', peerName);
+        const installedChainCodes: Map<string, Array<string>> = new Map<string, Array<string>>();
+        const peer: Client.Peer = this.getPeer(peerName);
+        let chaincodeResponse: Client.ChaincodeQueryResponse;
+        try {
+            chaincodeResponse = await this.gateway.getClient().queryInstalledChaincodes(peer);
+        } catch (error) {
+            if (error.message && error.message.match(/access denied/)) {
+                // Not allowed to do this as we're probably not an administrator.
+                // This is probably not the end of the world, so return the empty map.
+                return installedChainCodes;
+            }
+            throw error;
+        }
+        chaincodeResponse.chaincodes.forEach((chaincode: Client.ChaincodeInfo) => {
+            if (installedChainCodes.has(chaincode.name)) {
+                installedChainCodes.get(chaincode.name).push(chaincode.version);
+            } else {
+                installedChainCodes.set(chaincode.name, [chaincode.version]);
+            }
+        });
+
+        return installedChainCodes;
+    }
+
+    public async getAllOrdererNames(): Promise<Array<string>> {
+
+        const ordererSet: Set<string> = new Set();
+        const allPeerNames: Array<string> = this.getAllPeerNames();
+
+        for (const peer of allPeerNames) {
+            const channels: string[] = await this.getAllChannelsForPeer(peer);
+            for (const _channelName of channels) {
+
+                const channel: Client.Channel = await this.getChannel(_channelName);
+                const orderers: Client.Orderer[] = channel.getOrderers();
+
+                for (const orderer of orderers) {
+                    ordererSet.add(orderer.getName());
+                }
+            }
+        }
+
+        return Array.from(ordererSet);
+    }
+
+    public async installChaincode(packageRegistryEntry: PackageRegistryEntry, peerName: string): Promise<void> {
+        const peer: Client.Peer = this.getPeer(peerName);
+        const pkgBuffer: Buffer = await fs.readFile(packageRegistryEntry.path);
+        const installRequest: Client.ChaincodePackageInstallRequest = {
+            targets: [peer],
+            chaincodePackage: pkgBuffer,
+            txId: this.gateway.getClient().newTransactionID()
+        };
+        const response: Client.ProposalResponseObject = await this.gateway.getClient().installChaincode(installRequest);
+        const proposalResponse: Client.ProposalResponse | Error = response[0][0];
+        if (proposalResponse instanceof Error) {
+            throw proposalResponse;
+        } else if (proposalResponse.response.status !== 200) {
+            throw new Error(proposalResponse.response.message);
+        }
+    }
+
+    public async instantiateChaincode(name: string, version: string, channelName: string, fcn: string, args: Array<string>): Promise<any> {
+
+        const transactionId: Client.TransactionId = this.gateway.getClient().newTransactionID();
+        const instantiateRequest: Client.ChaincodeInstantiateUpgradeRequest = {
+            chaincodeId: name,
+            chaincodeVersion: version,
+            txId: transactionId,
+            fcn: fcn,
+            args: args
+        };
+
+        const network: Network = await this.gateway.getNetwork(channelName);
+        const channel: Client.Channel = network.getChannel();
+
+        const instantiatedChaincode: Array<any> = await this.getInstantiatedChaincode(channelName);
+
+        const foundChaincode: any = this.getChaincode(name, instantiatedChaincode);
+
+        let proposalResponseObject: Client.ProposalResponseObject;
+
+        let message: string;
+
+        if (foundChaincode) {
+            throw new Error('The name of the contract you tried to instantiate is already instantiated');
+        } else {
+            message = `Instantiating with function: '${fcn}' and arguments: '${args}'`;
+            this.outputAdapter.log(LogType.INFO, undefined, message);
+            proposalResponseObject = await channel.sendInstantiateProposal(instantiateRequest);
+        }
+
+        const contract: Contract = network.getContract(name);
+        const transaction: any = (contract as any).createTransaction('dummy');
+
+        const responses: any = transaction['_validatePeerResponses'](proposalResponseObject[0]);
+
+        const txId: any = transactionId.getTransactionID();
+        const eventHandlerOptions: any = (contract as any).getEventHandlerOptions();
+        const eventHandler: any = transaction['_createTxEventHandler'](txId, network, eventHandlerOptions);
+
+        if (!eventHandler) {
+            throw new Error('Failed to create an event handler');
+        }
+
+        await eventHandler.startListening();
+
+        const transactionRequest: Client.TransactionRequest = {
+            proposalResponses: proposalResponseObject[0] as Client.ProposalResponse[],
+            proposal: proposalResponseObject[1],
+            txId: transactionId
+        };
+
+        // Submit the endorsed transaction to the primary orderers.
+        const response: Client.BroadcastResponse = await network.getChannel().sendTransaction(transactionRequest);
+
+        if (response.status !== 'SUCCESS') {
+            const msg: string = `Failed to send peer responses for transaction ${transactionId.getTransactionID()} to orderer. Response status: ${response.status}`;
+            eventHandler.cancelListening();
+            throw new Error(msg);
+        }
+
+        await eventHandler.waitForEvents();
+        // return the payload from the invoked chaincode
+        let result: any = null;
+        if (responses && responses.validResponses[0].response.payload.length > 0) {
+            result = responses.validResponses[0].response.payload;
+        }
+
+        eventHandler.cancelListening();
+
+        return result;
+    }
+
+    public async upgradeChaincode(name: string, version: string, channelName: string, fcn: string, args: Array<string>): Promise<any> {
+
+        const transactionId: Client.TransactionId = this.gateway.getClient().newTransactionID();
+        const upgradeRequest: Client.ChaincodeInstantiateUpgradeRequest = {
+            chaincodeId: name,
+            chaincodeVersion: version,
+            txId: transactionId,
+            fcn: fcn,
+            args: args
+        };
+
+        const network: Network = await this.gateway.getNetwork(channelName);
+        const channel: Client.Channel = network.getChannel();
+
+        const instantiatedChaincode: Array<any> = await this.getInstantiatedChaincode(channelName);
+
+        const foundChaincode: any = this.getChaincode(name, instantiatedChaincode);
+
+        let proposalResponseObject: Client.ProposalResponseObject;
+
+        let message: string;
+
+        if (foundChaincode) {
+            message = `Upgrading with function: '${fcn}' and arguments: '${args}'`;
+            this.outputAdapter.log(LogType.INFO, undefined, message);
+            proposalResponseObject = await channel.sendUpgradeProposal(upgradeRequest);
+        } else {
+            //
+            throw new Error('The contract you tried to upgrade with has no previous versions instantiated');
+        }
+
+        const contract: Contract = network.getContract(name);
+        const transaction: any = (contract as any).createTransaction('dummy');
+
+        const responses: any = transaction['_validatePeerResponses'](proposalResponseObject[0]);
+
+        const txId: any = transactionId.getTransactionID();
+        const eventHandlerOptions: any = (contract as any).getEventHandlerOptions();
+        const eventHandler: any = transaction['_createTxEventHandler'](txId, network, eventHandlerOptions);
+
+        if (!eventHandler) {
+            throw new Error('Failed to create an event handler');
+        }
+
+        await eventHandler.startListening();
+
+        const transactionRequest: Client.TransactionRequest = {
+            proposalResponses: proposalResponseObject[0] as Client.ProposalResponse[],
+            proposal: proposalResponseObject[1],
+            txId: transactionId
+        };
+
+        // Submit the endorsed transaction to the primary orderers.
+        const response: Client.BroadcastResponse = await network.getChannel().sendTransaction(transactionRequest);
+
+        if (response.status !== 'SUCCESS') {
+            const msg: string = `Failed to send peer responses for transaction ${transactionId.getTransactionID()} to orderer. Response status: ${response.status}`;
+            eventHandler.cancelListening();
+            throw new Error(msg);
+        }
+
+        await eventHandler.waitForEvents();
+        // return the payload from the invoked chaincode
+        let result: any = null;
+        if (responses && responses.validResponses[0].response.payload.length > 0) {
+            result = responses.validResponses[0].response.payload;
+        }
+
+        eventHandler.cancelListening();
+
+        return result;
+    }
+
+    public async enroll(enrollmentID: string, enrollmentSecret: string): Promise<{certificate: string, privateKey: string}> {
+        const enrollment: ClientCA.IEnrollResponse = await this.gateway.getClient().getCertificateAuthority().enroll({ enrollmentID, enrollmentSecret });
+        return { certificate: enrollment.certificate, privateKey: enrollment.key.toBytes() };
+    }
+
+    public async register(enrollmentID: string, affiliation: string): Promise<string> {
+        const request: ClientCA.IRegisterRequest = {
+            enrollmentID: enrollmentID,
+            affiliation: affiliation,
+            role: 'client'
+        };
+        const registrar: Client.User = this.gateway.getCurrentIdentity();
+        const secret: string = await this.gateway.getClient().getCertificateAuthority().register(request, registrar);
+        return secret;
+    }
+
+    /**
+     * Get a chaincode from a list of list of chaincode
+     * @param name {String} The name of the chaincode to find
+     * @param chaincodeArray {Array<any>} An array of chaincode to search
+     * @returns {any} Returns a chaincode from the given array where the name matches the users input
+     */
+    private getChaincode(name: string, chaincodeArray: Array<any>): any {
+        return chaincodeArray.find((chaincode: any) => {
+            return chaincode.name === name;
+        });
+    }
+
 }

--- a/client/test/commands/submitTransaction.test.ts
+++ b/client/test/commands/submitTransaction.test.ts
@@ -70,7 +70,6 @@ describe('SubmitTransactionCommand', () => {
 
             fabricClientConnectionMock = sinon.createStubInstance(FabricClientConnection);
             fabricClientConnectionMock.connect.resolves();
-            fabricClientConnectionMock.instantiateChaincode.resolves();
             const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
             getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricClientConnectionMock);
 

--- a/client/test/commands/testSmartContractCommand.test.ts
+++ b/client/test/commands/testSmartContractCommand.test.ts
@@ -30,7 +30,6 @@ import { ChannelTreeItem } from '../../src/explorer/model/ChannelTreeItem';
 import { Reporter } from '../../src/util/Reporter';
 import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
-import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
 import { CommandUtil } from '../../src/util/CommandUtil';
 import { InstantiatedContractTreeItem } from '../../src/explorer/model/InstantiatedContractTreeItem';
 import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
@@ -46,7 +45,6 @@ chai.use(sinonChai);
 describe('testSmartContractCommand', () => {
     let mySandBox: sinon.SinonSandbox;
     let fabricClientConnectionMock: sinon.SinonStubbedInstance<FabricClientConnection>;
-    let fabricRuntimeConnectionMock: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
     let executeCommandStub: sinon.SinonStub;
     let logSpy: sinon.SinonSpy;
     let fsRemoveStub: sinon.SinonStub;
@@ -121,7 +119,6 @@ describe('testSmartContractCommand', () => {
             executeCommandStub.callThrough();
             fabricClientConnectionMock = sinon.createStubInstance(FabricClientConnection);
             fabricClientConnectionMock.connect.resolves();
-            fabricClientConnectionMock.instantiateChaincode.resolves();
             fakeMetadata = {
                 contracts: {
                     'my-contract': {
@@ -896,136 +893,5 @@ describe('testSmartContractCommand', () => {
             logSpy.getCall(5).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
         });
 
-    });
-
-    describe('Generate tests for Fabric Runtime Connection instantiated smart contract', () => {
-
-        beforeEach(async () => {
-            mySandBox = sinon.createSandbox();
-            reporterStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            fsRemoveStub = mySandBox.stub(fs, 'remove').resolves();
-            // ExecuteCommand stub
-            executeCommandStub = mySandBox.stub(vscode.commands, 'executeCommand');
-            executeCommandStub.withArgs(ExtensionCommands.CONNECT).resolves();
-            executeCommandStub.callThrough();
-            // Runtime Connection stubs
-            fabricRuntimeConnectionMock = sinon.createStubInstance(FabricRuntimeConnection);
-            fabricRuntimeConnectionMock.connect.resolves();
-            fabricRuntimeConnectionMock.instantiateChaincode.resolves();
-            fakeMetadata = {
-                contracts: {
-                    'my-contract': {
-                        name: 'my-contract',
-                        transactions: [
-                            {
-                                name: 'instantiate'
-                            },
-                            {
-                                name: 'wagonwheeling',
-                                parameters: []
-                            },
-                            {
-                                name: 'transaction2'
-                            }
-                        ]
-                    }
-                }
-            };
-            fabricRuntimeConnectionMock.getMetadata.resolves(fakeMetadata);
-            fabricConnectionManager = FabricConnectionManager.instance();
-            getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricRuntimeConnectionMock);
-            fabricRuntimeConnectionMock.getAllPeerNames.returns(['peerThree']);
-            fabricRuntimeConnectionMock.getAllChannelsForPeer.withArgs('peerThree').resolves(['myChannelTunnel']);
-            fabricRuntimeConnectionMock.getInstantiatedChaincode.resolves([
-                {
-                    name: 'doubleDecker',
-                    version: '0.0.7',
-                    label: 'doubleDecker@0.0.7',
-                    channel: 'myChannelTunnel'
-                }
-            ]);
-
-            const map: Map<string, Array<string>> = new Map<string, Array<string>>();
-            map.set('myChannelTunnel', ['peerThree']);
-            fabricRuntimeConnectionMock.createChannelMap.resolves(map);
-
-            gatewayRegistryEntry = new FabricGatewayRegistryEntry();
-            gatewayRegistryEntry.name = 'myConnection';
-            gatewayRegistryEntry.connectionProfilePath = 'myPath';
-            gatewayRegistryEntry.managedRuntime = true;
-            getGatewayRegistryStub = mySandBox.stub(fabricConnectionManager, 'getGatewayRegistryEntry').returns(gatewayRegistryEntry);
-
-            // Wallet stubs
-            walletRegistryEntry = new FabricWalletRegistryEntry();
-            walletRegistryEntry.name = 'myWallet';
-            walletRegistryEntry.walletPath = 'walletPath';
-            getWalletRegistryStub = mySandBox.stub(fabricConnectionManager, 'getConnectionWallet').returns(walletRegistryEntry);
-
-            // UserInputUtil stubs
-            showInstantiatedSmartContractsQuickPickStub = mySandBox.stub(UserInputUtil, 'showInstantiatedSmartContractsQuickPick').withArgs(sinon.match.any, 'myChannelTunnel').resolves('doubleDecker@0.0.7');
-            // Explorer provider stuff
-            blockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
-            allChildren = await blockchainGatewayExplorerProvider.getChildren();
-            const channelChildren: Array<ChannelTreeItem> = await blockchainGatewayExplorerProvider.getChildren(allChildren[2]) as Array<ChannelTreeItem>;
-            chaincodes = channelChildren[0].chaincodes;
-            instantiatedSmartContract = chaincodes[0] as InstantiatedContractTreeItem;
-            smartContractLabel = instantiatedSmartContract.label;
-            smartContractName = instantiatedSmartContract.name;
-            // Document editor stubs
-            testFileDir = path.join(rootPath, '..', 'data', 'smartContractTests');
-            mockDocumentStub = {
-                lineCount: 8,
-                save: (): any => {
-                    return Promise.resolve();
-                }
-            };
-            mockDocumentSaveSpy = mySandBox.spy(mockDocumentStub, 'save');
-            mockEditBuilder = {
-                replace: (): any => {
-                    return Promise.resolve();
-                }
-            };
-            mockEditBuilderReplaceSpy = mySandBox.spy(mockEditBuilder, 'replace');
-            mockTextEditor = {
-                edit: mySandBox.stub()
-            };
-            mockTextEditor.edit.yields(mockEditBuilder);
-            mockTextEditor.edit.resolves(true);
-            openTextDocumentStub = mySandBox.stub(vscode.workspace, 'openTextDocument').resolves(mockDocumentStub);
-            showTextDocumentStub = mySandBox.stub(vscode.window, 'showTextDocument').resolves(mockTextEditor);
-            packageJSONPath = vscode.Uri.file(path.join(testFileDir, 'package.json'));
-            mySandBox.stub(vscode.workspace, 'findFiles').resolves([packageJSONPath]);
-            const smartContractNameBuffer: Buffer = Buffer.from(`{"name": "${smartContractName}"}`);
-            readFileStub = mySandBox.stub(fs, 'readFile').resolves(smartContractNameBuffer);
-            workspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').resolves([{ name: 'wagonwheeling' }]);
-            sendCommandStub = mySandBox.stub(CommandUtil, 'sendCommand').resolves();
-            showLanguageQuickPickStub = mySandBox.stub(UserInputUtil, 'showLanguagesQuickPick').resolves({ label: 'JavaScript', type: LanguageType.CONTRACT });
-            logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
-        });
-
-        it('should generate tests for a runtime connection', async () => {
-            mySandBox.stub(fs, 'pathExists').resolves(false);
-            const testFilePath: string = path.join(packageJSONPath.fsPath, '..', 'functionalTests', `my-contract-${smartContractLabel}.test.js`);
-
-            await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
-            openTextDocumentStub.should.have.been.calledOnce;
-            showTextDocumentStub.should.have.been.calledOnce;
-            const templateData: string = mockEditBuilderReplaceSpy.args[0][1];
-            templateData.should.not.equal('');
-            templateData.includes(smartContractLabel).should.be.true;
-            templateData.includes(fakeMetadata.contracts['my-contract'].transactions[0].name).should.be.true;
-            templateData.includes(fakeMetadata.contracts['my-contract'].transactions[1].name).should.be.true;
-            templateData.includes(fakeMetadata.contracts['my-contract'].transactions[2].name).should.be.true;
-            templateData.startsWith('/*').should.be.true;
-            templateData.includes('walletPath').should.be.true;
-            templateData.includes('gateway.connect').should.be.true;
-            templateData.includes('submitTransaction').should.be.true;
-            sendCommandStub.should.have.been.calledOnce;
-
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
-            logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
-            logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.0, fabric-client@1.4.0`);
-            logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
-        });
     });
 });

--- a/client/test/commands/upgradeCommand.test.ts
+++ b/client/test/commands/upgradeCommand.test.ts
@@ -96,15 +96,6 @@ describe('UpgradeCommand', () => {
 
             fabricRuntimeMock.getInstantiatedChaincode.resolves([{ name: 'biscuit-network', version: '0.0.1' }]);
 
-            fabricRuntimeMock.getMetadata.resolves({
-                contracts: {
-                    'my-contract' : {
-                        name: 'my-contract',
-                        transactions: [],
-                    }
-                }
-            });
-
             const map: Map<string, Array<string>> = new Map<string, Array<string>>();
             map.set('channelOne', ['peerOne']);
             fabricRuntimeMock.createChannelMap.resolves(map);

--- a/client/test/explorer/gatewayExplorer.test.ts
+++ b/client/test/explorer/gatewayExplorer.test.ts
@@ -38,16 +38,10 @@ import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { InstantiatedChaincodeTreeItem } from '../../src/explorer/model/InstantiatedChaincodeTreeItem';
 import { GatewayTreeItem } from '../../src/explorer/model/GatewayTreeItem';
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 
 chai.use(sinonChai);
 const should: Chai.Should = chai.should();
-
-class TestFabricConnection extends FabricConnection {
-
-    async connect(): Promise<void> {
-        return;
-    }
-}
 
 // tslint:disable no-unused-expression
 describe('gatewayExplorer', () => {
@@ -88,7 +82,7 @@ describe('gatewayExplorer', () => {
             const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
             mySandBox.stub(blockchainGatewayExplorerProvider, 'connect').resolves();
             mySandBox.stub(blockchainGatewayExplorerProvider, 'disconnect').resolves();
-            const mockConnection: sinon.SinonStubbedInstance<TestFabricConnection> = sinon.createStubInstance(TestFabricConnection);
+            const mockConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
             const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
             connectionManager.emit('connected', mockConnection);
             blockchainGatewayExplorerProvider.connect.should.have.been.calledOnceWithExactly(mockConnection);
@@ -98,7 +92,7 @@ describe('gatewayExplorer', () => {
             const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
             mySandBox.stub(blockchainGatewayExplorerProvider, 'connect').rejects(new Error('wow such error'));
             mySandBox.stub(blockchainGatewayExplorerProvider, 'disconnect').resolves();
-            const mockConnection: sinon.SinonStubbedInstance<TestFabricConnection> = sinon.createStubInstance(TestFabricConnection);
+            const mockConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
             const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
             connectionManager.emit('connected', mockConnection);
             // Need to ensure the event handler gets a chance to run.
@@ -258,7 +252,7 @@ describe('gatewayExplorer', () => {
             });
 
             it('should handle errors thrown when connection fails', async () => {
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
 
                 const fabricConnectionManager: FabricConnectionManager = FabricConnectionManager.instance();
 
@@ -275,7 +269,7 @@ describe('gatewayExplorer', () => {
 
             it('should error if createChannelMap fails', async () => {
 
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
                 getConnectionStub.returns((fabricConnection as any) as FabricConnection);
                 fabricConnection.getAllPeerNames.returns(['peerOne']);
                 fabricConnection.createChannelMap.callThrough();
@@ -301,8 +295,8 @@ describe('gatewayExplorer', () => {
 
             it('should error if gRPC cant connect to Fabric', async () => {
 
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
-                getConnectionStub.returns((fabricConnection as any) as FabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
+                getConnectionStub.returns((fabricConnection as any) as FabricClientConnection);
                 fabricConnection.getAllPeerNames.returns(['peerOne']);
                 fabricConnection.createChannelMap.callThrough();
                 fabricConnection.getAllChannelsForPeer.throws({ message: 'Received http2 header with status: 503' });
@@ -331,7 +325,7 @@ describe('gatewayExplorer', () => {
             let mySandBox: sinon.SinonSandbox;
             let allChildren: Array<BlockchainTreeItem>;
             let blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider;
-            let fabricConnection: sinon.SinonStubbedInstance<FabricConnection>;
+            let fabricConnection: sinon.SinonStubbedInstance<FabricClientConnection>;
             let registryEntry: FabricGatewayRegistryEntry;
             let getGatewayRegistryEntryStub: sinon.SinonStub;
             let logSpy: sinon.SinonSpy;
@@ -342,7 +336,7 @@ describe('gatewayExplorer', () => {
 
                 await ExtensionUtil.activateExtension();
 
-                fabricConnection = sinon.createStubInstance(TestFabricConnection);
+                fabricConnection = sinon.createStubInstance(FabricClientConnection);
 
                 fabricConnection.getAllPeerNames.returns(['peerOne', 'peerTwo']);
 
@@ -877,7 +871,7 @@ describe('gatewayExplorer', () => {
 
             const onDidChangeTreeDataSpy: sinon.SinonSpy = mySandBox.spy(blockchainGatewayExplorerProvider['_onDidChangeTreeData'], 'fire');
 
-            const myConnection: TestFabricConnection = new TestFabricConnection();
+            const myConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
 
             const executeCommandSpy: sinon.SinonSpy = mySandBox.spy(vscode.commands, 'executeCommand');
 

--- a/client/test/explorer/runtimeOpsExplorer.test.ts
+++ b/client/test/explorer/runtimeOpsExplorer.test.ts
@@ -41,16 +41,10 @@ import { ExtensionCommands } from '../../ExtensionCommands';
 import { MetadataUtil } from '../../src/util/MetadataUtil';
 import { CertificateAuthorityTreeItem } from '../../src/explorer/runtimeOps/CertificateAuthorityTreeItem';
 import { OrdererTreeItem } from '../../src/explorer/runtimeOps/OrdererTreeItem';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
 
 chai.use(sinonChai);
 chai.should();
-
-class TestFabricConnection extends FabricConnection {
-
-    async connect(): Promise<void> {
-        return;
-    }
-}
 
 // tslint:disable no-unused-expression
 describe('runtimeOpsExplorer', () => {
@@ -125,8 +119,8 @@ describe('runtimeOpsExplorer', () => {
 
             it('should error if gRPC cant connect to Fabric', async () => {
                 isRunningStub.resolves(true);
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
-                getConnectionStub.returns((fabricConnection as any) as FabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection> = sinon.createStubInstance(FabricRuntimeConnection);
+                getConnectionStub.returns((fabricConnection as any) as FabricRuntimeConnection);
                 fabricConnection.getAllPeerNames.returns(['peerOne']);
                 fabricConnection.getAllChannelsForPeer.throws({ message: 'Received http2 header with status: 503' });
                 fabricConnection.createChannelMap.callThrough();
@@ -140,8 +134,8 @@ describe('runtimeOpsExplorer', () => {
 
             it('should error if getAllChannelsForPeer errors with message when populating channels view', async () => {
                 isRunningStub.resolves(true);
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
-                getConnectionStub.returns((fabricConnection as any) as FabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection> = sinon.createStubInstance(FabricRuntimeConnection);
+                getConnectionStub.returns((fabricConnection as any) as FabricRuntimeConnection);
                 fabricConnection.getAllPeerNames.returns(['peerOne']);
                 fabricConnection.getAllChannelsForPeer.throws({ message: 'some error' });
                 fabricConnection.createChannelMap.callThrough();
@@ -155,8 +149,8 @@ describe('runtimeOpsExplorer', () => {
 
             it('should error if getAllChannelsForPeer errors without a message when populating organizations view', async () => {
                 isRunningStub.resolves(true);
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
-                getConnectionStub.returns((fabricConnection as any) as FabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection> = sinon.createStubInstance(FabricRuntimeConnection);
+                getConnectionStub.returns((fabricConnection as any) as FabricRuntimeConnection);
                 fabricConnection.getAllPeerNames.returns(['peerOne']);
                 const error: Error = new Error('an error with no message');
                 fabricConnection.getAllChannelsForPeer.throws(error);
@@ -171,8 +165,8 @@ describe('runtimeOpsExplorer', () => {
 
             it('should error if populating nodes view fails', async () => {
                 isRunningStub.resolves(true);
-                const fabricConnection: sinon.SinonStubbedInstance<FabricConnection> = sinon.createStubInstance(TestFabricConnection);
-                getConnectionStub.returns((fabricConnection as any) as FabricConnection);
+                const fabricConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection> = sinon.createStubInstance(FabricRuntimeConnection);
+                getConnectionStub.returns((fabricConnection as any) as FabricRuntimeConnection);
                 fabricConnection.getAllPeerNames.throws({ message: 'some error' });
 
                 const blockchainRuntimeExplorerProvider: BlockchainRuntimeExplorerProvider = myExtension.getBlockchainRuntimeExplorerProvider();
@@ -188,7 +182,7 @@ describe('runtimeOpsExplorer', () => {
             let mySandBox: sinon.SinonSandbox;
             let allChildren: Array<BlockchainTreeItem>;
             let blockchainRuntimeExplorerProvider: BlockchainRuntimeExplorerProvider;
-            let fabricConnection: sinon.SinonStubbedInstance<FabricConnection>;
+            let fabricConnection: sinon.SinonStubbedInstance<FabricRuntimeConnection>;
             let logSpy: sinon.SinonSpy;
 
             beforeEach(async () => {
@@ -199,7 +193,7 @@ describe('runtimeOpsExplorer', () => {
 
                 await ExtensionUtil.activateExtension();
 
-                fabricConnection = sinon.createStubInstance(TestFabricConnection);
+                fabricConnection = sinon.createStubInstance(FabricRuntimeConnection);
 
                 fabricConnection.getAllPeerNames.returns(['peerOne', 'peerTwo']);
 

--- a/client/test/fabric/FabricClientConnection.test.ts
+++ b/client/test/fabric/FabricClientConnection.test.ts
@@ -31,6 +31,8 @@ chai.use(sinonChai);
 // tslint:disable no-unused-expression
 describe('FabricClientConnection', () => {
 
+    let fabricContractStub: any;
+    let fabricTransactionStub: any;
     let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
     let fabricClientConnection: FabricClientConnection;
     let fabricClientConnectionYaml: FabricClientConnection;
@@ -41,7 +43,7 @@ describe('FabricClientConnection', () => {
 
     let mySandBox: sinon.SinonSandbox;
 
-    let gatewayStub: sinon.SinonStubbedInstance<Gateway>;
+    let fabricGatewayStub: sinon.SinonStubbedInstance<Gateway>;
 
     const rootPath: string = path.dirname(__dirname);
 
@@ -55,8 +57,52 @@ describe('FabricClientConnection', () => {
 
         fabricClientStub.getMspid.returns('myMSPId');
 
-        gatewayStub = sinon.createStubInstance(Gateway);
-        gatewayStub.connect.resolves();
+        fabricGatewayStub = sinon.createStubInstance(Gateway);
+        fabricGatewayStub.connect.resolves();
+
+        const eventHandlerOptions: any = {
+            commitTimeout: 30,
+            strategy: 'MSPID_SCOPE_ANYFORTX'
+        };
+
+        const responsesStub: any = {
+            validResponses: [
+                {
+                    response: {
+                        payload: new Buffer('payload response buffer')
+                    }
+                }
+            ]
+        };
+
+        const eventHandlerStub: any = {
+            startListening: mySandBox.stub(),
+            cancelListening: mySandBox.stub(),
+            waitForEvents: mySandBox.stub(),
+        };
+
+        fabricTransactionStub = {
+            _validatePeerResponses: mySandBox.stub().returns(responsesStub),
+            _createTxEventHandler: mySandBox.stub().returns(eventHandlerStub)
+        };
+
+        fabricContractStub = {
+            createTransaction: mySandBox.stub().returns(fabricTransactionStub),
+            evaluateTransaction: mySandBox.stub(),
+            submitTransaction: mySandBox.stub(),
+            getEventHandlerOptions: mySandBox.stub().returns(eventHandlerOptions)
+        };
+
+        const fabricNetworkStub: any = {
+            getContract: mySandBox.stub().returns(fabricContractStub)
+        };
+
+        fabricGatewayStub.getNetwork.returns(fabricNetworkStub);
+        fabricGatewayStub.disconnect.returns(null);
+
+        fabricClientConnection = new FabricClientConnection({ connectionProfilePath: 'connectionpath', walletPath: 'walletPath' });
+        fabricClientConnection['gateway'] = fabricGatewayStub;
+        fabricClientConnection['outputAdapter'] = VSCodeBlockchainOutputAdapter.instance();
     });
 
     afterEach(() => {
@@ -71,14 +117,14 @@ describe('FabricClientConnection', () => {
                 walletPath: path.join(rootPath, '../../test/data/walletDir/wallet')
             };
             fabricClientConnection = FabricConnectionFactory.createFabricClientConnection(connectionData) as FabricClientConnection;
-            fabricClientConnection['gateway'] = gatewayStub;
+            fabricClientConnection['gateway'] = fabricGatewayStub;
 
             wallet = new FabricWallet(connectionData.walletPath);
         });
 
         it('should connect to a fabric', async () => {
             await fabricClientConnection.connect(wallet, 'Admin@org1.example.com');
-            gatewayStub.connect.should.have.been.called;
+            fabricGatewayStub.connect.should.have.been.called;
             logSpy.should.not.have.been.calledWith(LogType.ERROR);
             fabricClientConnection['networkIdProperty'].should.equal(false);
         });
@@ -86,61 +132,58 @@ describe('FabricClientConnection', () => {
         it('should connect with an already loaded client connection', async () => {
             should.exist(FabricConnectionFactory['clientConnection']);
             await fabricClientConnection.connect(wallet, 'Admin@org1.example.com');
-            gatewayStub.connect.should.have.been.called;
+            fabricGatewayStub.connect.should.have.been.called;
             logSpy.should.not.have.been.calledWith(LogType.ERROR);
             fabricClientConnection['networkIdProperty'].should.equal(false);
         });
 
-    });
+        it('should connect to a fabric with a .yaml connection profile', async () => {
+            const connectionYamlData: any = {
+                connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/connection.yaml'),
+                walletPath: path.join(rootPath, '../../test/data/connectionYaml/wallet')
+            };
+            wallet = new FabricWallet(connectionYamlData.walletPath);
+            fabricClientConnectionYaml = FabricConnectionFactory.createFabricClientConnection(connectionYamlData) as FabricClientConnection;
+            fabricClientConnectionYaml['gateway'] = fabricGatewayStub;
 
-    it('should connect to a fabric with a .yaml connection profile', async () => {
-        const connectionYamlData: any = {
-            connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/connection.yaml'),
-            walletPath: path.join(rootPath, '../../test/data/connectionYaml/wallet')
-        };
-        wallet = new FabricWallet(connectionYamlData.walletPath);
-        fabricClientConnectionYaml = FabricConnectionFactory.createFabricClientConnection(connectionYamlData) as FabricClientConnection;
-        fabricClientConnectionYaml['gateway'] = gatewayStub;
+            await fabricClientConnectionYaml.connect(wallet, 'Admin@org1.example.com');
+            fabricGatewayStub.connect.should.have.been.called;
+            logSpy.should.not.have.been.calledWith(LogType.ERROR);
+            fabricClientConnectionYaml['networkIdProperty'].should.equal(false);
+        });
 
-        await fabricClientConnectionYaml.connect(wallet, 'Admin@org1.example.com');
-        gatewayStub.connect.should.have.been.called;
-        logSpy.should.not.have.been.calledWith(LogType.ERROR);
-        fabricClientConnectionYaml['networkIdProperty'].should.equal(false);
-    });
+        it('should connect to a fabric with a .yml connection profile', async () => {
+            const otherConnectionYmlData: any = {
+                connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/otherConnectionProfile.yml'),
+                walletPath: path.join(rootPath, '../../test/data/connectionYaml/wallet')
+            };
+            wallet = new FabricWallet(otherConnectionYmlData.walletPath);
+            otherFabricClientConnectionYml = FabricConnectionFactory.createFabricClientConnection(otherConnectionYmlData) as FabricClientConnection;
+            otherFabricClientConnectionYml['gateway'] = fabricGatewayStub;
 
-    it('should connect to a fabric with a .yml connection profile', async () => {
-        const otherConnectionYmlData: any = {
-            connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/otherConnectionProfile.yml'),
-            walletPath: path.join(rootPath, '../../test/data/connectionYaml/wallet')
-        };
-        wallet = new FabricWallet(otherConnectionYmlData.walletPath);
-        otherFabricClientConnectionYml = FabricConnectionFactory.createFabricClientConnection(otherConnectionYmlData) as FabricClientConnection;
-        otherFabricClientConnectionYml['gateway'] = gatewayStub;
+            await otherFabricClientConnectionYml.connect(wallet, 'Admin@org1.example.com');
+            fabricGatewayStub.connect.should.have.been.called;
+            logSpy.should.not.have.been.calledWith(LogType.ERROR);
+            fabricClientConnectionYaml['networkIdProperty'].should.equal(false);
+        });
 
-        await otherFabricClientConnectionYml.connect(wallet, 'Admin@org1.example.com');
-        gatewayStub.connect.should.have.been.called;
-        logSpy.should.not.have.been.calledWith(LogType.ERROR);
-        fabricClientConnectionYaml['networkIdProperty'].should.equal(false);
-    });
+        it('should detecting connecting to ibp instance', async () => {
 
-    it('should detecting connecting to ibp instance', async () => {
+            const connectionData: any = {
+                connectionProfilePath: path.join(rootPath, '../../test/data/connectionTwo/connection.json'),
+                walletPath: path.join(rootPath, '../../test/data/walletDir/wallet')
+            };
+            wallet = new FabricWallet(connectionData.walletPath);
+            fabricClientConnection = FabricConnectionFactory.createFabricClientConnection(connectionData) as FabricClientConnection;
+            fabricClientConnection['gateway'] = fabricGatewayStub;
 
-        const connectionData: any = {
-            connectionProfilePath: path.join(rootPath, '../../test/data/connectionTwo/connection.json'),
-            walletPath: path.join(rootPath, '../../test/data/walletDir/wallet')
-        };
-        wallet = new FabricWallet(connectionData.walletPath);
-        fabricClientConnection = FabricConnectionFactory.createFabricClientConnection(connectionData) as FabricClientConnection;
-        fabricClientConnection['gateway'] = gatewayStub;
+            await fabricClientConnection.connect(wallet, 'Admin@org1.example.com');
 
-        await fabricClientConnection.connect(wallet, 'Admin@org1.example.com');
+            fabricGatewayStub.connect.should.have.been.called;
+            logSpy.should.not.have.been.calledWith(LogType.ERROR);
+            fabricClientConnection['networkIdProperty'].should.equal(true);
+        });
 
-        gatewayStub.connect.should.have.been.called;
-        logSpy.should.not.have.been.calledWith(LogType.ERROR);
-        fabricClientConnection['networkIdProperty'].should.equal(true);
-    });
-
-    describe('connection failure', () => {
         it('should show an error if connection profile is not .yaml or .json file', async () => {
             const connectionWrongData: any = {
                 connectionProfilePath: path.join(rootPath, '../../test/data/connectionYaml/connection'),
@@ -148,10 +191,122 @@ describe('FabricClientConnection', () => {
             };
             wallet = new FabricWallet(connectionWrongData.walletPath);
             fabricClientConnectionWrong = FabricConnectionFactory.createFabricClientConnection(connectionWrongData) as FabricClientConnection;
-            fabricClientConnectionWrong['gateway'] = gatewayStub;
+            fabricClientConnectionWrong['gateway'] = fabricGatewayStub;
 
             await fabricClientConnectionWrong.connect(wallet, 'Admin@org1.example.com').should.have.been.rejectedWith('Connection profile must be in JSON or yaml format');
-            gatewayStub.connect.should.not.have.been.called;
+            fabricGatewayStub.connect.should.not.have.been.called;
+        });
+
+    });
+
+    describe('isIBPConnection', () => {
+        it('should return true if connected to an IBP instance', async () => {
+            fabricClientConnection['networkIdProperty'] = true;
+            const result: boolean = await fabricClientConnection.isIBPConnection();
+            result.should.equal(true);
+        });
+        it('should return false if not connected to an IBP instance', async () => {
+            fabricClientConnection['networkIdProperty'] = false;
+            const result: boolean = await fabricClientConnection.isIBPConnection();
+            result.should.equal(false);
+        });
+    });
+
+    describe('getMetadata', () => {
+        it('should return the metadata for an instantiated smart contract', async () => {
+            const fakeMetaData: string = '{"contracts":{"my-contract":{"name":"","contractInstance":{"name":""},"transactions":[{"name":"instantiate"},{"name":"wagonwheeling"},{"name":"transaction2"}],"info":{"title":"","version":""}},"org.hyperledger.fabric":{"name":"org.hyperledger.fabric","contractInstance":{"name":"org.hyperledger.fabric"},"transactions":[{"name":"GetMetadata"}],"info":{"title":"","version":""}}},"info":{"version":"0.0.2","title":"victoria_sponge"},"components":{"schemas":{}}}';
+            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
+            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
+
+            const metadata: any = await fabricClientConnection.getMetadata('myChaincode', 'channelConga');
+            // tslint:disable-next-line
+            const testFunction: string = metadata.contracts["my-contract"].transactions[1].name;
+            // tslint:disable-next-line
+            testFunction.should.equal("wagonwheeling");
+        });
+
+        it('should throw an error if an error is thrown by an instantiated smart contract', async () => {
+            fabricContractStub.evaluateTransaction.rejects(new Error('no such function!'));
+
+            await fabricClientConnection.getMetadata('myChaincode', 'channelConga')
+                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" returned an error: no such function!/);
+        });
+
+        it('should throw an error if no metadata is returned by an instantiated smart contract', async () => {
+            const fakeMetaData: string = '';
+            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
+            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
+
+            await fabricClientConnection.getMetadata('myChaincode', 'channelConga')
+                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" did not return any metadata/);
+        });
+
+        it('should throw an error if non-JSON metadata is returned by an instantiated smart contract', async () => {
+            const fakeMetaData: string = '500 tokens to lulzwat@dogecorp.com';
+            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
+            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
+
+            await fabricClientConnection.getMetadata('myChaincode', 'channelConga')
+                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" did not return valid JSON metadata/);
+        });
+
+    });
+
+    describe('submitTransaction', () => {
+        it('should handle no response from a submitted transaction', async () => {
+            const buffer: Buffer = Buffer.from([]);
+            fabricContractStub.submitTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
+            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            should.equal(result, undefined);
+        });
+
+        it('should handle a returned string response from a submitted transaction', async () => {
+            const buffer: Buffer = Buffer.from('hello world');
+            fabricContractStub.submitTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
+            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            result.should.equal('hello world');
+        });
+
+        it('should handle a returned empty string response from a submitted transaction', async () => {
+            const buffer: Buffer = Buffer.from('');
+            fabricContractStub.submitTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
+            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            should.equal(result, undefined);
+        });
+
+        it('should handle a returned array from a submitted transaction', async () => {
+
+            const buffer: Buffer = Buffer.from(JSON.stringify(['hello', 'world']));
+            fabricContractStub.submitTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
+            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            should.equal(result, '["hello","world"]');
+        });
+
+        it('should handle returned object from a submitted transaction', async () => {
+
+            const buffer: Buffer = Buffer.from(JSON.stringify({hello: 'world'}));
+            fabricContractStub.submitTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
+            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            should.equal(result, '{"hello":"world"}');
+        });
+
+        it('should evaluate a transaction if specified', async () => {
+            const buffer: Buffer = Buffer.from([]);
+            fabricContractStub.evaluateTransaction.resolves(buffer);
+
+            const result: string | undefined = await fabricClientConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract', true);
+            fabricContractStub.evaluateTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
+            should.equal(result, undefined);
         });
     });
 });

--- a/client/test/fabric/FabricConnection.test.ts
+++ b/client/test/fabric/FabricConnection.test.ts
@@ -13,8 +13,6 @@
 */
 
 import { FabricConnection } from '../../src/fabric/FabricConnection';
-import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
-import * as path from 'path';
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
@@ -23,16 +21,14 @@ import * as fabricClientCA from 'fabric-ca-client';
 import { Gateway, Wallet, FileSystemWallet } from 'fabric-network';
 import { Channel, Peer } from 'fabric-client';
 import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
-import { LogType, OutputAdapter } from '../../src/logging/OutputAdapter';
+import { OutputAdapter } from '../../src/logging/OutputAdapter';
 
-const should: Chai.Should = chai.should();
+chai.should();
 chai.use(sinonChai);
 
 // tslint:disable no-unused-expression
 // tslint:disable no-use-before-declare
 describe('FabricConnection', () => {
-
-    const TEST_PACKAGE_DIRECTORY: string = path.join(path.dirname(__dirname), '..', '..', 'test', 'data', 'packageDir', 'packages');
 
     class TestFabricConnection extends FabricConnection {
 
@@ -52,9 +48,7 @@ describe('FabricConnection', () => {
     let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
     let fabricGatewayStub: sinon.SinonStubbedInstance<Gateway>;
     let fabricConnection: TestFabricConnection;
-    let fabricContractStub: any;
     let fabricChannelStub: sinon.SinonStubbedInstance<Channel>;
-    let fabricTransactionStub: any;
     let fabricCAStub: sinon.SinonStubbedInstance<fabricClientCA>;
     let mockWallet: sinon.SinonStubbedInstance<Wallet>;
     const mockIdentityName: string = 'admin';
@@ -102,37 +96,6 @@ describe('FabricConnection', () => {
         fabricGatewayStub.connect.resolves();
         fabricGatewayStub.getCurrentIdentity.resolves({});
 
-        const eventHandlerOptions: any = {
-            commitTimeout: 30,
-            strategy: 'MSPID_SCOPE_ANYFORTX'
-        };
-
-        const eventHandlerStub: any = {
-            startListening: mySandBox.stub(),
-            cancelListening: mySandBox.stub(),
-            waitForEvents: mySandBox.stub(),
-        };
-        const responsesStub: any = {
-            validResponses: [
-                {
-                    response: {
-                        payload: new Buffer('payload response buffer')
-                    }
-                }
-            ]
-        };
-        fabricTransactionStub = {
-            _validatePeerResponses: mySandBox.stub().returns(responsesStub),
-            _createTxEventHandler: mySandBox.stub().returns(eventHandlerStub)
-        };
-
-        fabricContractStub = {
-            createTransaction: mySandBox.stub().returns(fabricTransactionStub),
-            evaluateTransaction: mySandBox.stub(),
-            submitTransaction: mySandBox.stub(),
-            getEventHandlerOptions: mySandBox.stub().returns(eventHandlerOptions)
-        };
-
         fabricChannelStub = sinon.createStubInstance(Channel);
         fabricChannelStub.sendInstantiateProposal.resolves([{}, {}]);
         fabricChannelStub.sendUpgradeProposal.resolves([{}, {}]);
@@ -140,7 +103,6 @@ describe('FabricConnection', () => {
         fabricChannelStub.getOrganizations.resolves([{id: 'Org1MSP'}]);
 
         const fabricNetworkStub: any = {
-            getContract: mySandBox.stub().returns(fabricContractStub),
             getChannel: mySandBox.stub().returns(fabricChannelStub)
         };
 
@@ -316,29 +278,19 @@ describe('FabricConnection', () => {
         });
     });
 
-    describe('getPeer', () => {
-        it('should get a peer', async () => {
-            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
-            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
+    // describe('getPeer', () => {
+    //     it('should get a peer', async () => {
+    //         const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
+    //         const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
 
-            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
+    //         fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
 
-            await fabricConnection.connect(mockWallet, mockIdentityName);
+    //         await fabricConnection.connect(mockWallet, mockIdentityName);
 
-            const peer: fabricClient.Peer = await fabricConnection.getPeer('peerTwo');
-            peer.getName().should.deep.equal('peerTwo');
-        });
-    });
-
-    describe('getOrganization', () => {
-        it('should get an organization', async () => {
-            await fabricConnection.connect(mockWallet, mockIdentityName);
-
-            const orgs: any[] = await fabricConnection.getOrganizations('myChannel');
-            orgs.length.should.equal(1);
-            orgs[0].id.should.deep.equal('Org1MSP');
-        });
-    });
+    //         const peer: fabricClient.Peer = await fabricConnection.getPeer('peerTwo');
+    //         peer.getName().should.deep.equal('peerTwo');
+    //     });
+    // });
 
     describe('getAllChannelsForPeer', () => {
         it('should get all the channels a peer has joined', async () => {
@@ -355,55 +307,6 @@ describe('FabricConnection', () => {
             const channelNames: Array<string> = await fabricConnection.getAllChannelsForPeer('peerTwo');
 
             channelNames.should.deep.equal(['channel-one', 'channel-two']);
-        });
-    });
-
-    describe('getInstalledChaincode', () => {
-        it('should get the install chaincode', async () => {
-            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
-            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
-
-            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
-
-            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).resolves({
-                chaincodes: [{
-                    name: 'biscuit-network',
-                    version: '0.7'
-                }, { name: 'biscuit-network', version: '0.8' }, { name: 'cake-network', version: '0.8' }]
-            });
-
-            await fabricConnection.connect(mockWallet, mockIdentityName);
-            const installedChaincode: Map<string, Array<string>> = await fabricConnection.getInstalledChaincode('peerOne');
-            installedChaincode.size.should.equal(2);
-            Array.from(installedChaincode.keys()).should.deep.equal(['biscuit-network', 'cake-network']);
-            installedChaincode.get('biscuit-network').should.deep.equal(['0.7', '0.8']);
-            installedChaincode.get('cake-network').should.deep.equal(['0.8']);
-        });
-
-        it('should handle and swallow an access denied error', async () => {
-            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
-            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
-
-            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
-
-            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).rejects(new Error('wow u cannot see cc cos access denied as u is not an admin'));
-
-            await fabricConnection.connect(mockWallet, mockIdentityName);
-            const installedChaincode: Map<string, Array<string>> = await fabricConnection.getInstalledChaincode('peerOne');
-            installedChaincode.size.should.equal(0);
-            Array.from(installedChaincode.keys()).should.deep.equal([]);
-        });
-
-        it('should rethrow any error other than access denied', async () => {
-            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
-            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
-
-            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
-
-            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).rejects(new Error('wow u cannot see cc cos peer no works'));
-
-            await fabricConnection.connect(mockWallet, mockIdentityName);
-            await fabricConnection.getInstalledChaincode('peerOne').should.be.rejectedWith(/peer no works/);
         });
     });
 
@@ -505,397 +408,10 @@ describe('FabricConnection', () => {
         });
     });
 
-    describe('installChaincode', () => {
-
-        let peer: fabricClient.Peer;
-
-        beforeEach(async () => {
-            peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peer1' });
-            fabricClientStub.getPeersForOrg.returns([peer]);
-            const responseStub: any = [[{
-                response: {
-                    status: 200
-                }
-            }]];
-            fabricClientStub.installChaincode.resolves(responseStub);
-            await fabricConnection.connect(mockWallet, mockIdentityName);
-        });
-
-        it('should install the chaincode package', async () => {
-            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
-                name: 'vscode-pkg-1',
-                version: '0.0.1',
-                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
-            });
-
-            await fabricConnection.installChaincode(packageEntry, 'peer1');
-            fabricClientStub.installChaincode.should.have.been.calledWith({
-                targets: [peer],
-                txId: sinon.match.any,
-                chaincodePackage: sinon.match((buffer: Buffer) => {
-                    buffer.should.be.an.instanceOf(Buffer);
-                    buffer.length.should.equal(2719);
-                    return true;
-                })
-            });
-        });
-
-        it('should handle error response', async () => {
-            const responseStub: any = [[new Error('some error')]];
-            fabricClientStub.installChaincode.resolves(responseStub);
-
-            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
-                name: 'vscode-pkg-1',
-                version: '0.0.1',
-                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
-            });
-
-            await fabricConnection.installChaincode(packageEntry, 'peer1').should.be.rejectedWith(/some error/);
-            fabricClientStub.installChaincode.should.have.been.calledWith({
-                targets: [peer],
-                txId: sinon.match.any,
-                chaincodePackage: sinon.match((buffer: Buffer) => {
-                    buffer.should.be.an.instanceOf(Buffer);
-                    buffer.length.should.equal(2719);
-                    return true;
-                })
-            });
-        });
-
-        it('should handle failed response', async () => {
-            const responseStub: any = [[{
-                response: {
-                    message: 'some error',
-                    status: 400
-                }
-            }]];
-            fabricClientStub.installChaincode.resolves(responseStub);
-
-            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
-                name: 'vscode-pkg-1',
-                version: '0.0.1',
-                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
-            });
-
-            await fabricConnection.installChaincode(packageEntry, 'peer1').should.be.rejectedWith('some error');
-            fabricClientStub.installChaincode.should.have.been.calledWith({
-                targets: [peer],
-                txId: sinon.match.any,
-                chaincodePackage: sinon.match((buffer: Buffer) => {
-                    buffer.should.be.an.instanceOf(Buffer);
-                    buffer.length.should.equal(2719);
-                    return true;
-                })
-            });
-        });
-
-        it('should handle an error if the chaincode package does not exist', async () => {
-            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
-                name: 'vscode-pkg-1',
-                version: '0.0.1',
-                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-doesnotexist@0.0.1.cds')
-            });
-
-            await fabricConnection.installChaincode(packageEntry, 'peer1')
-                .should.have.been.rejectedWith(/ENOENT/);
-        });
-
-        it('should handle an error installing the chaincode package', async () => {
-            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
-                name: 'vscode-pkg-1',
-                version: '0.0.1',
-                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
-            });
-
-            fabricClientStub.installChaincode.rejects(new Error('such error'));
-            await fabricConnection.installChaincode(packageEntry, 'peer1')
-                .should.have.been.rejectedWith(/such error/);
-        });
-
-    });
-
-    describe('instantiateChaincode', () => {
-
-        let getChanincodesStub: sinon.SinonStub;
-        beforeEach(() => {
-            getChanincodesStub = mySandBox.stub(fabricConnection, 'getInstantiatedChaincode');
-            getChanincodesStub.resolves([]);
-        });
-
-        it('should instantiate a chaincode', async () => {
-            const outputSpy: sinon.SinonSpy = mySandBox.spy(fabricConnection['outputAdapter'], 'log');
-
-            const responsePayload: any = await fabricConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.not.be.rejected;
-            fabricChannelStub.sendInstantiateProposal.should.have.been.calledWith({
-                chaincodeId: 'myChaincode',
-                chaincodeVersion: '0.0.1',
-                txId: sinon.match.any,
-                fcn: 'instantiate',
-                args: ['arg1']
-            });
-            responsePayload.toString().should.equal('payload response buffer');
-            outputSpy.should.have.been.calledWith(LogType.INFO, undefined, "Instantiating with function: 'instantiate' and arguments: 'arg1'");
-        });
-
-        it('should throw an error instantiating if contract is already instantiated', async () => {
-            const output: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
-            const logSpy: sinon.SinonSpy = mySandBox.spy(output, 'log');
-            getChanincodesStub.withArgs('myChannel').resolves([{ name: 'myChaincode' }]);
-            await fabricConnection.instantiateChaincode('myChaincode', '0.0.2', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('The name of the contract you tried to instantiate is already instantiated');
-            fabricChannelStub.sendUpgradeProposal.should.not.have.been.called;
-
-            logSpy.should.not.have.been.calledWith("Upgrading with function: 'instantiate' and arguments: 'arg1'");
-        });
-
-        it('should instantiate a chaincode and can return empty payload response', async () => {
-            fabricTransactionStub._validatePeerResponses.returns(null);
-            const nullResponsePayload: any = await fabricConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']);
-            fabricChannelStub.sendInstantiateProposal.should.have.been.calledWith({
-                chaincodeId: 'myChaincode',
-                chaincodeVersion: '0.0.1',
-                txId: sinon.match.any,
-                fcn: 'instantiate',
-                args: ['arg1']
-            });
-            should.not.exist(nullResponsePayload);
-        });
-
-        it('should throw an error if cant create event handler', async () => {
-            fabricTransactionStub._createTxEventHandler.returns();
-            await fabricConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to create an event handler');
-        });
-
-        it('should throw an error if submitting the transaction failed', async () => {
-            fabricChannelStub.sendTransaction.returns({ status: 'FAILED' });
-            await fabricConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to send peer responses for transaction 1234 to orderer. Response status: FAILED');
-        });
-    });
-
-    describe('isIBPConnection', () => {
-        it('should return true if connected to an IBP instance', async () => {
-            fabricConnection['networkIdProperty'] = true;
-            const result: boolean = await fabricConnection.isIBPConnection();
-            result.should.equal(true);
-        });
-        it('should return false if not connected to an IBP instance', async () => {
-            fabricConnection['networkIdProperty'] = false;
-            const result: boolean = await fabricConnection.isIBPConnection();
-            result.should.equal(false);
-        });
-    });
-
-    describe('getMetadata', () => {
-        it('should return the metadata for an instantiated smart contract', async () => {
-            const fakeMetaData: string = '{"contracts":{"my-contract":{"name":"","contractInstance":{"name":""},"transactions":[{"name":"instantiate"},{"name":"wagonwheeling"},{"name":"transaction2"}],"info":{"title":"","version":""}},"org.hyperledger.fabric":{"name":"org.hyperledger.fabric","contractInstance":{"name":"org.hyperledger.fabric"},"transactions":[{"name":"GetMetadata"}],"info":{"title":"","version":""}}},"info":{"version":"0.0.2","title":"victoria_sponge"},"components":{"schemas":{}}}';
-            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
-            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
-
-            const metadata: any = await fabricConnection.getMetadata('myChaincode', 'channelConga');
-            // tslint:disable-next-line
-            const testFunction: string = metadata.contracts["my-contract"].transactions[1].name;
-            // tslint:disable-next-line
-            testFunction.should.equal("wagonwheeling");
-        });
-
-        it('should throw an error if an error is thrown by an instantiated smart contract', async () => {
-            fabricContractStub.evaluateTransaction.rejects(new Error('no such function!'));
-
-            await fabricConnection.getMetadata('myChaincode', 'channelConga')
-                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" returned an error: no such function!/);
-        });
-
-        it('should throw an error if no metadata is returned by an instantiated smart contract', async () => {
-            const fakeMetaData: string = '';
-            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
-            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
-
-            await fabricConnection.getMetadata('myChaincode', 'channelConga')
-                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" did not return any metadata/);
-        });
-
-        it('should throw an error if non-JSON metadata is returned by an instantiated smart contract', async () => {
-            const fakeMetaData: string = '500 tokens to lulzwat@dogecorp.com';
-            const fakeMetaDataBuffer: Buffer = Buffer.from(fakeMetaData, 'utf8');
-            fabricContractStub.evaluateTransaction.resolves(fakeMetaDataBuffer);
-
-            await fabricConnection.getMetadata('myChaincode', 'channelConga')
-                .should.be.rejectedWith(/Transaction function "org.hyperledger.fabric:GetMetadata" did not return valid JSON metadata/);
-        });
-
-    });
-
-    describe('submitTransaction', () => {
-        it('should handle no response from a submitted transaction', async () => {
-            const buffer: Buffer = Buffer.from([]);
-            fabricContractStub.submitTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
-            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            should.equal(result, undefined);
-        });
-
-        it('should handle a returned string response from a submitted transaction', async () => {
-            const buffer: Buffer = Buffer.from('hello world');
-            fabricContractStub.submitTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
-            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            result.should.equal('hello world');
-        });
-
-        it('should handle a returned empty string response from a submitted transaction', async () => {
-            const buffer: Buffer = Buffer.from('');
-            fabricContractStub.submitTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
-            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            should.equal(result, undefined);
-        });
-
-        it('should handle a returned array from a submitted transaction', async () => {
-
-            const buffer: Buffer = Buffer.from(JSON.stringify(['hello', 'world']));
-            fabricContractStub.submitTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
-            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            should.equal(result, '["hello","world"]');
-        });
-
-        it('should handle returned object from a submitted transaction', async () => {
-
-            const buffer: Buffer = Buffer.from(JSON.stringify({hello: 'world'}));
-            fabricContractStub.submitTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract');
-            fabricContractStub.submitTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            should.equal(result, '{"hello":"world"}');
-        });
-
-        it('should evaluate a transaction if specified', async () => {
-            const buffer: Buffer = Buffer.from([]);
-            fabricContractStub.evaluateTransaction.resolves(buffer);
-
-            const result: string | undefined = await fabricConnection.submitTransaction('mySmartContract', 'transaction1', 'myChannel', ['arg1', 'arg2'], 'my-contract', true);
-            fabricContractStub.evaluateTransaction.should.have.been.calledWith('transaction1', 'arg1', 'arg2');
-            should.equal(result, undefined);
-        });
-    });
-
     describe('disconnect', () => {
         it('should disconnect from gateway', async () => {
             await fabricConnection.disconnect();
             fabricGatewayStub.disconnect.should.have.been.called;
-        });
-    });
-
-    describe('upgradeChaincode', () => {
-
-        let getChanincodesStub: sinon.SinonStub;
-        beforeEach(() => {
-            getChanincodesStub = mySandBox.stub(fabricConnection, 'getInstantiatedChaincode');
-            getChanincodesStub.resolves([]);
-        });
-
-        it('should upgrade a chaincode', async () => {
-            const outputSpy: sinon.SinonSpy = mySandBox.spy(fabricConnection['outputAdapter'], 'log');
-            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
-            const responsePayload: any = await fabricConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.not.be.rejected;
-            fabricChannelStub.sendUpgradeProposal.should.have.been.calledWith({
-                chaincodeId: 'myChaincode',
-                chaincodeVersion: '0.0.1',
-                txId: sinon.match.any,
-                fcn: 'instantiate',
-                args: ['arg1']
-            });
-            responsePayload.toString().should.equal('payload response buffer');
-            outputSpy.should.have.been.calledWith(LogType.INFO, undefined, "Upgrading with function: 'instantiate' and arguments: 'arg1'");
-        });
-
-        it('should throw an error instantiating if no contract with the same name has been instantiated', async () => {
-            const output: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
-            const outputSpy: sinon.SinonSpy = mySandBox.spy(output, 'log');
-
-            await fabricConnection.upgradeChaincode('myChaincode', '0.0.2', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('The contract you tried to upgrade with has no previous versions instantiated');
-            fabricChannelStub.sendUpgradeProposal.should.not.have.been.called;
-
-            outputSpy.should.not.have.been.calledWith("Upgrading with function: 'instantiate' and arguments: 'arg1'");
-        });
-
-        it('should instantiate a chaincode and can return empty payload response', async () => {
-            fabricTransactionStub._validatePeerResponses.returns(null);
-            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
-
-            const nullResponsePayload: any = await fabricConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']);
-            fabricChannelStub.sendUpgradeProposal.should.have.been.calledWith({
-                chaincodeId: 'myChaincode',
-                chaincodeVersion: '0.0.1',
-                txId: sinon.match.any,
-                fcn: 'instantiate',
-                args: ['arg1']
-            });
-            should.not.exist(nullResponsePayload);
-        });
-
-        it('should throw an error if cant create event handler', async () => {
-            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
-            fabricTransactionStub._createTxEventHandler.returns();
-            await fabricConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to create an event handler');
-        });
-
-        it('should throw an error if submitting the transaction failed', async () => {
-            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
-            fabricChannelStub.sendTransaction.returns({ status: 'FAILED' });
-            await fabricConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to send peer responses for transaction 1234 to orderer. Response status: FAILED');
-        });
-    });
-
-    describe('enroll', () => {
-        it('should enroll an identity', async () => {
-            const result: {certificate: string, privateKey: string} =  await fabricConnection.enroll('myId', 'mySecret');
-            result.should.deep.equal({certificate : 'myCert', privateKey: 'myKey'});
-        });
-    });
-
-    describe('getCertificateAuthorityName', () => {
-        it('should get the certificate authority name', async () => {
-            fabricClientStub.getCertificateAuthority.returns({
-                getCaName: mySandBox.stub().returns('ca-name')
-            });
-            fabricConnection.getAllCertificateAuthorityNames().should.deep.equal(['ca-name']);
-        });
-    });
-    describe('getOrderers', () => {
-        it('should get orderers', async () => {
-            fabricClientStub.getChannel.onFirstCall().returns({
-                getOrderers: mySandBox.stub().returns([
-                    {
-                        getName: mySandBox.stub().returns('orderer1')
-                    }
-                ])
-            });
-            fabricClientStub.getChannel.onSecondCall().returns({
-                getOrderers: mySandBox.stub().returns([
-                    {
-                        getName: mySandBox.stub().returns('orderer2')
-                    }
-                ])
-            });
-            fabricChannelStub.getOrderers.onFirstCall().returns([new fabricClient.Orderer('grpc://url1')]);
-            fabricChannelStub.getOrderers.onSecondCall().returns([new fabricClient.Orderer('grpc://url2')]);
-            mySandBox.stub(fabricConnection, 'getAllPeerNames').returns(['peerOne', 'peerTwo']);
-            const getAllChannelsForPeer: sinon.SinonStub = mySandBox.stub(fabricConnection, 'getAllChannelsForPeer');
-            getAllChannelsForPeer.withArgs('peerOne').resolves(['channel1']);
-            getAllChannelsForPeer.withArgs('peerTwo').resolves(['channel2']);
-            const orderers: Array<string> = await fabricConnection.getAllOrdererNames();
-            orderers.should.deep.equal(['orderer1', 'orderer2']);
-        });
-    });
-
-    describe('register', () => {
-        it('should register a new user and return a secret', async () => {
-            const secret: string = await fabricConnection.register('enrollThis', 'departmentE');
-            secret.should.deep.equal('its a secret');
         });
     });
 
@@ -944,31 +460,5 @@ describe('FabricConnection', () => {
 
             await fabricConnection.createChannelMap().should.be.rejectedWith(`Error creating channel map: ${error.message}`);
         });
-    });
-
-    describe('getAllInstantiatedChaincodes', () => {
-
-        it('should get all instantiated chaincodes', async () => {
-            const map: Map<string, Array<string>> = new Map<string, Array<string>>();
-            map.set('channel1', ['peerOne']);
-            map.set('channel2', ['peerOne', 'peerTwo']);
-            mySandBox.stub(fabricConnection, 'createChannelMap').resolves(map);
-
-            const getInstantiatedChaincodeStub: sinon.SinonStub = mySandBox.stub(fabricConnection, 'getInstantiatedChaincode');
-            getInstantiatedChaincodeStub.withArgs('channel1').resolves([{name: 'a_chaincode', version: '0.0.1'}, {name: 'another_chaincode', version: '0.0.7'}]);
-            getInstantiatedChaincodeStub.withArgs('channel2').resolves([{name: 'another_chaincode', version: '0.0.7'}]);
-
-            const instantiatedChaincodes: Array<{name: string, version: string}> = await fabricConnection.getAllInstantiatedChaincodes();
-
-            instantiatedChaincodes.should.deep.equal([{name: 'a_chaincode', version: '0.0.1'}, {name: 'another_chaincode', version: '0.0.7'}]);
-        });
-
-        it('should handle any errors', async () => {
-            const error: Error = new Error('Could not create channel map');
-            mySandBox.stub(fabricConnection, 'createChannelMap').rejects(error);
-
-            await fabricConnection.getAllInstantiatedChaincodes().should.be.rejectedWith(`Could not get all instantiated chaincodes: ${error}`);
-        });
-
     });
 });

--- a/client/test/fabric/FabricConnectionManager.test.ts
+++ b/client/test/fabric/FabricConnectionManager.test.ts
@@ -12,34 +12,26 @@
  * limitations under the License.
 */
 
-import { FabricConnection } from '../../src/fabric/FabricConnection';
 import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
 import { FabricWalletRegistryEntry } from '../../src/fabric/FabricWalletRegistryEntry';
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 
 const should: Chai.Should = chai.should();
 
 describe('FabricConnectionManager', () => {
 
-    class TestFabricConnection extends FabricConnection {
-
-        async connect(): Promise<void> {
-            return;
-        }
-
-    }
-
     const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
-    let mockFabricConnection: sinon.SinonStubbedInstance<TestFabricConnection>;
+    let mockFabricConnection: sinon.SinonStubbedInstance<FabricClientConnection>;
     let sandbox: sinon.SinonSandbox;
     let registryEntry: FabricGatewayRegistryEntry;
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();
-        mockFabricConnection = sinon.createStubInstance(TestFabricConnection);
+        mockFabricConnection = sinon.createStubInstance(FabricClientConnection);
         connectionManager['connection'] = null;
 
         registryEntry = new FabricGatewayRegistryEntry();
@@ -56,7 +48,7 @@ describe('FabricConnectionManager', () => {
     describe('#getConnection', () => {
 
         it('should get the connection', () => {
-            connectionManager['connection'] = ((mockFabricConnection as any) as FabricConnection);
+            connectionManager['connection'] = ((mockFabricConnection as any) as FabricClientConnection);
             connectionManager.getConnection().should.equal(mockFabricConnection);
         });
 
@@ -74,7 +66,7 @@ describe('FabricConnectionManager', () => {
         it('should store the connection and emit an event', () => {
             const listenerStub: sinon.SinonStub = sinon.stub();
             connectionManager.once('connected', listenerStub);
-            connectionManager.connect((mockFabricConnection as any) as FabricConnection, registryEntry);
+            connectionManager.connect((mockFabricConnection as any) as FabricClientConnection, registryEntry);
             connectionManager.getConnection().should.equal(mockFabricConnection);
             connectionManager.getGatewayRegistryEntry().should.equal(registryEntry);
             listenerStub.should.have.been.calledOnceWithExactly(mockFabricConnection);
@@ -98,7 +90,7 @@ describe('FabricConnectionManager', () => {
 
         it('should get the name of the identity used to connect', () => {
             mockFabricConnection.identityName = 'admin@conga';
-            connectionManager['connection'] = ((mockFabricConnection as any) as FabricConnection);
+            connectionManager['connection'] = ((mockFabricConnection as any) as FabricClientConnection);
             connectionManager.getConnectionIdentity().should.equal('admin@conga');
         });
 
@@ -112,7 +104,7 @@ describe('FabricConnectionManager', () => {
                 walletPath: '/some/path'
             });
             mockFabricConnection.wallet = walletRegistryEntry;
-            connectionManager['connection'] = ((mockFabricConnection as any) as FabricConnection);
+            connectionManager['connection'] = ((mockFabricConnection as any) as FabricClientConnection);
             connectionManager.getConnectionWallet().should.deep.equal(walletRegistryEntry);
         });
 

--- a/client/test/fabric/FabricRuntimeConnection.test.ts
+++ b/client/test/fabric/FabricRuntimeConnection.test.ts
@@ -18,11 +18,16 @@ import { FabricConnectionFactory } from '../../src/fabric/FabricConnectionFactor
 import { FabricWallet } from '../../src/fabric/FabricWallet';
 import { Gateway } from 'fabric-network';
 import * as fabricClient from 'fabric-client';
+import * as fabricClientCA from 'fabric-ca-client';
+import { Channel } from 'fabric-client';
 import * as path from 'path';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
 import * as sinonChai from 'sinon-chai';
+import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
+import { PackageRegistryEntry } from '../../src/packages/PackageRegistryEntry';
+import { LogType } from '../../src/logging/OutputAdapter';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -30,10 +35,17 @@ chai.use(sinonChai);
 // tslint:disable no-unused-expression
 describe('FabricRuntimeConnection', () => {
 
+    const TEST_PACKAGE_DIRECTORY: string = path.join(path.dirname(__dirname), '..', '..', 'test', 'data', 'packageDir', 'packages');
+
     let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
     let fabricRuntimeStub: sinon.SinonStubbedInstance<FabricRuntime>;
     let fabricRuntimeConnection: FabricRuntimeConnection;
+    let fabricChannelStub: sinon.SinonStubbedInstance<Channel>;
+    let fabricContractStub: any;
+    let fabricTransactionStub: any;
     let wallet: FabricWallet;
+    const mockIdentityName: string = 'Admin@org1.example.com';
+    let fabricCAStub: sinon.SinonStubbedInstance<fabricClientCA>;
 
     let mySandBox: sinon.SinonSandbox;
 
@@ -118,6 +130,62 @@ describe('FabricRuntimeConnection', () => {
         gatewayStub = sinon.createStubInstance(Gateway);
         gatewayStub.connect.resolves();
         fabricRuntimeConnection['gateway'] = gatewayStub;
+
+        const eventHandlerOptions: any = {
+            commitTimeout: 30,
+            strategy: 'MSPID_SCOPE_ANYFORTX'
+        };
+
+        const eventHandlerStub: any = {
+            startListening: mySandBox.stub(),
+            cancelListening: mySandBox.stub(),
+            waitForEvents: mySandBox.stub(),
+        };
+        const responsesStub: any = {
+            validResponses: [
+                {
+                    response: {
+                        payload: new Buffer('payload response buffer')
+                    }
+                }
+            ]
+        };
+        fabricTransactionStub = {
+            _validatePeerResponses: mySandBox.stub().returns(responsesStub),
+            _createTxEventHandler: mySandBox.stub().returns(eventHandlerStub)
+        };
+
+        fabricContractStub = {
+            createTransaction: mySandBox.stub().returns(fabricTransactionStub),
+            evaluateTransaction: mySandBox.stub(),
+            submitTransaction: mySandBox.stub(),
+            getEventHandlerOptions: mySandBox.stub().returns(eventHandlerOptions)
+        };
+
+        fabricChannelStub = sinon.createStubInstance(Channel);
+        fabricChannelStub.sendInstantiateProposal.resolves([{}, {}]);
+        fabricChannelStub.sendUpgradeProposal.resolves([{}, {}]);
+        fabricChannelStub.sendTransaction.resolves({ status: 'SUCCESS' });
+        fabricChannelStub.getOrganizations.resolves([{id: 'Org1MSP'}]);
+
+        const fabricNetworkStub: any = {
+            getContract: mySandBox.stub().returns(fabricContractStub),
+            getChannel: mySandBox.stub().returns(fabricChannelStub)
+        };
+
+        gatewayStub.getNetwork.returns(fabricNetworkStub);
+
+        fabricClientStub = mySandBox.createStubInstance(fabricClient);
+        fabricClientStub.newTransactionID.returns({
+            getTransactionID: mySandBox.stub().returns('1234')
+        });
+        gatewayStub.getClient.returns(fabricClientStub);
+
+        fabricClientStub.getMspid.returns('myMSPId');
+        fabricCAStub = mySandBox.createStubInstance(fabricClientCA);
+        fabricCAStub.enroll.returns({certificate : 'myCert', key : { toBytes : mySandBox.stub().returns('myKey')}});
+        fabricCAStub.register.resolves('its a secret');
+        fabricClientStub.getCertificateAuthority.returns(fabricCAStub);
     });
 
     afterEach(() => {
@@ -133,6 +201,368 @@ describe('FabricRuntimeConnection', () => {
             should.exist(FabricConnectionFactory['runtimeConnection']);
             await fabricRuntimeConnection.connect(wallet, 'Admin@org1.example.com');
             gatewayStub.connect.should.have.been.called;
+        });
+    });
+
+    describe('getAllInstantiatedChaincodes', () => {
+
+        it('should get all instantiated chaincodes', async () => {
+            const map: Map<string, Array<string>> = new Map<string, Array<string>>();
+            map.set('channel1', ['peerOne']);
+            map.set('channel2', ['peerOne', 'peerTwo']);
+            mySandBox.stub(fabricRuntimeConnection, 'createChannelMap').resolves(map);
+
+            const getInstantiatedChaincodeStub: sinon.SinonStub = mySandBox.stub(fabricRuntimeConnection, 'getInstantiatedChaincode');
+            getInstantiatedChaincodeStub.withArgs('channel1').resolves([{name: 'a_chaincode', version: '0.0.1'}, {name: 'another_chaincode', version: '0.0.7'}]);
+            getInstantiatedChaincodeStub.withArgs('channel2').resolves([{name: 'another_chaincode', version: '0.0.7'}]);
+
+            const instantiatedChaincodes: Array<{name: string, version: string}> = await fabricRuntimeConnection.getAllInstantiatedChaincodes();
+
+            instantiatedChaincodes.should.deep.equal([{name: 'a_chaincode', version: '0.0.1'}, {name: 'another_chaincode', version: '0.0.7'}]);
+        });
+
+        it('should handle any errors', async () => {
+            const error: Error = new Error('Could not create channel map');
+            mySandBox.stub(fabricRuntimeConnection, 'createChannelMap').rejects(error);
+
+            await fabricRuntimeConnection.getAllInstantiatedChaincodes().should.be.rejectedWith(`Could not get all instantiated chaincodes: ${error}`);
+        });
+
+    });
+
+    describe('getOrganization', () => {
+        it('should get an organization', async () => {
+            await fabricRuntimeConnection.connect(wallet, mockIdentityName);
+
+            const orgs: any[] = await fabricRuntimeConnection.getOrganizations('myChannel');
+            orgs.length.should.equal(1);
+            orgs[0].id.should.deep.equal('Org1MSP');
+        });
+    });
+
+    describe('getAllCertificateAuthorityNames', () => {
+        it('should get the certificate authority name', async () => {
+            fabricClientStub.getCertificateAuthority.returns({
+                getCaName: mySandBox.stub().returns('ca-name')
+            });
+            fabricRuntimeConnection.getAllCertificateAuthorityNames().should.deep.equal(['ca-name']);
+        });
+    });
+
+    describe('getInstalledChaincode', () => {
+        it('should get the install chaincode', async () => {
+            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
+            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
+
+            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
+
+            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).resolves({
+                chaincodes: [{
+                    name: 'biscuit-network',
+                    version: '0.7'
+                }, { name: 'biscuit-network', version: '0.8' }, { name: 'cake-network', version: '0.8' }]
+            });
+
+            await fabricRuntimeConnection.connect(wallet, mockIdentityName);
+            const installedChaincode: Map<string, Array<string>> = await fabricRuntimeConnection.getInstalledChaincode('peerOne');
+            installedChaincode.size.should.equal(2);
+            Array.from(installedChaincode.keys()).should.deep.equal(['biscuit-network', 'cake-network']);
+            installedChaincode.get('biscuit-network').should.deep.equal(['0.7', '0.8']);
+            installedChaincode.get('cake-network').should.deep.equal(['0.8']);
+        });
+
+        it('should handle and swallow an access denied error', async () => {
+            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
+            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
+
+            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
+
+            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).rejects(new Error('wow u cannot see cc cos access denied as u is not an admin'));
+
+            await fabricRuntimeConnection.connect(wallet, mockIdentityName);
+            const installedChaincode: Map<string, Array<string>> = await fabricRuntimeConnection.getInstalledChaincode('peerOne');
+            installedChaincode.size.should.equal(0);
+            Array.from(installedChaincode.keys()).should.deep.equal([]);
+        });
+
+        it('should rethrow any error other than access denied', async () => {
+            const peerOne: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1454', { name: 'peerOne' });
+            const peerTwo: fabricClient.Peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peerTwo' });
+
+            fabricClientStub.getPeersForOrg.returns([peerOne, peerTwo]);
+
+            fabricClientStub.queryInstalledChaincodes.withArgs(peerOne).rejects(new Error('wow u cannot see cc cos peer no works'));
+
+            await fabricRuntimeConnection.connect(wallet, mockIdentityName);
+            await fabricRuntimeConnection.getInstalledChaincode('peerOne').should.be.rejectedWith(/peer no works/);
+        });
+    });
+
+    describe('getAllOrdererNames', () => {
+        it('should get orderers', async () => {
+            fabricClientStub.getChannel.onFirstCall().returns({
+                getOrderers: mySandBox.stub().returns([
+                    {
+                        getName: mySandBox.stub().returns('orderer1')
+                    }
+                ])
+            });
+            fabricClientStub.getChannel.onSecondCall().returns({
+                getOrderers: mySandBox.stub().returns([
+                    {
+                        getName: mySandBox.stub().returns('orderer2')
+                    }
+                ])
+            });
+            fabricChannelStub.getOrderers.onFirstCall().returns([new fabricClient.Orderer('grpc://url1')]);
+            fabricChannelStub.getOrderers.onSecondCall().returns([new fabricClient.Orderer('grpc://url2')]);
+            mySandBox.stub(fabricRuntimeConnection, 'getAllPeerNames').returns(['peerOne', 'peerTwo']);
+            const getAllChannelsForPeer: sinon.SinonStub = mySandBox.stub(fabricRuntimeConnection, 'getAllChannelsForPeer');
+            getAllChannelsForPeer.withArgs('peerOne').resolves(['channel1']);
+            getAllChannelsForPeer.withArgs('peerTwo').resolves(['channel2']);
+            const orderers: Array<string> = await fabricRuntimeConnection.getAllOrdererNames();
+            orderers.should.deep.equal(['orderer1', 'orderer2']);
+        });
+    });
+
+    describe('installChaincode', () => {
+
+        let peer: fabricClient.Peer;
+
+        beforeEach(async () => {
+            peer = new fabricClient.Peer('grpc://localhost:1453', { name: 'peer1' });
+            fabricClientStub.getPeersForOrg.returns([peer]);
+            const responseStub: any = [[{
+                response: {
+                    status: 200
+                }
+            }]];
+            fabricClientStub.installChaincode.resolves(responseStub);
+            await fabricRuntimeConnection.connect(wallet, mockIdentityName);
+        });
+
+        it('should install the chaincode package', async () => {
+            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
+                name: 'vscode-pkg-1',
+                version: '0.0.1',
+                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
+            });
+
+            await fabricRuntimeConnection.installChaincode(packageEntry, 'peer1');
+            fabricClientStub.installChaincode.should.have.been.calledWith({
+                targets: [peer],
+                txId: sinon.match.any,
+                chaincodePackage: sinon.match((buffer: Buffer) => {
+                    buffer.should.be.an.instanceOf(Buffer);
+                    buffer.length.should.equal(2719);
+                    return true;
+                })
+            });
+        });
+
+        it('should handle error response', async () => {
+            const responseStub: any = [[new Error('some error')]];
+            fabricClientStub.installChaincode.resolves(responseStub);
+
+            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
+                name: 'vscode-pkg-1',
+                version: '0.0.1',
+                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
+            });
+
+            await fabricRuntimeConnection.installChaincode(packageEntry, 'peer1').should.be.rejectedWith(/some error/);
+            fabricClientStub.installChaincode.should.have.been.calledWith({
+                targets: [peer],
+                txId: sinon.match.any,
+                chaincodePackage: sinon.match((buffer: Buffer) => {
+                    buffer.should.be.an.instanceOf(Buffer);
+                    buffer.length.should.equal(2719);
+                    return true;
+                })
+            });
+        });
+
+        it('should handle failed response', async () => {
+            const responseStub: any = [[{
+                response: {
+                    message: 'some error',
+                    status: 400
+                }
+            }]];
+            fabricClientStub.installChaincode.resolves(responseStub);
+
+            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
+                name: 'vscode-pkg-1',
+                version: '0.0.1',
+                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
+            });
+
+            await fabricRuntimeConnection.installChaincode(packageEntry, 'peer1').should.be.rejectedWith('some error');
+            fabricClientStub.installChaincode.should.have.been.calledWith({
+                targets: [peer],
+                txId: sinon.match.any,
+                chaincodePackage: sinon.match((buffer: Buffer) => {
+                    buffer.should.be.an.instanceOf(Buffer);
+                    buffer.length.should.equal(2719);
+                    return true;
+                })
+            });
+        });
+
+        it('should handle an error if the chaincode package does not exist', async () => {
+            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
+                name: 'vscode-pkg-1',
+                version: '0.0.1',
+                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-doesnotexist@0.0.1.cds')
+            });
+
+            await fabricRuntimeConnection.installChaincode(packageEntry, 'peer1')
+                .should.have.been.rejectedWith(/ENOENT/);
+        });
+
+        it('should handle an error installing the chaincode package', async () => {
+            const packageEntry: PackageRegistryEntry = new PackageRegistryEntry({
+                name: 'vscode-pkg-1',
+                version: '0.0.1',
+                path: path.join(TEST_PACKAGE_DIRECTORY, 'vscode-pkg-1@0.0.1.cds')
+            });
+
+            fabricClientStub.installChaincode.rejects(new Error('such error'));
+            await fabricRuntimeConnection.installChaincode(packageEntry, 'peer1')
+                .should.have.been.rejectedWith(/such error/);
+        });
+
+    });
+
+    describe('instantiateChaincode', () => {
+
+        let getChanincodesStub: sinon.SinonStub;
+        beforeEach(() => {
+            getChanincodesStub = mySandBox.stub(fabricRuntimeConnection, 'getInstantiatedChaincode');
+            getChanincodesStub.resolves([]);
+        });
+
+        it('should instantiate a chaincode', async () => {
+            const outputSpy: sinon.SinonSpy = mySandBox.spy(fabricRuntimeConnection['outputAdapter'], 'log');
+
+            const responsePayload: any = await fabricRuntimeConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.not.be.rejected;
+            fabricChannelStub.sendInstantiateProposal.should.have.been.calledWith({
+                chaincodeId: 'myChaincode',
+                chaincodeVersion: '0.0.1',
+                txId: sinon.match.any,
+                fcn: 'instantiate',
+                args: ['arg1']
+            });
+            responsePayload.toString().should.equal('payload response buffer');
+            outputSpy.should.have.been.calledWith(LogType.INFO, undefined, "Instantiating with function: 'instantiate' and arguments: 'arg1'");
+        });
+
+        it('should throw an error instantiating if contract is already instantiated', async () => {
+            const output: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
+            const logSpy: sinon.SinonSpy = mySandBox.spy(output, 'log');
+            getChanincodesStub.withArgs('myChannel').resolves([{ name: 'myChaincode' }]);
+            await fabricRuntimeConnection.instantiateChaincode('myChaincode', '0.0.2', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('The name of the contract you tried to instantiate is already instantiated');
+            fabricChannelStub.sendUpgradeProposal.should.not.have.been.called;
+
+            logSpy.should.not.have.been.calledWith("Upgrading with function: 'instantiate' and arguments: 'arg1'");
+        });
+
+        it('should instantiate a chaincode and can return empty payload response', async () => {
+            fabricTransactionStub._validatePeerResponses.returns(null);
+            const nullResponsePayload: any = await fabricRuntimeConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']);
+            fabricChannelStub.sendInstantiateProposal.should.have.been.calledWith({
+                chaincodeId: 'myChaincode',
+                chaincodeVersion: '0.0.1',
+                txId: sinon.match.any,
+                fcn: 'instantiate',
+                args: ['arg1']
+            });
+            should.not.exist(nullResponsePayload);
+        });
+
+        it('should throw an error if cant create event handler', async () => {
+            fabricTransactionStub._createTxEventHandler.returns();
+            await fabricRuntimeConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to create an event handler');
+        });
+
+        it('should throw an error if submitting the transaction failed', async () => {
+            fabricChannelStub.sendTransaction.returns({ status: 'FAILED' });
+            await fabricRuntimeConnection.instantiateChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to send peer responses for transaction 1234 to orderer. Response status: FAILED');
+        });
+    });
+
+    describe('upgradeChaincode', () => {
+
+        let getChanincodesStub: sinon.SinonStub;
+        beforeEach(() => {
+            getChanincodesStub = mySandBox.stub(fabricRuntimeConnection, 'getInstantiatedChaincode');
+            getChanincodesStub.resolves([]);
+        });
+
+        it('should upgrade a chaincode', async () => {
+            const outputSpy: sinon.SinonSpy = mySandBox.spy(fabricRuntimeConnection['outputAdapter'], 'log');
+            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
+            const responsePayload: any = await fabricRuntimeConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.not.be.rejected;
+            fabricChannelStub.sendUpgradeProposal.should.have.been.calledWith({
+                chaincodeId: 'myChaincode',
+                chaincodeVersion: '0.0.1',
+                txId: sinon.match.any,
+                fcn: 'instantiate',
+                args: ['arg1']
+            });
+            responsePayload.toString().should.equal('payload response buffer');
+            outputSpy.should.have.been.calledWith(LogType.INFO, undefined, "Upgrading with function: 'instantiate' and arguments: 'arg1'");
+        });
+
+        it('should throw an error instantiating if no contract with the same name has been instantiated', async () => {
+            const output: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
+            const outputSpy: sinon.SinonSpy = mySandBox.spy(output, 'log');
+
+            await fabricRuntimeConnection.upgradeChaincode('myChaincode', '0.0.2', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('The contract you tried to upgrade with has no previous versions instantiated');
+            fabricChannelStub.sendUpgradeProposal.should.not.have.been.called;
+
+            outputSpy.should.not.have.been.calledWith("Upgrading with function: 'instantiate' and arguments: 'arg1'");
+        });
+
+        it('should instantiate a chaincode and can return empty payload response', async () => {
+            fabricTransactionStub._validatePeerResponses.returns(null);
+            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
+
+            const nullResponsePayload: any = await fabricRuntimeConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']);
+            fabricChannelStub.sendUpgradeProposal.should.have.been.calledWith({
+                chaincodeId: 'myChaincode',
+                chaincodeVersion: '0.0.1',
+                txId: sinon.match.any,
+                fcn: 'instantiate',
+                args: ['arg1']
+            });
+            should.not.exist(nullResponsePayload);
+        });
+
+        it('should throw an error if cant create event handler', async () => {
+            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
+            fabricTransactionStub._createTxEventHandler.returns();
+            await fabricRuntimeConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to create an event handler');
+        });
+
+        it('should throw an error if submitting the transaction failed', async () => {
+            getChanincodesStub.resolves([{name: 'myChaincode', version: '0.0.2'}]);
+            fabricChannelStub.sendTransaction.returns({ status: 'FAILED' });
+            await fabricRuntimeConnection.upgradeChaincode('myChaincode', '0.0.1', 'myChannel', 'instantiate', ['arg1']).should.be.rejectedWith('Failed to send peer responses for transaction 1234 to orderer. Response status: FAILED');
+        });
+    });
+
+    describe('enroll', () => {
+        it('should enroll an identity', async () => {
+            const result: {certificate: string, privateKey: string} =  await fabricRuntimeConnection.enroll('myId', 'mySecret');
+            result.should.deep.equal({certificate : 'myCert', privateKey: 'myKey'});
+        });
+    });
+
+    describe('register', () => {
+        it('should register a new user and return a secret', async () => {
+            const secret: string = await fabricRuntimeConnection.register('enrollThis', 'departmentE');
+            secret.should.deep.equal('its a secret');
         });
     });
 


### PR DESCRIPTION
Move functions from the generic FabricConnection class into the FabricClientConnection class if they are client connection specific, and into the FabricRuntimeConnection class if they are runtime connection specific. The remaining functions are applicable to both (for now!).

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>