### PR TITLE
Remove old runtime related APIs (contributes to #776)

### DIFF
--- a/client/integrationTest/integrationTestUtil.ts
+++ b/client/integrationTest/integrationTestUtil.ts
@@ -150,11 +150,8 @@ export class IntegrationTestUtil {
         try {
             gatewayEntry = this.gatewayRegistry.get(name);
         } catch (error) {
-            gatewayEntry = new FabricGatewayRegistryEntry();
-            gatewayEntry.name = name;
-            gatewayEntry.managedRuntime = true;
-            gatewayEntry.associatedWallet = FabricWalletUtil.LOCAL_WALLET;
-            gatewayEntry.connectionProfilePath = FabricRuntimeManager.instance().getRuntime().getConnectionProfilePath();
+            const gatewayEntries: FabricGatewayRegistryEntry[] = await FabricRuntimeManager.instance().getGatewayRegistryEntries();
+            gatewayEntry = gatewayEntries[0];
         }
 
         let walletEntry: FabricWalletRegistryEntry;

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -76,7 +76,7 @@ export class UserInputUtil {
 
         if (showManagedRuntime) {
             // Allow users to choose local_fabric
-            const runtimeGateways: Array<FabricGatewayRegistryEntry> = FabricRuntimeManager.instance().getGatewayRegistryEntries();
+            const runtimeGateways: Array<FabricGatewayRegistryEntry> = await FabricRuntimeManager.instance().getGatewayRegistryEntries();
             allGateways.push(...runtimeGateways);
         }
 

--- a/client/src/commands/addWalletIdentityCommand.ts
+++ b/client/src/commands/addWalletIdentityCommand.ts
@@ -23,8 +23,6 @@ import { FabricWalletGeneratorFactory } from '../fabric/FabricWalletGeneratorFac
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricWalletRegistryEntry } from '../fabric/FabricWalletRegistryEntry';
 import { FabricWalletRegistry } from '../fabric/FabricWalletRegistry';
-import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
-import { FabricRuntime } from '../fabric/FabricRuntime';
 import { FabricGatewayRegistryEntry } from '../fabric/FabricGatewayRegistryEntry';
 import { IFabricCertificateAuthority } from '../fabric/IFabricCertificateAuthority';
 import { FabricCertificateAuthorityFactory } from '../fabric/FabricCertificateAuthorityFactory';
@@ -107,12 +105,6 @@ export async function addWalletIdentity(walletItem: BlockchainTreeItem | IFabric
         }
 
         const gatewayRegistryEntry: FabricGatewayRegistryEntry = chosenEntry.data;
-        if (gatewayRegistryEntry.managedRuntime) {
-            const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
-            const runtime: FabricRuntime = runtimeManager.getRuntime();
-
-            gatewayRegistryEntry.connectionProfilePath = runtime.getConnectionProfilePath();
-        }
 
         const enrollIdSecret: {enrollmentID: string, enrollmentSecret: string} = await UserInputUtil.getEnrollIdSecret();
         if (!enrollIdSecret) {

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -210,35 +210,6 @@ export class FabricRuntime extends EventEmitter {
         }
     }
 
-    public async getConnectionProfile(): Promise<object> {
-        const containerPrefix: string = this.docker.getContainerPrefix();
-        const connectionProfile: any = basicNetworkConnectionProfile;
-        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_peer0.org1.example.com`);
-        const peerRequestHost: string = Docker.fixHost(peerPorts['7051/tcp'][0].HostIp);
-        const peerRequestPort: string = peerPorts['7051/tcp'][0].HostPort;
-        const peerEventHost: string = Docker.fixHost(peerPorts['7053/tcp'][0].HostIp);
-        const peerEventPort: string = peerPorts['7053/tcp'][0].HostPort;
-        const ordererPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_orderer.example.com`);
-        const ordererHost: string = Docker.fixHost(ordererPorts['7050/tcp'][0].HostIp);
-        const ordererPort: string = ordererPorts['7050/tcp'][0].HostPort;
-        const caPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_ca.example.com`);
-        const caHost: string = Docker.fixHost(caPorts['7054/tcp'][0].HostIp);
-        const caPort: string = caPorts['7054/tcp'][0].HostPort;
-        connectionProfile.peers['peer0.org1.example.com'].url = `grpc://${peerRequestHost}:${peerRequestPort}`;
-        connectionProfile.peers['peer0.org1.example.com'].eventUrl = `grpc://${peerEventHost}:${peerEventPort}`;
-        connectionProfile.orderers['orderer.example.com'].url = `grpc://${ordererHost}:${ordererPort}`;
-        connectionProfile.certificateAuthorities['ca.org1.example.com'].url = `http://${caHost}:${caPort}`;
-        return connectionProfile;
-    }
-
-    public getConnectionProfilePath(): string {
-        const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
-        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
-        const dir: string = path.join(homeExtDir, this.name);
-
-        return path.join(dir, 'connection.json');
-    }
-
     public async getCertificate(): Promise<string> {
         return basicNetworkAdminCertificate;
     }
@@ -385,6 +356,35 @@ export class FabricRuntime extends EventEmitter {
             developmentMode: this.isDevelopmentMode(),
         };
         await vscode.workspace.getConfiguration().update('fabric.runtime', runtimeObject, vscode.ConfigurationTarget.Global);
+    }
+
+    private async getConnectionProfile(): Promise<object> {
+        const containerPrefix: string = this.docker.getContainerPrefix();
+        const connectionProfile: any = basicNetworkConnectionProfile;
+        const peerPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_peer0.org1.example.com`);
+        const peerRequestHost: string = Docker.fixHost(peerPorts['7051/tcp'][0].HostIp);
+        const peerRequestPort: string = peerPorts['7051/tcp'][0].HostPort;
+        const peerEventHost: string = Docker.fixHost(peerPorts['7053/tcp'][0].HostIp);
+        const peerEventPort: string = peerPorts['7053/tcp'][0].HostPort;
+        const ordererPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_orderer.example.com`);
+        const ordererHost: string = Docker.fixHost(ordererPorts['7050/tcp'][0].HostIp);
+        const ordererPort: string = ordererPorts['7050/tcp'][0].HostPort;
+        const caPorts: ContainerPorts = await this.docker.getContainerPorts(`${containerPrefix}_ca.example.com`);
+        const caHost: string = Docker.fixHost(caPorts['7054/tcp'][0].HostIp);
+        const caPort: string = caPorts['7054/tcp'][0].HostPort;
+        connectionProfile.peers['peer0.org1.example.com'].url = `grpc://${peerRequestHost}:${peerRequestPort}`;
+        connectionProfile.peers['peer0.org1.example.com'].eventUrl = `grpc://${peerEventHost}:${peerEventPort}`;
+        connectionProfile.orderers['orderer.example.com'].url = `grpc://${ordererHost}:${ordererPort}`;
+        connectionProfile.certificateAuthorities['ca.org1.example.com'].url = `http://${caHost}:${caPort}`;
+        return connectionProfile;
+    }
+
+    private getConnectionProfilePath(): string {
+        const extDir: string = vscode.workspace.getConfiguration().get('blockchain.ext.directory');
+        const homeExtDir: string = UserInputUtil.getDirPath(extDir);
+        const dir: string = path.join(homeExtDir, this.name);
+
+        return path.join(dir, 'connection.json');
     }
 
     private setBusy(busy: boolean): void {

--- a/client/src/fabric/FabricRuntime.ts
+++ b/client/src/fabric/FabricRuntime.ts
@@ -191,12 +191,12 @@ export class FabricRuntime extends EventEmitter {
 
     public async getWalletNames(): Promise<string[]> {
         return [
-            `${FabricWalletUtil.LOCAL_WALLET}`
+            `${FabricWalletUtil.LOCAL_WALLET}-ops`
         ];
     }
 
     public async getIdentities(walletName: string): Promise<FabricIdentity[]> {
-        if (walletName !== FabricWalletUtil.LOCAL_WALLET) {
+        if (walletName !== `${FabricWalletUtil.LOCAL_WALLET}-ops`) {
             throw new Error(`The wallet ${walletName} does not exist`);
         } else {
             return [
@@ -208,18 +208,6 @@ export class FabricRuntime extends EventEmitter {
                 )
             ];
         }
-    }
-
-    public async getCertificate(): Promise<string> {
-        return basicNetworkAdminCertificate;
-    }
-
-    public getCertificatePath(): string {
-        return basicNetworkAdminCertificatePath;
-    }
-
-    public async getPrivateKey(): Promise<string> {
-        return basicNetworkAdminPrivateKey;
     }
 
     public async isCreated(): Promise<boolean> {

--- a/client/src/fabric/FabricRuntimeManager.ts
+++ b/client/src/fabric/FabricRuntimeManager.ts
@@ -24,6 +24,7 @@ import { IFabricRuntimeConnection } from './IFabricRuntimeConnection';
 import { FabricGatewayRegistryEntry } from './FabricGatewayRegistryEntry';
 import { FabricWalletUtil } from './FabricWalletUtil';
 import { FabricRuntimeUtil } from './FabricRuntimeUtil';
+import { FabricGateway } from './FabricGateway';
 
 export class FabricRuntimeManager {
 
@@ -94,15 +95,15 @@ export class FabricRuntimeManager {
         }
     }
 
-    public getGatewayRegistryEntries(): FabricGatewayRegistryEntry[] {
+    public async getGatewayRegistryEntries(): Promise<FabricGatewayRegistryEntry[]> {
         const runtime: FabricRuntime = this.getRuntime();
-        const registryEntry: FabricGatewayRegistryEntry = new FabricGatewayRegistryEntry({
-            name: runtime.getName(),
+        const gateways: FabricGateway[] = await runtime.getGateways();
+        return gateways.map((gateway: FabricGateway) => new FabricGatewayRegistryEntry({
+            name: gateway.name,
             managedRuntime: true,
-            connectionProfilePath: runtime.getConnectionProfilePath(),
+            connectionProfilePath: gateway.path,
             associatedWallet: FabricWalletUtil.LOCAL_WALLET
-        });
-        return [registryEntry];
+        }));
     }
 
     private readRuntimeUserSettings(): any {

--- a/client/test/commands/UserInputUtil.test.ts
+++ b/client/test/commands/UserInputUtil.test.ts
@@ -174,10 +174,16 @@ describe('UserInputUtil', () => {
         fabricClientConnectionStub.getInstantiatedChaincode.withArgs('channelOne').resolves([{ name: 'biscuit-network', channel: 'channelOne', version: '0.0.1' }, { name: 'cake-network', channel: 'channelOne', version: '0.0.3' }]);
         getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricClientConnectionStub);
         mySandBox.stub(fabricRuntimeManager, 'getConnection').returns(fabricRuntimeConnectionStub);
+        mySandBox.stub(fabricRuntimeManager, 'getGatewayRegistryEntries').resolves([
+            new FabricGatewayRegistryEntry({
+                name: FabricRuntimeUtil.LOCAL_FABRIC,
+                managedRuntime: true,
+                connectionProfilePath: 'connection.json',
+                associatedWallet: FabricWalletUtil.LOCAL_WALLET
+            })
+        ]);
 
         quickPickStub = mySandBox.stub(vscode.window, 'showQuickPick');
-
-        FabricRuntimeManager.instance().exists().should.be.true;
     });
 
     afterEach(async () => {
@@ -206,8 +212,7 @@ describe('UserInputUtil', () => {
             managedRuntime.name = FabricRuntimeUtil.LOCAL_FABRIC;
             managedRuntime.managedRuntime = true;
             managedRuntime.associatedWallet = FabricWalletUtil.LOCAL_WALLET;
-            const connectionProfilePath: string = UserInputUtil.getDirPath(`~/.fabric-vscode/${FabricRuntimeUtil.LOCAL_FABRIC}/connection.json`);
-            managedRuntime.connectionProfilePath = connectionProfilePath;
+            managedRuntime.connectionProfilePath = 'connection.json';
 
             quickPickStub.resolves();
             await UserInputUtil.showGatewayQuickPickBox('Choose a gateway', true);

--- a/client/test/commands/addWalletIdentityCommand.test.ts
+++ b/client/test/commands/addWalletIdentityCommand.test.ts
@@ -364,13 +364,12 @@ describe('AddWalletIdentityCommand', () => {
                     label: FabricRuntimeUtil.LOCAL_FABRIC,
                     data: new FabricGatewayRegistryEntry({
                         name: FabricRuntimeUtil.LOCAL_FABRIC,
-                        connectionProfilePath: undefined,
+                        connectionProfilePath: '/some/path',
                         managedRuntime: true,
                         associatedWallet: FabricWalletUtil.LOCAL_WALLET
                     })
                 });
                 const runtime: FabricRuntime = new FabricRuntime();
-                mySandBox.stub(runtime, 'getConnectionProfilePath').returns('/some/path');
                 mySandBox.stub(FabricRuntimeManager.instance(), 'getRuntime').returns(runtime);
                 getEnrollIdSecretStub.resolves({enrollmentID: 'enrollID', enrollmentSecret: 'enrollSecret'});
                 enrollStub.resolves({certificate: '---CERT---', privateKey: '---KEY---'});

--- a/client/test/commands/associateWalletCommand.test.ts
+++ b/client/test/commands/associateWalletCommand.test.ts
@@ -30,6 +30,7 @@ import { ExtensionCommands } from '../../ExtensionCommands';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../../src/logging/OutputAdapter';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
 
 // tslint:disable no-unused-expression
 const should: Chai.Should = chai.should();
@@ -85,6 +86,8 @@ describe('AssociateWalletCommand', () => {
             fabricGatewayRegistryUpdateStub = mySandBox.stub(FabricGatewayRegistry.instance(), 'update').resolves();
             showWalletsQuickPickBoxStub = mySandBox.stub(UserInputUtil, 'showWalletsQuickPickBox');
             showGatewayQuickPickBoxStub = mySandBox.stub(UserInputUtil, 'showGatewayQuickPickBox');
+
+            mySandBox.stub(FabricRuntimeManager.instance(), 'getGatewayRegistryEntries').resolves([]);
         });
 
         afterEach(async () => {
@@ -99,7 +102,7 @@ describe('AssociateWalletCommand', () => {
 
             const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
             const gateways: Array<BlockchainTreeItem> = await blockchainGatewayExplorerProvider.getChildren();
-            const gatewayTreeItem: GatewayDissociatedTreeItem = gateways[1] as GatewayDissociatedTreeItem;
+            const gatewayTreeItem: GatewayDissociatedTreeItem = gateways[0] as GatewayDissociatedTreeItem;
 
             await vscode.commands.executeCommand(ExtensionCommands.ASSOCIATE_WALLET, gatewayTreeItem);
 
@@ -119,7 +122,7 @@ describe('AssociateWalletCommand', () => {
 
             const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
             const gateways: Array<BlockchainTreeItem> = await blockchainGatewayExplorerProvider.getChildren();
-            const gatewayTreeItem: GatewayDissociatedTreeItem = gateways[1] as GatewayDissociatedTreeItem;
+            const gatewayTreeItem: GatewayDissociatedTreeItem = gateways[0] as GatewayDissociatedTreeItem;
 
             await vscode.commands.executeCommand(ExtensionCommands.ASSOCIATE_WALLET, gatewayTreeItem);
 

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -145,9 +145,16 @@ describe('ConnectCommand', () => {
             mockRuntime.isRunning.resolves(true);
             mockRuntime.start.resolves();
             mySandBox.stub(FabricRuntimeManager.instance(), 'getRuntime').returns(mockRuntime);
+            mySandBox.stub(FabricRuntimeManager.instance(), 'getGatewayRegistryEntries').resolves([
+                new FabricGatewayRegistryEntry({
+                    name: FabricRuntimeUtil.LOCAL_FABRIC,
+                    managedRuntime: true,
+                    connectionProfilePath: '/some/path',
+                    associatedWallet: FabricWalletUtil.LOCAL_WALLET
+                })
+            ]);
 
             logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
-            mockRuntime.getConnectionProfilePath.resolves(path.join(rootPath, '../../basic-network/connection.json'));
             walletGenerator = await FabricWalletGenerator.instance();
 
             identity = {

--- a/client/test/commands/deleteGatewayCommand.test.ts
+++ b/client/test/commands/deleteGatewayCommand.test.ts
@@ -25,6 +25,7 @@ import { FabricGatewayRegistry } from '../../src/fabric/FabricGatewayRegistry';
 import { BlockchainGatewayExplorerProvider } from '../../src/explorer/gatewayExplorer';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { ExtensionCommands } from '../../ExtensionCommands';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
 
 chai.should();
 chai.use(sinonChai);
@@ -78,6 +79,8 @@ describe('DeleteGatewayCommand', () => {
                 label: 'myGatewayB',
                 data: FabricGatewayRegistry.instance().get('myGatewayB')
             });
+
+            mySandBox.stub(FabricRuntimeManager.instance(), 'getGatewayRegistryEntries').resolves([]);
         });
 
         afterEach(() => {
@@ -99,7 +102,7 @@ describe('DeleteGatewayCommand', () => {
 
             const allChildren: Array<BlockchainTreeItem> = await blockchainGatewayExplorerProvider.getChildren();
 
-            const connectionToDelete: BlockchainTreeItem = allChildren[1];
+            const connectionToDelete: BlockchainTreeItem = allChildren[0];
             await vscode.commands.executeCommand(ExtensionCommands.DELETE_GATEWAY, connectionToDelete);
 
             gateways = vscode.workspace.getConfiguration().get('fabric.gateways');

--- a/client/test/commands/dissociateWalletCommand.test.ts
+++ b/client/test/commands/dissociateWalletCommand.test.ts
@@ -30,6 +30,7 @@ import { ExtensionCommands } from '../../ExtensionCommands';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../../src/logging/OutputAdapter';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
 
 // tslint:disable no-unused-expression
 const should: Chai.Should = chai.should();
@@ -83,6 +84,7 @@ describe('DissociateWalletCommand', () => {
             logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
             fabricGatewayRegistryUpdateStub = mySandBox.stub(FabricGatewayRegistry.instance(), 'update').resolves();
             showGatewayQuickPickBoxStub = mySandBox.stub(UserInputUtil, 'showGatewayQuickPickBox');
+            mySandBox.stub(FabricRuntimeManager.instance(), 'getGatewayRegistryEntries').resolves([]);
         });
 
         afterEach(async () => {
@@ -92,7 +94,7 @@ describe('DissociateWalletCommand', () => {
         it('should test a wallet can be dissociated from a gateway using the tree', async () => {
             const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
             const gateways: Array<BlockchainTreeItem> = await blockchainGatewayExplorerProvider.getChildren();
-            const gatewayTreeItem: GatewayAssociatedTreeItem = gateways[1] as GatewayAssociatedTreeItem;
+            const gatewayTreeItem: GatewayAssociatedTreeItem = gateways[0] as GatewayAssociatedTreeItem;
 
             await vscode.commands.executeCommand(ExtensionCommands.DISSOCIATE_WALLET, gatewayTreeItem);
 

--- a/client/test/commands/startFabricRuntime.test.ts
+++ b/client/test/commands/startFabricRuntime.test.ts
@@ -63,8 +63,6 @@ describe('startFabricRuntime', () => {
         runtime = runtimeManager.getRuntime();
         sandbox.stub(FabricRuntimeManager.instance().getRuntime(), 'isRunning').resolves(false);
 
-        sandbox.stub(runtime, 'getCertificate').resolves();
-        sandbox.stub(runtime, 'getPrivateKey').resolves();
         const testFabricWallet: FabricWallet = new FabricWallet(path.join(rootPath, '../../test/data/walletDir/emptyWallet'));
         sandbox.stub(testFabricWallet, 'importIdentity').resolves();
         sandbox.stub(FabricWalletGenerator.instance(), 'createLocalWallet').resolves(testFabricWallet);

--- a/client/test/commands/startFabricRuntime.test.ts
+++ b/client/test/commands/startFabricRuntime.test.ts
@@ -63,7 +63,6 @@ describe('startFabricRuntime', () => {
         runtime = runtimeManager.getRuntime();
         sandbox.stub(FabricRuntimeManager.instance().getRuntime(), 'isRunning').resolves(false);
 
-        sandbox.stub(runtime, 'getConnectionProfile').resolves();
         sandbox.stub(runtime, 'getCertificate').resolves();
         sandbox.stub(runtime, 'getPrivateKey').resolves();
         const testFabricWallet: FabricWallet = new FabricWallet(path.join(rootPath, '../../test/data/walletDir/emptyWallet'));

--- a/client/test/debug/FabricDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricDebugConfigurationProvider.test.ts
@@ -85,7 +85,6 @@ describe('FabricDebugConfigurationProvider', () => {
 
             runtimeStub = sinon.createStubInstance(FabricRuntime);
             runtimeStub.getName.returns('localfabric');
-            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
             runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
             runtimeStub.isRunning.resolves(true);
             runtimeStub.isDevelopmentMode.returns(true);

--- a/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -75,7 +75,6 @@ describe('FabricGoDebugConfigurationProvider', () => {
 
             runtimeStub = sinon.createStubInstance(FabricRuntime);
             runtimeStub.getName.returns('localfabric');
-            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
             runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
             runtimeStub.isRunning.resolves(true);
             runtimeStub.isDevelopmentMode.returns(true);

--- a/client/test/debug/FabricJavaDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricJavaDebugConfigurationProvider.test.ts
@@ -75,7 +75,6 @@ describe('FabricJavaDebugConfigurationProvider', () => {
 
             runtimeStub = sinon.createStubInstance(FabricRuntime);
             runtimeStub.getName.returns('localfabric');
-            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
             runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
             runtimeStub.isRunning.resolves(true);
             runtimeStub.isDevelopmentMode.returns(true);

--- a/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -75,7 +75,6 @@ describe('FabricNodeDebugConfigurationProvider', () => {
 
             runtimeStub = sinon.createStubInstance(FabricRuntime);
             runtimeStub.getName.returns('localfabric');
-            runtimeStub.getConnectionProfile.resolves({ peers: [{ name: 'peer1' }] });
             runtimeStub.getChaincodeAddress.resolves('127.0.0.1:54321');
             runtimeStub.isRunning.resolves(true);
             runtimeStub.isDevelopmentMode.returns(true);

--- a/client/test/explorer/gatewayExplorer.test.ts
+++ b/client/test/explorer/gatewayExplorer.test.ts
@@ -235,8 +235,15 @@ describe('gatewayExplorer', () => {
                 mockRuntime.getName.returns(FabricRuntimeUtil.LOCAL_FABRIC);
                 mockRuntime.isBusy.returns(false);
                 mockRuntime.isRunning.resolves(true);
-                mockRuntime.getConnectionProfilePath.returns('connection.json');
                 mySandBox.stub(FabricRuntimeManager.instance(), 'getRuntime').returns(mockRuntime);
+                mySandBox.stub(FabricRuntimeManager.instance(), 'getGatewayRegistryEntries').resolves([
+                    new FabricGatewayRegistryEntry({
+                        name: FabricRuntimeUtil.LOCAL_FABRIC,
+                        managedRuntime: true,
+                        connectionProfilePath: 'connection.json',
+                        associatedWallet: FabricWalletUtil.LOCAL_WALLET
+                    })
+                ]);
 
                 const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = myExtension.getBlockchainGatewayExplorerProvider();
                 const allChildren: BlockchainTreeItem[] = await blockchainGatewayExplorerProvider.getChildren();

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -776,34 +776,6 @@ describe('FabricRuntime', () => {
         });
     });
 
-    describe('#getCertificate', () => {
-
-        it('should get the PEM encoded certificate', async () => {
-            let certificate: string = await runtime.getCertificate();
-            certificate = certificate.replace(/\r/g, ''); // Windows!
-            certificate.should.equal('-----BEGIN CERTIFICATE-----\nMIICGDCCAb+gAwIBAgIQFSxnLAGsu04zrFkAEwzn6zAKBggqhkjOPQQDAjBzMQsw\nCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy\nYW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEcMBoGA1UEAxMTY2Eu\nb3JnMS5leGFtcGxlLmNvbTAeFw0xNzA4MzEwOTE0MzJaFw0yNzA4MjkwOTE0MzJa\nMFsxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1T\nYW4gRnJhbmNpc2NvMR8wHQYDVQQDDBZBZG1pbkBvcmcxLmV4YW1wbGUuY29tMFkw\nEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV1dfmKxsFKWo7o6DNBIaIVebCCPAM9C/\nsLBt4pJRre9pWE987DjXZoZ3glc4+DoPMtTmBRqbPVwYcUvpbYY8p6NNMEswDgYD\nVR0PAQH/BAQDAgeAMAwGA1UdEwEB/wQCMAAwKwYDVR0jBCQwIoAgQjmqDc122u64\nugzacBhR0UUE0xqtGy3d26xqVzZeSXwwCgYIKoZIzj0EAwIDRwAwRAIgXMy26AEU\n/GUMPfCMs/nQjQME1ZxBHAYZtKEuRR361JsCIEg9BOZdIoioRivJC+ZUzvJUnkXu\no2HkWiuxLsibGxtE\n-----END CERTIFICATE-----\n');
-        });
-    });
-
-    describe('#getPrivateKey', () => {
-
-        it('should get the PEM encoded private key', async () => {
-            let privateKey: string = await runtime.getPrivateKey();
-            privateKey = privateKey.replace(/\r/g, ''); // Windows!
-            privateKey.should.equal('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRgQr347ij6cjwX7m\nKjzbbD8Tlwdfu6FaubjWJWLGyqahRANCAARXV1+YrGwUpajujoM0EhohV5sII8Az\n0L+wsG3iklGt72lYT3zsONdmhneCVzj4Og8y1OYFGps9XBhxS+lthjyn\n-----END PRIVATE KEY-----\n');
-        });
-
-    });
-
-    describe('#getCertificatePath', () => {
-
-        it('should get the runtime certificate path', async () => {
-            const certPath: string = await runtime.getCertificatePath();
-            certPath.should.equal(path.join(rootPath, '..', '..', 'basic-network', 'crypto-config', 'peerOrganizations', 'org1.example.com', 'users', FabricRuntimeUtil.ADMIN_USER, 'msp', 'signcerts', `${FabricRuntimeUtil.ADMIN_USER}-cert.pem`));
-        });
-
-    });
-
     describe('#isCreated', () => {
 
         it('should return true if the peer, orderer, CA, couchdb, and logs exist', async () => {
@@ -1150,14 +1122,14 @@ describe('FabricRuntime', () => {
         it('should return an array of wallet names', async () => {
             const walletNames: string[] = await runtime.getWalletNames();
             walletNames.should.deep.equal([
-                FabricWalletUtil.LOCAL_WALLET
+                `${FabricWalletUtil.LOCAL_WALLET}-ops`
             ]);
         });
     });
 
     describe('#getIdentities', () => {
         it('should return an array of identities for a wallet that exists', async () => {
-            const identities: FabricIdentity[] = await runtime.getIdentities(FabricWalletUtil.LOCAL_WALLET);
+            const identities: FabricIdentity[] = await runtime.getIdentities(`${FabricWalletUtil.LOCAL_WALLET}-ops`);
             let certificate: string;
             let privateKey: string;
             if (os.platform() === 'win32') {

--- a/client/test/fabric/FabricRuntime.test.ts
+++ b/client/test/fabric/FabricRuntime.test.ts
@@ -776,68 +776,6 @@ describe('FabricRuntime', () => {
         });
     });
 
-    describe('#getConnectionProfile', () => {
-
-        it('should get a connection profile', async () => {
-            const connectionProfile: object = await runtime.getConnectionProfile();
-            connectionProfile.should.deep.equal({
-                name: 'basic-network',
-                version: '1.0.0',
-                client: {
-                    organization: 'Org1',
-                    connection: {
-                        timeout: {
-                            peer: {
-                                endorser: '300',
-                                eventHub: '300',
-                                eventReg: '300'
-                            },
-                            orderer: '300'
-                        }
-                    }
-                },
-                channels: {
-                    mychannel: {
-                        orderers: [
-                            'orderer.example.com'
-                        ],
-                        peers: {
-                            'peer0.org1.example.com': {}
-                        }
-                    }
-                },
-                organizations: {
-                    Org1: {
-                        mspid: 'Org1MSP',
-                        peers: [
-                            'peer0.org1.example.com'
-                        ],
-                        certificateAuthorities: [
-                            'ca.org1.example.com'
-                        ]
-                    }
-                },
-                orderers: {
-                    'orderer.example.com': {
-                        url: 'grpc://127.0.0.1:12347'
-                    }
-                },
-                peers: {
-                    'peer0.org1.example.com': {
-                        url: 'grpc://localhost:12345',
-                        eventUrl: 'grpc://localhost:12346'
-                    }
-                },
-                certificateAuthorities: {
-                    'ca.org1.example.com': {
-                        url: 'http://127.0.0.1:12348',
-                        caName: 'ca.example.com'
-                    }
-                }
-            });
-        });
-    });
-
     describe('#getCertificate', () => {
 
         it('should get the PEM encoded certificate', async () => {
@@ -862,15 +800,6 @@ describe('FabricRuntime', () => {
         it('should get the runtime certificate path', async () => {
             const certPath: string = await runtime.getCertificatePath();
             certPath.should.equal(path.join(rootPath, '..', '..', 'basic-network', 'crypto-config', 'peerOrganizations', 'org1.example.com', 'users', FabricRuntimeUtil.ADMIN_USER, 'msp', 'signcerts', `${FabricRuntimeUtil.ADMIN_USER}-cert.pem`));
-        });
-
-    });
-
-    describe('#getConnectionProfilePath', () => {
-
-        it('should get the runtime connection profile path', async () => {
-            const connectionPath: string = runtime.getConnectionProfilePath();
-            connectionPath.should.equal(path.join(rootPath, '..', '..', 'out', 'data', FabricRuntimeUtil.LOCAL_FABRIC, 'connection.json'));
         });
 
     });
@@ -1121,7 +1050,7 @@ describe('FabricRuntime', () => {
             gateways.should.deep.equal([
                 {
                     name: FabricRuntimeUtil.LOCAL_FABRIC,
-                    path: runtime.getConnectionProfilePath(),
+                    path: runtime['getConnectionProfilePath'](),
                     connectionProfile: {
                         name: 'basic-network',
                         version: '1.0.0',

--- a/client/test/fabric/FabricRuntimeManager.test.ts
+++ b/client/test/fabric/FabricRuntimeManager.test.ts
@@ -28,6 +28,7 @@ import { IFabricRuntimeConnection } from '../../src/fabric/IFabricRuntimeConnect
 import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
 import { FabricRuntimeUtil } from '../../src/fabric/FabricRuntimeUtil';
 import { FabricWalletUtil } from '../../src/fabric/FabricWalletUtil';
+import { FabricGateway } from '../../src/fabric/FabricGateway';
 
 const should: Chai.Should = chai.should();
 
@@ -81,7 +82,6 @@ describe('FabricRuntimeManager', () => {
             runtimeManager['connectingPromise'] = undefined;
             await runtimeManager.add();
             const runtime: FabricRuntime = runtimeManager.getRuntime();
-            sandbox.stub(runtime, 'getConnectionProfile');
             sandbox.stub(runtimeManager, 'getRuntime').returns(runtime);
             sandbox.stub(runtime, 'startLogs');
             connection.connect.resolves();
@@ -454,14 +454,13 @@ describe('FabricRuntimeManager', () => {
     describe('#getGatewayRegistryEntries', () => {
 
         it('should return an array of gateway registry entires', async () => {
-
-            // WE SHOULD BE STUBBING runtime.getConnectionProfilePath HERE
             const instance: FabricRuntimeManager = FabricRuntimeManager.instance();
             const runtime: FabricRuntime = runtimeManager.getRuntime();
-            sandbox.stub(runtime, 'getConnectionProfilePath').returns('SOME_PATH');
-            sandbox.stub(instance, 'getRuntime').returns(runtime);
+            sandbox.stub(runtime, 'getGateways').resolves([
+                new FabricGateway(FabricRuntimeUtil.LOCAL_FABRIC, 'SOME_PATH', { connection: 'profile' })
+            ]);
 
-            const registryEntries: FabricGatewayRegistryEntry[] = instance.getGatewayRegistryEntries();
+            const registryEntries: FabricGatewayRegistryEntry[] = await instance.getGatewayRegistryEntries();
             registryEntries.should.have.lengthOf(1);
             registryEntries[0].name.should.equal(FabricRuntimeUtil.LOCAL_FABRIC);
             registryEntries[0].managedRuntime.should.be.true;


### PR DESCRIPTION
Remove the connection profile, certificate, and private key functions from the FabricRuntime class - these shouldn't be used by anyone anymore - they should be using the new nodes/wallets/identities APIs instead.