### PR TITLE
Jake's fix for npm install separation

### DIFF
--- a/client/integrationTest/integrationTestRemoteFabricUtil.ts
+++ b/client/integrationTest/integrationTestRemoteFabricUtil.ts
@@ -53,7 +53,7 @@ export class IntegrationTestRemoteFabricUtil {
             skipPersistence: false
         });
 
-        this.client.setUserContext(user);
+        await this.client.setUserContext(user);
     }
 
     public async installChaincode(language: string): Promise<void> {

--- a/client/src/commands/createSmartContractProjectCommand.ts
+++ b/client/src/commands/createSmartContractProjectCommand.ts
@@ -86,7 +86,8 @@ export async function createSmartContractProject(): Promise<void> {
 
     try {
 
-        const packageJson: any = ExtensionUtil.getPackageJSON();
+        const skipInstall: boolean = ExtensionUtil.skipNpmInstall();
+
         const runOptions: any = {
             'destination': folderPath,
             'language': smartContractLanguage,
@@ -95,7 +96,7 @@ export async function createSmartContractProject(): Promise<void> {
             'description': 'My Smart Contract',
             'author': 'John Doe',
             'license': 'Apache-2.0',
-            'skip-install': !packageJson.production,
+            'skip-install': skipInstall,
             'asset': assetType
         };
 

--- a/client/src/util/ExtensionUtil.ts
+++ b/client/src/util/ExtensionUtil.ts
@@ -116,6 +116,10 @@ export class ExtensionUtil {
 
     }
 
+    public static skipNpmInstall(): boolean {
+        return false; // We should never skip npm install, except for unit tests
+    }
+
     private static extensionContext: vscode.ExtensionContext;
 
     private static getExtension(): vscode.Extension<any> {

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -44,6 +44,7 @@ describe('CreateSmartContractProjectCommand', () => {
     let executeCommandStub: sinon.SinonStub;
     let updateWorkspaceFoldersStub: sinon.SinonStub;
     let uri: vscode.Uri;
+    let skipNpmInstallStub: sinon.SinonStub;
 
     before(async () => {
         await TestUtil.setupTests();
@@ -71,6 +72,8 @@ describe('CreateSmartContractProjectCommand', () => {
         updateWorkspaceFoldersStub = mySandBox.stub(vscode.workspace, 'updateWorkspaceFolders');
         // Create a tmp directory for Smart Contract packages, and create a Uri of it
         uri = vscode.Uri.file(tmp.dirSync().name);
+        skipNpmInstallStub = mySandBox.stub(ExtensionUtil, 'skipNpmInstall');
+        skipNpmInstallStub.resolves(true);  // we don't want npm install running during unit tests
     });
     afterEach(() => {
         mySandBox.restore();

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -284,11 +284,11 @@ describe('Extension Tests', () => {
         await vscode.commands.executeCommand('blockchain.refreshEntry').should.be.rejectedWith(`command 'blockchain.refreshEntry' not found`);
     });
 
-    it('should check if production flag is false on extension activiation', async () => {
+    it('should check if production flag is false on extension activation', async () => {
         mySandBox.stub(vscode.commands, 'executeCommand').resolves();
 
         mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: false});
-        const reporterStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'dispose');
+        const reporterDisposeStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'dispose');
 
         const dependencyManager: DependencyManager = DependencyManager.instance();
         mySandBox.stub(vscode.commands, 'registerCommand');
@@ -299,10 +299,10 @@ describe('Extension Tests', () => {
 
         await myExtension.activate(context);
 
-        reporterStub.should.have.been.called;
+        reporterDisposeStub.should.have.been.called;
     });
 
-    it('should check if production flag is true on extension activiation', async () => {
+    it('should check if production flag is true on extension activation', async () => {
         mySandBox.stub(vscode.commands, 'executeCommand').resolves();
 
         mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: true});

--- a/client/test/util/ExtensionUtil.test.ts
+++ b/client/test/util/ExtensionUtil.test.ts
@@ -252,4 +252,14 @@ describe('ExtensionUtil Tests', () => {
         });
 
     });
+
+    describe('skipNpmInstall', () => {
+
+        it('skipNpmInstall should return false', async () => {
+
+            const result: boolean = await ExtensionUtil.skipNpmInstall();
+            result.should.equal(false);
+
+        });
+    });
 });


### PR DESCRIPTION
Covers #876 and the options listed in my latest comment
- Telemetry is already disabled for non-production releases
- npm install is only disabled for unit tests in travis/locally

Signed-off-by: heatherlp <heatherpollard0@gmail.com>