### PR TITLE
Removed telemetry tests and moved telemetry stubs

### DIFF
--- a/client/src/commands/addWalletIdentityCommand.ts
+++ b/client/src/commands/addWalletIdentityCommand.ts
@@ -115,7 +115,6 @@ export async function addWalletIdentity(walletItem: BlockchainTreeItem | IFabric
         }
         certificatePath = certKey.certificatePath;
         privateKeyPath = certKey.privateKeyPath;
-        Reporter.instance().sendTelemetryEvent('addWalletIdentityCommand', {method: 'Certificate'});
     } else {
         // User wants to add an identity by providing a enrollment id and secret
 
@@ -160,7 +159,6 @@ export async function addWalletIdentity(walletItem: BlockchainTreeItem | IFabric
         const enrollment: {certificate: string, privateKey: string} = await certificateAuthority.enroll(gatewayRegistryEntry.connectionProfilePath, enrollmentID, enrollmentSecret);
         certificate = enrollment.certificate;
         privateKey = enrollment.privateKey;
-        Reporter.instance().sendTelemetryEvent('addWalletIdentityCommand', {method: 'enrollmentID'});
     }
 
     if (certificatePath && privateKeyPath) {
@@ -178,4 +176,11 @@ export async function addWalletIdentity(walletItem: BlockchainTreeItem | IFabric
 
     await vscode.commands.executeCommand(ExtensionCommands.REFRESH_WALLETS);
     outputAdapter.log(LogType.SUCCESS, 'Successfully added identity', `Successfully added identity to wallet`);
+
+    // Send telemetry event
+    if (addIdentityMethod === UserInputUtil.ADD_CERT_KEY_OPTION) {
+        Reporter.instance().sendTelemetryEvent('addWalletIdentityCommand', {method: 'Certificate'});
+    } else {
+        Reporter.instance().sendTelemetryEvent('addWalletIdentityCommand', {method: 'enrollmentID'});
+    }
 }

--- a/client/test/commands/addGatewayCommand.test.ts
+++ b/client/test/commands/addGatewayCommand.test.ts
@@ -25,7 +25,6 @@ import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricGatewayRegistry } from '../../src/fabric/FabricGatewayRegistry';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { SettingConfigurations } from '../../SettingConfigurations';
 
 // tslint:disable no-unused-expression
@@ -40,6 +39,7 @@ describe('AddGatewayCommand', () => {
     let browseStub: sinon.SinonStub;
     let copyConnectionProfileStub: sinon.SinonStub;
     let executeCommandSpy: sinon.SinonSpy;
+    let sendTelemetryEventStub: sinon.SinonStub;
 
     before(async () => {
         await TestUtil.setupTests();
@@ -64,6 +64,7 @@ describe('AddGatewayCommand', () => {
             copyConnectionProfileStub.onFirstCall().resolves(path.join('blockchain', 'extension', 'directory', 'gatewayOne', 'connection.json'));
             copyConnectionProfileStub.onSecondCall().resolves(path.join('blockchain', 'extension', 'directory', 'gatewayTwo', 'connection.json'));
             executeCommandSpy = mySandBox.spy(vscode.commands, 'executeCommand');
+            sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
         });
 
         afterEach(async () => {
@@ -88,6 +89,7 @@ describe('AddGatewayCommand', () => {
             copyConnectionProfileStub.should.have.been.calledOnce;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'addGateway');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully added a new gateway');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('addGatewayCommand');
         });
 
         it('should test multiple gateways can be added', async () => {
@@ -125,6 +127,8 @@ describe('AddGatewayCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully added a new gateway');
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, 'addGateway');
             logSpy.getCall(3).should.have.been.calledWith(LogType.SUCCESS, 'Successfully added a new gateway');
+            sendTelemetryEventStub.should.have.been.calledTwice;
+            sendTelemetryEventStub.should.have.been.calledWithExactly('addGatewayCommand');
         });
 
         it('should test adding a gateway can be cancelled when giving a gateway name', async () => {
@@ -135,6 +139,7 @@ describe('AddGatewayCommand', () => {
             const gateways: Array<any> = vscode.workspace.getConfiguration().get(SettingConfigurations.FABRIC_GATEWAYS);
             gateways.length.should.equal(0);
             logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'addGateway');
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should test adding a gateway can be cancelled when giving a connection profile', async () => {
@@ -147,6 +152,7 @@ describe('AddGatewayCommand', () => {
             const gateways: Array<any> = vscode.workspace.getConfiguration().get(SettingConfigurations.FABRIC_GATEWAYS);
             gateways.length.should.equal(0);
             logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'addGateway');
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should handle errors when adding a gateway', async () => {
@@ -162,18 +168,7 @@ describe('AddGatewayCommand', () => {
             logSpy.should.have.been.calledTwice;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'addGateway');
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Failed to add a new gateway: already exists`);
+            sendTelemetryEventStub.should.not.have.been.called;
         });
-
-        it ('should send a telemetry event if the extension is for production', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            showInputBoxStub.onFirstCall().resolves('myGateway');
-            browseStub.onFirstCall().resolves(path.join(rootPath, '../../test/data/connectionOne/connection.json'));
-
-            await vscode.commands.executeCommand(ExtensionCommands.ADD_GATEWAY);
-
-            reporterStub.should.have.been.calledWith('addGatewayCommand');
-        });
-
     });
 });

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -28,7 +28,6 @@ import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegist
 import { FabricRuntime } from '../../src/fabric/FabricRuntime';
 import { FabricConnectionFactory } from '../../src/fabric/FabricConnectionFactory';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { BlockchainGatewayExplorerProvider } from '../../src/explorer/gatewayExplorer';
 import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from '../../src/logging/OutputAdapter';
@@ -82,12 +81,14 @@ describe('ConnectCommand', () => {
         let choseWalletQuickPick: sinon.SinonStub;
         let identity: IdentityInfo;
         let walletGenerator: FabricWalletGenerator;
+        let sendTelemetryEventStub: sinon.SinonStub;
 
         beforeEach(async () => {
             mySandBox = sinon.createSandbox();
 
             mockConnection = sinon.createStubInstance(FabricClientConnection);
             mockConnection.connect.resolves();
+            mockConnection.isIBPConnection.returns(false);
 
             mySandBox.stub(FabricConnectionFactory, 'createFabricClientConnection').returns(mockConnection);
 
@@ -171,6 +172,7 @@ describe('ConnectCommand', () => {
                 label: 'myGatewayAWallet',
                 data: FabricWalletRegistry.instance().get('myGatewayAWallet')
             });
+            sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
 
         });
 
@@ -188,6 +190,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
                 mockConnection.connect.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricWallet), identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should test that a fabric gateway with multiple identities can be connected to from the quick pick', async () => {
@@ -208,6 +211,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.calledOnce;
                 mockConnection.connect.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricWallet), identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should do nothing if the user cancels choosing a gateway', async () => {
@@ -277,6 +281,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
                 mockConnection.connect.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricWallet), identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should test that a fabric gateway with multiple identities can be connected to from the tree', async () => {
@@ -292,6 +297,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
                 mockConnection.connect.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricWallet), FabricRuntimeUtil.ADMIN_USER);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should handle no identities found in wallet', async () => {
@@ -306,6 +312,7 @@ describe('ConnectCommand', () => {
 
                 await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
 
+                mockConnection.connect.should.not.have.been.called;
                 logSpy.should.have.been.calledWith(LogType.ERROR, 'No identities found in wallet: ' + connectionSingleWallet.name);
             });
 
@@ -318,6 +325,7 @@ describe('ConnectCommand', () => {
                 logSpy.should.have.been.calledTwice;
                 logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `connect`);
                 logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `${error.message}`, `${error.toString()}`);
+                sendTelemetryEventStub.should.not.have.been.called;
             });
         });
 
@@ -361,6 +369,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.calledOnceWithExactly;
                 mockConnection.connect.should.have.been.calledOnceWithExactly(testFabricWallet, identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'managed runtime' });
             });
 
             it('should connect to a managed runtime with multiple identities, using a quick pick', async () => {
@@ -374,6 +383,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.called;
                 mockConnection.connect.should.have.been.calledWith(testFabricWallet, testIdentityName);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'managed runtime' });
             });
 
             it('should connect to a managed runtime from the tree', async () => {
@@ -386,6 +396,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
                 mockConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'managed runtime' });
             });
 
             it('should handle the user cancelling an identity to choose from when connecting to a fabric runtime', async () => {
@@ -428,8 +439,8 @@ describe('ConnectCommand', () => {
 
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.calledOnceWithExactly;
-                console.log('aas', mockConnection.connect.getCalls());
                 mockConnection.connect.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricWallet), identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should connect to a non-local fabric with multiple identities, using a quick pick', async () => {
@@ -443,6 +454,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.have.been.called;
                 mockConnection.connect.should.have.been.calledWith(testFabricWallet, testIdentityName);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should connect to a non-local runtime from the tree', async () => {
@@ -456,6 +468,7 @@ describe('ConnectCommand', () => {
                 connectStub.should.have.been.calledOnceWithExactly(sinon.match.instanceOf(FabricClientConnection));
                 choseIdentityQuickPick.should.not.have.been.called;
                 mockConnection.connect.should.have.been.calledWith(testFabricWallet, identity.label);
+                sendTelemetryEventStub.should.have.been.calledOnceWithExactly('connectCommand', { runtimeData: 'user runtime' });
             });
 
             it('should handle the user cancelling an identity to choose from when connecting to a fabric runtime', async () => {
@@ -470,39 +483,13 @@ describe('ConnectCommand', () => {
 
         });
 
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterSpy: sinon.SinonSpy = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-
-            mySandBox.stub(myExtension.getBlockchainGatewayExplorerProvider(), 'connect');
-
-            await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
-
-            reporterSpy.should.have.been.calledWith('connectCommand', { runtimeData: 'user runtime' });
-        });
-
-        it('should send a telemetry event if using IBP', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterSpy: sinon.SinonSpy = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
+        it('should send a connectCommand telemetry event if connecting to IBP', async () => {
             mockConnection.isIBPConnection.returns(true);
-
             mySandBox.stub(myExtension.getBlockchainGatewayExplorerProvider(), 'connect');
 
             await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
 
-            reporterSpy.should.have.been.calledWith('connectCommand', { runtimeData: 'IBP instance' });
-        });
-
-        it('should send a telemetry event if not using IBP', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterSpy: sinon.SinonSpy = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            mockConnection.isIBPConnection.returns(false);
-
-            mySandBox.stub(myExtension.getBlockchainGatewayExplorerProvider(), 'connect');
-
-            await vscode.commands.executeCommand(ExtensionCommands.CONNECT);
-
-            reporterSpy.should.have.been.calledWith('connectCommand', { runtimeData: 'user runtime' });
+            sendTelemetryEventStub.should.have.been.calledWith('connectCommand', { runtimeData: 'IBP instance' });
         });
     });
 });

--- a/client/test/commands/createSmartContractProjectCommand.test.ts
+++ b/client/test/commands/createSmartContractProjectCommand.test.ts
@@ -24,10 +24,10 @@ import { UserInputUtil, LanguageType, LanguageQuickPickItem } from '../../src/co
 import { TestUtil } from '../TestUtil';
 import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchainOutputAdapter';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { YeomanUtil } from '../../src/util/YeomanUtil';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 
 chai.use(sinonChai);
 
@@ -45,6 +45,7 @@ describe('CreateSmartContractProjectCommand', () => {
     let updateWorkspaceFoldersStub: sinon.SinonStub;
     let uri: vscode.Uri;
     let skipNpmInstallStub: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
 
     before(async () => {
         await TestUtil.setupTests();
@@ -74,14 +75,15 @@ describe('CreateSmartContractProjectCommand', () => {
         uri = vscode.Uri.file(tmp.dirSync().name);
         skipNpmInstallStub = mySandBox.stub(ExtensionUtil, 'skipNpmInstall');
         skipNpmInstallStub.resolves(true);  // we don't want npm install running during unit tests
+        sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
     });
     afterEach(() => {
         mySandBox.restore();
     });
 
     const testLanguageItems: LanguageQuickPickItem[] = [
-        { label: 'TypeScript', type: LanguageType.CONTRACT },
-        { label: 'Go', type: LanguageType.CHAINCODE }
+        { label: 'typescript', type: LanguageType.CONTRACT },
+        { label: 'go', type: LanguageType.CHAINCODE }
     ];
 
     for (const testLanguageItem of testLanguageItems) {
@@ -109,9 +111,9 @@ describe('CreateSmartContractProjectCommand', () => {
         }
 
         async function checkSmartContract(): Promise<void> {
-            if (testLanguageItem.label === 'TypeScript') {
+            if (testLanguageItem.label === 'typescript') {
                 return checkTypeScriptSmartContract();
-            } else if (testLanguageItem.label === 'Go') {
+            } else if (testLanguageItem.label === 'go') {
                 return checkGoSmartContract();
             } else {
                 throw new Error(`You must update this test to support the ${testLanguageItem.label} language`);
@@ -131,6 +133,7 @@ describe('CreateSmartContractProjectCommand', () => {
             executeCommandStub.should.have.been.calledWith('vscode.openFolder', uri, true);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
         it(`should start a ${testLanguageItem.label} smart contract project, in current window`, async () => {
@@ -146,6 +149,7 @@ describe('CreateSmartContractProjectCommand', () => {
             executeCommandStub.should.have.been.calledWith('vscode.openFolder', uri, false);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
         it(`should start a ${testLanguageItem.label} smart contract project, in current window with unsaved files and save`, async () => {
@@ -167,6 +171,7 @@ describe('CreateSmartContractProjectCommand', () => {
             saveDialogStub.should.have.been.calledWith(true);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
         it(`should start a ${testLanguageItem.label} smart contract project, in current window with unsaved files and not save`, async () => {
@@ -188,6 +193,7 @@ describe('CreateSmartContractProjectCommand', () => {
             saveDialogStub.should.not.have.been.called;
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
         it(`should start a ${testLanguageItem.label} smart contract project, in a new workspace with no folders`, async () => {
@@ -205,6 +211,7 @@ describe('CreateSmartContractProjectCommand', () => {
             updateWorkspaceFoldersStub.should.have.been.calledWith(sinon.match.number, 0, {uri: uri});
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
         it(`should start a ${testLanguageItem.label} smart contract project, in a new workspace with folders`, async () => {
@@ -220,6 +227,7 @@ describe('CreateSmartContractProjectCommand', () => {
             updateWorkspaceFoldersStub.should.have.been.calledWith(sinon.match.number, 0, {uri: uri});
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated smart contract project');
             await checkSmartContract();
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('createSmartContractProject', {contractLanguage: testLanguageItem.label});
         });
 
     }
@@ -233,6 +241,7 @@ describe('CreateSmartContractProjectCommand', () => {
         browseStub.resolves(uri);
         await vscode.commands.executeCommand(ExtensionCommands.CREATE_SMART_CONTRACT_PROJECT);
         logSpy.should.have.been.calledWith(LogType.ERROR, 'Issue creating smart contract project: such error');
+        sendTelemetryEventStub.should.not.have.been.called;
     });
 
     it('should not do anything if the user cancels the open dialog', async () => {
@@ -271,20 +280,6 @@ describe('CreateSmartContractProjectCommand', () => {
         await vscode.commands.executeCommand(ExtensionCommands.CREATE_SMART_CONTRACT_PROJECT);
         quickPickStub.should.have.been.calledOnce;
         browseStub.should.not.have.been.called;
-    });
-
-    it('should send a telemetry event if the extension is for production', async () => {
-        const getPackageJSONStub: sinon.SinonStub = mySandBox.stub(ExtensionUtil, 'getPackageJSON');
-        getPackageJSONStub.onCall(0).returns({production: false}); // To disable npm install!
-        getPackageJSONStub.onCall(1).returns({production: true}); // For the reporter!
-        const reporterStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-
-        quickPickStub.onFirstCall().resolves({ label: 'TypeScript', type: LanguageType.CONTRACT });
-        showInputBoxStub.onFirstCall().resolves('Conga');
-        quickPickStub.onSecondCall().resolves(UserInputUtil.OPEN_IN_NEW_WINDOW);
-        browseStub.resolves(uri);
-        await vscode.commands.executeCommand(ExtensionCommands.CREATE_SMART_CONTRACT_PROJECT);
-        reporterStub.should.have.been.calledWith('createSmartContractProject', {contractLanguage: 'typescript'});
     });
 
     it('should check if Mac (Darwin) devices have Xcode installed', async () => {

--- a/client/test/commands/exportSmartContractPackageCommand.test.ts
+++ b/client/test/commands/exportSmartContractPackageCommand.test.ts
@@ -31,7 +31,6 @@ import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchai
 import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { SettingConfigurations } from '../../SettingConfigurations';
 
 const should: Chai.Should = chai.should();
@@ -57,12 +56,15 @@ describe('exportSmartContractPackageCommand', () => {
     let showSaveDialogStub: sinon.SinonStub;
     let copyStub: sinon.SinonStub;
     let logSpy: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();
         showSaveDialogStub = sandbox.stub(vscode.window, 'showSaveDialog').resolves(vscode.Uri.file(targetPath));
         copyStub = sandbox.stub(fs, 'copy').resolves();
         logSpy = sandbox.stub(VSCodeBlockchainOutputAdapter.instance(), 'log');
+        sendTelemetryEventStub = sandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
+
     });
 
     afterEach(async () => {
@@ -81,6 +83,7 @@ describe('exportSmartContractPackageCommand', () => {
         copyStub.should.have.been.calledOnceWithExactly(_package.path, targetPath, { overwrite: true });
         logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'exportSmartContractPackage');
         logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Exported smart contract package vscode-pkg-1@0.0.1 to ${targetPath}.`);
+        sendTelemetryEventStub.should.have.been.calledOnceWithExactly('exportSmartContractPackageCommand');
     });
 
     it('should export a package to the file system using the tree menu item', async () => {
@@ -92,6 +95,7 @@ describe('exportSmartContractPackageCommand', () => {
         copyStub.should.have.been.calledOnceWithExactly(_package.packageEntry.path, targetPath, { overwrite: true });
         logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'exportSmartContractPackage');
         logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Exported smart contract package vscode-pkg-1@0.0.1 to ${targetPath}.`);
+        sendTelemetryEventStub.should.have.been.calledOnceWithExactly('exportSmartContractPackageCommand');
     });
 
     it('should handle the user cancelling the package quick pick', async () => {
@@ -129,20 +133,6 @@ describe('exportSmartContractPackageCommand', () => {
         await vscode.commands.executeCommand(ExtensionCommands.EXPORT_SMART_CONTRACT);
         logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'exportSmartContractPackage');
         logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, error.message, error.toString());
+        sendTelemetryEventStub.should.not.have.been.called;
     });
-
-    it('should send a telemetry event if the extension is for production', async () => {
-        sandbox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-        const reporterStub: sinon.SinonStub = sandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
-        const _packages: PackageRegistryEntry[] = await PackageRegistry.instance().getAll();
-        const _package: PackageRegistryEntry = _packages[0];
-        sandbox.stub(vscode.window, 'showQuickPick').resolves({
-            label: 'vscode-pkg-1@0.0.1',
-            data: _package
-        });
-        await vscode.commands.executeCommand(ExtensionCommands.EXPORT_SMART_CONTRACT);
-
-        reporterStub.should.have.been.calledWith('exportSmartContractPackageCommand');
-    });
-
 });

--- a/client/test/commands/instantiateCommand.test.ts
+++ b/client/test/commands/instantiateCommand.test.ts
@@ -34,7 +34,6 @@ import { ExtensionCommands } from '../../ExtensionCommands';
 import { VSCodeBlockchainDockerOutputAdapter } from '../../src/logging/VSCodeBlockchainDockerOutputAdapter';
 import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -63,6 +62,7 @@ describe('InstantiateCommand', () => {
         let smartContractsChildren: BlockchainTreeItem[];
         let channelsChildren: BlockchainTreeItem[];
         let showYesNo: sinon.SinonStub;
+        let sendTelemetryEventStub: sinon.SinonStub;
 
         beforeEach(async () => {
             mySandBox = sinon.createSandbox();
@@ -106,6 +106,7 @@ describe('InstantiateCommand', () => {
 
             logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
             dockerLogsOutputSpy = mySandBox.spy(VSCodeBlockchainDockerOutputAdapter.instance(), 'show');
+            sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
 
             fabricRuntimeMock.getAllPeerNames.returns(['peerOne']);
 
@@ -139,6 +140,7 @@ describe('InstantiateCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.REFRESH_GATEWAYS);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate the smart contract through the command when not connected', async () => {
@@ -151,6 +153,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should stop if starting the local_fabric fails', async () => {
@@ -160,7 +163,7 @@ describe('InstantiateCommand', () => {
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.START_FABRIC);
             fabricRuntimeMock.instantiateChaincode.should.not.have.been.called;
 
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
 
         it('should instantiate the smart contract through the command with collection', async () => {
@@ -176,6 +179,7 @@ describe('InstantiateCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.REFRESH_GATEWAYS);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate the smart contract through the command with collection and set dialog folder', async () => {
@@ -206,6 +210,7 @@ describe('InstantiateCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.REFRESH_GATEWAYS);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should handle cancel when choosing if want collection', async () => {
@@ -232,8 +237,7 @@ describe('InstantiateCommand', () => {
 
             fabricRuntimeMock.instantiateChaincode.should.not.have.been.called;
             dockerLogsOutputSpy.should.not.been.called;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
-            should.not.exist(logSpy.getCall(1));
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
 
         it('should handle error from instantiating smart contract', async () => {
@@ -248,6 +252,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Error instantiating smart contract: ${error.message}`, `Error instantiating smart contract: ${error.toString()}`);
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should handle cancel when choosing chaincode and version', async () => {
@@ -257,8 +262,7 @@ describe('InstantiateCommand', () => {
             fabricRuntimeMock.instantiateChaincode.should.not.have.been.called;
 
             dockerLogsOutputSpy.should.not.been.called;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
-            should.not.exist(logSpy.getCall(1));
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
 
         it('should instantiate smart contract through the tree by clicking + Instantiate in the runtime ops view', async () => {
@@ -269,6 +273,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate smart contract through the tree by right-clicking Instantiated in the runtime ops view', async () => {
@@ -279,6 +284,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate smart contract through the tree by right-clicking on channel in the runtime ops view', async () => {
@@ -289,6 +295,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate the smart contract through the command with no function', async () => {
@@ -300,6 +307,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should instantiate the smart contract through the command with function but no args', async () => {
@@ -312,6 +320,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should cancel instantiating when user escape entering args', async () => {
@@ -388,6 +397,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should be able to cancel install and instantiate for package', async () => {
@@ -411,8 +421,7 @@ describe('InstantiateCommand', () => {
 
             fabricRuntimeMock.instantiateChaincode.should.not.been.calledWith('somepackage', '0.0.1', ['peerOne'], 'myChannel', 'instantiate', ['arg1', 'arg2', 'arg3'], undefined);
             dockerLogsOutputSpy.should.not.have.been.called;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
-            should.not.exist(logSpy.getCall(1));
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
 
         it('should package, install and instantiate a project', async () => {
@@ -435,6 +444,7 @@ describe('InstantiateCommand', () => {
             dockerLogsOutputSpy.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully instantiated smart contract');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('instantiateCommand');
         });
 
         it('should be able to cancel a project packaging, installing and instantiating', async () => {
@@ -455,8 +465,7 @@ describe('InstantiateCommand', () => {
 
             fabricRuntimeMock.instantiateChaincode.should.not.been.called;
             dockerLogsOutputSpy.should.not.have.been.called;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
-            should.not.exist(logSpy.getCall(1));
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
 
         it('should be able to handle a project failing to package', async () => {
@@ -475,17 +484,7 @@ describe('InstantiateCommand', () => {
             should.not.exist(packageEntry);
 
             fabricRuntimeMock.instantiateChaincode.should.not.been.called;
-            logSpy.should.have.been.calledOnce;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'instantiateSmartContract');
         });
-
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            await vscode.commands.executeCommand(ExtensionCommands.INSTANTIATE_SMART_CONTRACT);
-
-            reporterStub.should.have.been.calledWith('instantiateCommand');
-        });
-
     });
 });

--- a/client/test/commands/openNewTerminal.test.ts
+++ b/client/test/commands/openNewTerminal.test.ts
@@ -38,6 +38,7 @@ describe('openNewTerminal', () => {
     let node: FabricNode;
     let mockTerminal: any;
     let createTerminalStub: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
 
     before(async () => {
         await TestUtil.setupTests();
@@ -61,6 +62,7 @@ describe('openNewTerminal', () => {
             show: sinon.stub()
         };
         createTerminalStub = sandbox.stub(vscode.window, 'createTerminal').returns(mockTerminal);
+        sendTelemetryEventStub = sandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
     });
 
     afterEach(async () => {
@@ -80,6 +82,7 @@ describe('openNewTerminal', () => {
             ]
         );
         mockTerminal.show.should.have.been.calledOnce;
+        sendTelemetryEventStub.should.have.been.calledOnceWithExactly('openFabricRuntimeTerminalCommand', { type: FabricNodeType.PEER });
     });
 
     it('should open a terminal for a Fabric node specified by user selection', async () => {
@@ -96,19 +99,12 @@ describe('openNewTerminal', () => {
             ]
         );
         mockTerminal.show.should.have.been.calledOnce;
+        sendTelemetryEventStub.should.have.been.calledOnceWithExactly('openFabricRuntimeTerminalCommand', { type: FabricNodeType.PEER });
     });
 
     it('should not open a terminal if a user cancels specifying a Fabric node', async () => {
         sandbox.stub(UserInputUtil, 'showRuntimeNodeQuickPick').resolves(undefined);
         await vscode.commands.executeCommand(ExtensionCommands.OPEN_NEW_TERMINAL);
         createTerminalStub.should.not.have.been.called;
-    });
-
-    it('should send a telemetry event if the extension is for production', async () => {
-        sandbox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-        const reporterStub: sinon.SinonStub = sandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
-        await vscode.commands.executeCommand(ExtensionCommands.OPEN_NEW_TERMINAL, nodeItem);
-
-        reporterStub.should.have.been.calledWithExactly('openFabricRuntimeTerminalCommand', { type: FabricNodeType.PEER });
     });
 });

--- a/client/test/commands/packageSmartContractCommand.test.ts
+++ b/client/test/commands/packageSmartContractCommand.test.ts
@@ -25,7 +25,6 @@ import { VSCodeBlockchainOutputAdapter } from '../../src/logging/VSCodeBlockchai
 import { LogType } from '../../src/logging/OutputAdapter';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { SettingConfigurations } from '../../SettingConfigurations';
 
 chai.should();
@@ -142,6 +141,7 @@ describe('packageSmartContract', () => {
     let findFilesStub: sinon.SinonStub;
     let buildTasks: vscode.Task[];
     let executeTaskStub: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
 
     beforeEach(async () => {
         mySandBox = sinon.createSandbox();
@@ -160,6 +160,7 @@ describe('packageSmartContract', () => {
         showInputStub = mySandBox.stub(UserInputUtil, 'showInputBox');
         showWorkspaceQuickPickStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
         workspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders');
+        sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
         await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_DIRECTORY, extDir, true);
 
         findFilesStub = mySandBox.stub(vscode.workspace, 'findFiles').resolves([]);
@@ -274,8 +275,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
-            logSpy;
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the JavaScript project with specified folder and name', async () => {
@@ -306,6 +307,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the JavaScript project with specified folder and version', async () => {
@@ -336,6 +338,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the JavaScript project with specified folder, name and version', async () => {
@@ -366,6 +369,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the JavaScript project with a META-INF directory', async () => {
@@ -401,6 +405,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(5).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(6).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         }).timeout(10000);
 
         it('should package the TypeScript project', async () => {
@@ -432,8 +437,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.js`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.ts`);
             logSpy.getCall(5).should.have.been.calledWith(LogType.INFO, undefined, '- src/package.json');
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Go project', async () => {
@@ -467,8 +472,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `1 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/goProject/chaincode.go`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Go project with specified name', async () => {
@@ -501,8 +506,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `1 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/goProject/chaincode.go`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Go project with specified version', async () => {
@@ -535,8 +540,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `1 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/goProject/chaincode.go`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Go project with specified name and version', async () => {
@@ -567,8 +572,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `1 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/goProject/chaincode.go`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should use the GOPATH if set', async () => {
@@ -604,8 +609,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `1 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/goProject/chaincode.go`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Java (Gradle) project', async () => {
@@ -639,8 +644,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/build.gradle`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.java`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Java (Gradle) project with specified name', async () => {
@@ -673,8 +678,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/build.gradle`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.java`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Java (Gradle) project with specified version', async () => {
@@ -707,8 +712,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/build.gradle`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.java`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Java (Gradle) project with specified name and version', async () => {
@@ -742,8 +747,8 @@ describe('packageSmartContract', () => {
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/build.gradle`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.java`);
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should package the Java (Maven) project', async () => {
@@ -773,15 +778,13 @@ describe('packageSmartContract', () => {
                 'src/pom.xml'
             ]);
 
-            executeTaskStub.should.have.been.calledOnce;
-            executeTaskStub.should.have.been.calledWithExactly(buildTasks[testIndex]);
-
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'packageSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, undefined, `2 file(s) packaged:`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, `- src/chaincode.java`);
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/pom.xml`);
-
+            executeTaskStub.should.have.been.calledOnceWithExactly(buildTasks[testIndex]);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should throw an error as the package json does not contain a name or version', async () => {
@@ -805,6 +808,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'packageSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Please enter a package name and/or package version into your package.json`);
             logSpy.should.have.been.calledTwice;
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should throw an error as the project does not contain a chaincode file', async () => {
@@ -1097,7 +1101,7 @@ describe('packageSmartContract', () => {
             const smartContractExists: boolean = await fs.pathExists(packageDir);
 
             smartContractExists.should.equal(false);
-            logSpy.should.have.been.calledOnce;
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'packageSmartContract');
         });
 
         it('should handle cancelling the input box for the Go project name', async () => {
@@ -1121,7 +1125,7 @@ describe('packageSmartContract', () => {
             const smartContractExists: boolean = await fs.pathExists(packageDir);
 
             smartContractExists.should.equal(false);
-            logSpy.should.have.been.calledOnce;
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'packageSmartContract');
         });
 
         it('should handle cancelling the input box for the Go project version', async () => {
@@ -1146,7 +1150,7 @@ describe('packageSmartContract', () => {
             const smartContractExists: boolean = await fs.pathExists(packageDir);
 
             smartContractExists.should.equal(false);
-            logSpy.should.have.been.calledOnce;
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'packageSmartContract');
         });
 
         it('should handle cancelling the input box for the Java project name', async () => {
@@ -1168,7 +1172,7 @@ describe('packageSmartContract', () => {
             const smartContractExists: boolean = await fs.pathExists(packageDir);
 
             smartContractExists.should.equal(false);
-            logSpy.should.have.been.calledOnce;
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'packageSmartContract');
         });
 
         it('should handle cancelling the input box for the Java project version', async () => {
@@ -1191,7 +1195,8 @@ describe('packageSmartContract', () => {
             const smartContractExists: boolean = await fs.pathExists(packageDir);
 
             smartContractExists.should.equal(false);
-            logSpy.should.have.been.calledOnce;
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'packageSmartContract');
+
         }).timeout(4000);
 
         it('should package a smart contract given a project workspace', async () => {
@@ -1223,6 +1228,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(4).should.have.been.calledWith(LogType.INFO, undefined, `- src/package.json`);
             logSpy.callCount.should.equal(5);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         }).timeout(10000);
 
         it('should throw an error if there are errors in project', async () => {
@@ -1280,6 +1286,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'packageSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             executeTaskStub.should.have.not.been.called;
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
 
         it('should ignore if errors in another project', async () => {
@@ -1311,23 +1318,7 @@ describe('packageSmartContract', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'packageSmartContract');
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, `Smart Contract packaged: ${pkgFile}`);
             executeTaskStub.should.have.not.been.called;
-        });
-
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            await createTestFiles('javascriptProject', '0.0.1', 'javascript', true, false);
-            const testIndex: number = 0;
-
-            workspaceFoldersStub.returns(folders);
-            showWorkspaceQuickPickStub.onFirstCall().resolves({
-                label: folders[testIndex].name,
-                data: folders[testIndex]
-            });
-
-            await vscode.commands.executeCommand(ExtensionCommands.PACKAGE_SMART_CONTRACT);
-
-            reporterStub.should.have.been.calledWith('packageCommand');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('packageCommand');
         });
     });
 });

--- a/client/test/commands/testSmartContractCommand.test.ts
+++ b/client/test/commands/testSmartContractCommand.test.ts
@@ -29,7 +29,6 @@ import * as myExtension from '../../src/extension';
 import { ChannelTreeItem } from '../../src/explorer/model/ChannelTreeItem';
 import { Reporter } from '../../src/util/Reporter';
 import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { CommandUtil } from '../../src/util/CommandUtil';
 import { InstantiatedContractTreeItem } from '../../src/explorer/model/InstantiatedContractTreeItem';
 import { FabricGatewayRegistryEntry } from '../../src/fabric/FabricGatewayRegistryEntry';
@@ -49,7 +48,7 @@ describe('testSmartContractCommand', () => {
     let executeCommandStub: sinon.SinonStub;
     let logSpy: sinon.SinonSpy;
     let fsRemoveStub: sinon.SinonStub;
-    let reporterStub: sinon.SinonStub;
+    let sendTelemetryEventStub: sinon.SinonStub;
     let getConnectionStub: sinon.SinonStub;
     let showInstantiatedSmartContractsQuickPickStub: sinon.SinonStub;
     let openTextDocumentStub: sinon.SinonStub;
@@ -80,6 +79,7 @@ describe('testSmartContractCommand', () => {
     let getConfigurationStub: sinon.SinonStub;
     let workspaceConfigurationUpdateStub: sinon.SinonStub;
     let workspaceConfigurationGetStub: sinon.SinonStub;
+    let writeJsonStub: sinon.SinonStub;
     let fakeMetadata: any;
     let transactionOne: any;
     let transactionTwo: any;
@@ -98,6 +98,7 @@ describe('testSmartContractCommand', () => {
         include: ['./functionalTests/**/*']
     };
     const tsConfigFormat: any = { spaces: '\t' };
+
     before(async () => {
         await TestUtil.setupTests();
     });
@@ -113,7 +114,7 @@ describe('testSmartContractCommand', () => {
         beforeEach(async () => {
             mySandBox = sinon.createSandbox();
             logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
-            reporterStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
+            sendTelemetryEventStub = mySandBox.stub(Reporter.instance(), 'sendTelemetryEvent');
             fsRemoveStub = mySandBox.stub(fs, 'remove').resolves();
             // ExecuteCommand stub
             executeCommandStub = mySandBox.stub(vscode.commands, 'executeCommand');
@@ -215,7 +216,6 @@ describe('testSmartContractCommand', () => {
             smartContractLabel = instantiatedSmartContract.label;
             smartContractName = instantiatedSmartContract.name;
             // Document editor stubs
-
             testFileDir = path.join(rootPath, '..', '..', 'data', 'smartContractTests');
             mockDocumentStub = {
                 lineCount: 8,
@@ -242,8 +242,9 @@ describe('testSmartContractCommand', () => {
             const smartContractNameBuffer: Buffer = Buffer.from(`{"name": "${smartContractName}"}`);
             readFileStub = mySandBox.stub(fs, 'readFile').resolves(smartContractNameBuffer);
             workspaceFoldersStub = mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').resolves([{ name: 'wagonwheeling' }]);
+            writeJsonStub = mySandBox.stub(fs, 'writeJson').resolves();
             // Other stubs
-            sendCommandStub = mySandBox.stub(CommandUtil, 'sendCommand').resolves();
+            sendCommandStub = mySandBox.stub(CommandUtil, 'sendCommand').resolves('some npm install output');
             showLanguageQuickPickStub = mySandBox.stub(UserInputUtil, 'showLanguagesQuickPick').resolves({ label: 'JavaScript', type: LanguageType.CONTRACT });
             workspaceConfigurationUpdateStub = mySandBox.stub();
             workspaceConfigurationGetStub = mySandBox.stub();
@@ -282,6 +283,10 @@ describe('testSmartContractCommand', () => {
             sendCommandStub.should.have.been.calledOnce;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
+            logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
+            logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a typescript test file for a selected instantiated smart contract', async () => {
@@ -323,6 +328,10 @@ describe('testSmartContractCommand', () => {
             workspaceConfigurationUpdateStub.should.have.been.calledOnce;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
+            logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1, @types/mocha, ts-node, typescript`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
+            logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should provide a path.join if the wallet path contains the home directory', async () => {
@@ -366,6 +375,7 @@ describe('testSmartContractCommand', () => {
             showTextDocumentStub.should.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should handle connecting being cancelled', async () => {
@@ -420,7 +430,6 @@ describe('testSmartContractCommand', () => {
             showLanguageQuickPickStub.resolves({ label: 'TypeScript', type: LanguageType.CONTRACT });
             mySandBox.stub(fs, 'pathExists').resolves(false);
             mySandBox.stub(fs, 'ensureFile').resolves();
-            const writeJsonStub: sinon.SinonStub = mySandBox.stub(fs, 'writeJson').resolves();
             fabricClientConnectionMock.getMetadata.resolves(
                 {
                     contracts: {
@@ -463,6 +472,7 @@ describe('testSmartContractCommand', () => {
             workspaceConfigurationUpdateStub.should.have.been.calledOnce;
             writeJsonStub.should.have.been.calledWith(path.join(testFileDir, 'tsconfig.json'), tsConfigContents, tsConfigFormat);
             logSpy.should.not.have.been.calledWith(LogType.ERROR);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should show an error message if the user has no workspaces open', async () => {
@@ -489,6 +499,7 @@ describe('testSmartContractCommand', () => {
 
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Smart contract project ${smartContractName} is not open in workspace. Please ensure the ${smartContractName} smart contract project folder is not nested within your workspace.`);
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should generate a test file for each smart contract defined in the metadata (from tree)', async () => {
@@ -570,6 +581,8 @@ describe('testSmartContractCommand', () => {
             secondTemplateData.includes(morefakeMetadata.contracts['my-other-contract'].transactions[1].name).should.be.true;
             secondTemplateData.includes(morefakeMetadata.contracts['my-other-contract'].transactions[0].parameters[0].name).should.be.true;
             secondTemplateData.includes(`const args = [];`).should.be.true;
+
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a test file for just the contract tree item passed in', async () => {
@@ -647,6 +660,8 @@ describe('testSmartContractCommand', () => {
             firstTemplateData.includes(morefakeMetadata.contracts['my-contract'].transactions[0].parameters[0].name).should.be.true;
             firstTemplateData.includes(morefakeMetadata.contracts['my-contract'].transactions[0].parameters[1].name).should.be.true;
             firstTemplateData.includes(`const args = [];`).should.be.true;
+
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a test file for just the selected contract', async () => {
@@ -721,6 +736,8 @@ describe('testSmartContractCommand', () => {
             firstTemplateData.includes(morefakeMetadata.contracts['my-contract'].transactions[0].parameters[0].name).should.be.true;
             firstTemplateData.includes(morefakeMetadata.contracts['my-contract'].transactions[0].parameters[1].name).should.be.true;
             firstTemplateData.includes(`const args = [];`).should.be.true;
+
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a test file for all contracts', async () => {
@@ -804,6 +821,8 @@ describe('testSmartContractCommand', () => {
             secondTemplateData.includes(morefakeMetadata.contracts['my-other-contract'].transactions[1].name).should.be.true;
             secondTemplateData.includes(morefakeMetadata.contracts['my-other-contract'].transactions[0].parameters[0].name).should.be.true;
             secondTemplateData.includes(`const args = [];`).should.be.true;
+
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should handle cancel from choosing contract', async () => {
@@ -932,6 +951,10 @@ describe('testSmartContractCommand', () => {
             templateData.includes(`const args = [ ${transactionOne.parameters[0].name.replace(`"`, '')}, ${transactionOne.parameters[1].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[2].name.replace(`"`, '')}), ${transactionOne.parameters[3].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[4].name.replace(`"`, '')})`).should.be.true;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
+            logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
+            logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a copy of the test file if the user tells it to', async () => {
@@ -954,6 +977,7 @@ describe('testSmartContractCommand', () => {
             templateData.includes(transactionTwo.name).should.be.true;
             templateData.includes(transactionThree.name).should.be.true;
             logSpy.should.not.have.been.calledWith(LogType.ERROR);
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should generate a copy of the test file and name it correctly if the smart contract namespace isnt defined', async () => {
@@ -998,7 +1022,10 @@ describe('testSmartContractCommand', () => {
             templateData.includes('transaction2').should.be.true;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
+            logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
             logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should show an error if it fails to create test file', async () => {
@@ -1029,24 +1056,6 @@ describe('testSmartContractCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.ERROR, `Error editing test file: ${testFilePath}`);
             fsRemoveStub.should.have.been.called;
-        });
-
-        it('should send a telemetry event for testSmartContract if the extension is for production', async () => {
-            const testFilePath: string = path.join(packageJSONPath.fsPath, '..', 'functionalTests', `my-contract-${smartContractLabel}.test.js`);
-
-            mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            mySandBox.stub(fs, 'pathExists').resolves(false);
-            mySandBox.stub(fs, 'ensureFile').resolves();
-
-            await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
-            openTextDocumentStub.should.have.been.called;
-            showTextDocumentStub.should.have.been.called;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
-            logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
-            logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
-
-            reporterStub.should.have.been.calledWith('testSmartContractCommand');
-
         });
 
         it('should handle errors when attempting to remove created test file', async () => {
@@ -1092,6 +1101,7 @@ describe('testSmartContractCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1`);
             logSpy.getCall(3).should.have.been.calledWith(LogType.ERROR, `Error installing node modules in smart contract project: ${error.message}`, `Error installing node modules in smart contract project: ${error.toString()}`);
+            sendTelemetryEventStub.should.not.have.been.called;
         });
 
         it('should correctly detect existing test runner user settings for typescript tests', async () => {
@@ -1107,14 +1117,16 @@ describe('testSmartContractCommand', () => {
             showLanguageQuickPickStub.resolves({ label: 'TypeScript', type: LanguageType.CONTRACT });
             mySandBox.stub(fs, 'pathExists').resolves(false);
             mySandBox.stub(fs, 'ensureFile').resolves();
-            const writeJsonStub: sinon.SinonStub = mySandBox.stub(fs, 'writeJson').resolves();
+
             await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
             workspaceConfigurationUpdateStub.should.not.have.been.called;
             writeJsonStub.should.have.been.calledWith(path.join(testFileDir, 'tsconfig.json'), tsConfigContents, tsConfigFormat);
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1, @types/mocha, ts-node, typescript`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
             logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should correctly detect no test runner user settings for typescript tests', async () => {
@@ -1129,7 +1141,6 @@ describe('testSmartContractCommand', () => {
             showLanguageQuickPickStub.resolves({ label: 'TypeScript', type: LanguageType.CONTRACT });
             mySandBox.stub(fs, 'pathExists').resolves(false);
             mySandBox.stub(fs, 'ensureFile').resolves();
-            const writeJsonStub: sinon.SinonStub = mySandBox.stub(fs, 'writeJson').resolves();
 
             await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
             workspaceConfigurationUpdateStub.should.have.been.called;
@@ -1137,7 +1148,9 @@ describe('testSmartContractCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1, @types/mocha, ts-node, typescript`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
             logSpy.getCall(4).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
+            sendTelemetryEventStub.should.have.been.calledOnceWithExactly('testSmartContractCommand');
         });
 
         it('should error if tsconfig.json file cannot be created', async () => {
@@ -1154,7 +1167,7 @@ describe('testSmartContractCommand', () => {
             mySandBox.stub(fs, 'ensureFile').resolves();
 
             const error: Error = new Error('failed for some reason');
-            mySandBox.stub(fs, 'writeJson').throws(error);
+            writeJsonStub.throws(error);
 
             await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
             workspaceConfigurationUpdateStub.should.have.been.called;
@@ -1162,6 +1175,7 @@ describe('testSmartContractCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1, @types/mocha, ts-node, typescript`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
             logSpy.getCall(4).should.have.been.calledWith(LogType.ERROR, 'Unable to create tsconfig.json file: failed for some reason', `Unable to create tsconfig.json file: ${error.toString()}`);
         });
 
@@ -1180,14 +1194,13 @@ describe('testSmartContractCommand', () => {
             pathExistsStub.onSecondCall().resolves(true);
             mySandBox.stub(fs, 'ensureFile').resolves();
 
-            const writeJsonSpy: sinon.SinonSpy = mySandBox.spy(fs, 'writeJson');
-
             await vscode.commands.executeCommand(ExtensionCommands.TEST_SMART_CONTRACT, instantiatedSmartContract);
             workspaceConfigurationUpdateStub.should.have.been.called;
-            writeJsonSpy.should.not.have.been.called;
+            writeJsonStub.should.not.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
             logSpy.getCall(1).should.have.been.calledWith(LogType.INFO, undefined, `Writing to Smart Contract test file: ${testFilePath}`);
             logSpy.getCall(2).should.have.been.calledWith(LogType.INFO, `Installing package dependencies including: fabric-network@1.4.1, fabric-client@1.4.1, @types/mocha, ts-node, typescript`);
+            logSpy.getCall(3).should.have.been.calledWith(LogType.INFO, undefined, 'some npm install output');
             logSpy.getCall(4).should.have.been.calledWith(LogType.WARNING, 'Unable to create tsconfig.json file as it already exists');
             logSpy.getCall(5).should.have.been.calledWith(LogType.SUCCESS, 'Successfully generated tests');
         });

--- a/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -30,7 +30,6 @@ import { FabricGoDebugConfigurationProvider } from '../../src/debug/FabricGoDebu
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { FabricRuntimeUtil } from '../../src/fabric/FabricRuntimeUtil';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -67,6 +66,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
         let date: Date;
         let formattedDate: string;
         let startDebuggingStub: sinon.SinonStub;
+        let sendTelemetryEventStub: sinon.SinonStub;
 
         beforeEach(() => {
             mySandbox = sinon.createSandbox();
@@ -143,6 +143,9 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 data: true,
                 description: `Create a new debug package and install`
             });
+
+            sendTelemetryEventStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
+
         });
 
         afterEach(() => {
@@ -163,6 +166,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
 
         it('should set mode if not set', async () => {
@@ -180,6 +184,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
 
         it('should set program if not set', async () => {
@@ -197,6 +202,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
 
         it('should add cwd if not set', async () => {
@@ -230,6 +236,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
 
         it('should add more args if some args exist', async () => {
@@ -246,6 +253,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--myArgs', 'myValue', '--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
 
         it('should add in request if not defined', async () => {
@@ -262,15 +270,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
         });
-
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandbox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
-
-            reporterStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Go'});
-        });
-
     });
 });

--- a/client/test/debug/FabricJavaDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricJavaDebugConfigurationProvider.test.ts
@@ -30,7 +30,6 @@ import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { FabricJavaDebugConfigurationProvider } from '../../src/debug/FabricJavaDebugConfigurationProvider';
 import { FabricRuntimeUtil } from '../../src/fabric/FabricRuntimeUtil';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -67,6 +66,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
         let date: Date;
         let formattedDate: string;
         let startDebuggingStub: sinon.SinonStub;
+        let sendTelemetryEventStub: sinon.SinonStub;
 
         beforeEach(() => {
             mySandbox = sinon.createSandbox();
@@ -141,6 +141,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 data: true,
                 description: `Create a new debug package and install`
             });
+            sendTelemetryEventStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
         });
 
         afterEach(() => {
@@ -159,6 +160,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
         });
 
         it('should add cwd if not set', async () => {
@@ -174,6 +176,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
         });
 
         it('should add args if not defined', async () => {
@@ -188,6 +191,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
         });
 
         it('should add more args if some args exist', async () => {
@@ -202,6 +206,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--myArgs', 'myValue', '--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
         });
 
         it('should add in request if not defined', async () => {
@@ -216,14 +221,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345']
             });
-        });
-
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandbox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
-
-            reporterStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Java'});
         });
     });
 });

--- a/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/client/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -30,7 +30,6 @@ import * as dateFormat from 'dateformat';
 import { UserInputUtil } from '../../src/commands/UserInputUtil';
 import { FabricRuntimeUtil } from '../../src/fabric/FabricRuntimeUtil';
 import { Reporter } from '../../src/util/Reporter';
-import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -67,6 +66,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
         let date: Date;
         let formattedDate: string;
         let startDebuggingStub: sinon.SinonStub;
+        let sendTelemetryEventStub: sinon.SinonStub;
 
         beforeEach(() => {
             mySandbox = sinon.createSandbox();
@@ -140,6 +140,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 data: true,
                 description: `Create a new debug package and install`
             });
+            sendTelemetryEventStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
         });
 
         afterEach(() => {
@@ -159,6 +160,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should add start arg if not in there', async () => {
@@ -175,6 +177,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--peer.address', 'localhost:12345', 'start']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should set program if not set', async () => {
@@ -191,6 +194,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should add cwd if not set', async () => {
@@ -207,6 +211,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should add args if not defined', async () => {
@@ -222,6 +227,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['start', '--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should add more args if some args exist', async () => {
@@ -237,6 +243,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['--myArgs', 'myValue', 'start', '--peer.address', '127.0.0.1:54321']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
 
         it('should add in request if not defined', async () => {
@@ -252,15 +259,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
                 env: { CORE_CHAINCODE_ID_NAME: `mySmartContract:vscode-debug-${formattedDate}`, CORE_CHAINCODE_EXECUTETIMEOUT: '540s' },
                 args: ['start', '--peer.address', 'localhost:12345']
             });
+            sendTelemetryEventStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
         });
-
-        it('should send a telemetry event if the extension is for production', async () => {
-            mySandbox.stub(ExtensionUtil, 'getPackageJSON').returns({ production: true });
-            const reporterStub: sinon.SinonStub = mySandbox.stub(Reporter.instance(), 'sendTelemetryEvent');
-            await fabricDebugConfig.resolveDebugConfiguration(workspaceFolder, debugConfig);
-
-            reporterStub.should.have.been.calledWith('Smart Contract Debugged', {language: 'Node'});
-        });
-
     });
 });

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -284,7 +284,7 @@ describe('Extension Tests', () => {
         await vscode.commands.executeCommand('blockchain.refreshEntry').should.be.rejectedWith(`command 'blockchain.refreshEntry' not found`);
     });
 
-    it('should check if production flag is false on extension activation', async () => {
+    it('should dispose of the reporter instance production flag is false on extension activiation', async () => {
         mySandBox.stub(vscode.commands, 'executeCommand').resolves();
 
         mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: false});
@@ -302,7 +302,7 @@ describe('Extension Tests', () => {
         reporterDisposeStub.should.have.been.called;
     });
 
-    it('should check if production flag is true on extension activation', async () => {
+    it('should push the reporter instance to the context if production flag is true on extension activiation', async () => {
         mySandBox.stub(vscode.commands, 'executeCommand').resolves();
 
         mySandBox.stub(ExtensionUtil, 'getPackageJSON').returns({production: true});


### PR DESCRIPTION
We don't need separate telemetry tests because we stub the sendTelemetryEvent wrapper function, so we're never getting to the production flag check. That is tested in the reporter tests. I've added stubbed where relevant so that we're checking the sendTelemetryEvent is being called

Signed-off-by: heatherlp <heatherpollard0@gmail.com>