### PR TITLE
Prevent duplicate wallets (close #989)

### DIFF
--- a/client/integrationTest/integrationTestUtil.ts
+++ b/client/integrationTest/integrationTestUtil.ts
@@ -133,7 +133,7 @@ export class IntegrationTestUtil {
         if (this.walletRegistry.exists(name)) {
             await this.walletRegistry.delete(name);
         }
-        this.showAddWalletOptionsQuickPickStub.resolves(UserInputUtil.WALLET);
+        this.showAddWalletOptionsQuickPickStub.resolves(UserInputUtil.IMPORT_WALLET);
 
         const walletPath: vscode.Uri = vscode.Uri.file(path.join(__dirname, '../../integrationTest/data/myWallet'));
 

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -63,7 +63,7 @@ export class UserInputUtil {
     static readonly BROWSE_LABEL: string = '📁 Browse';
     static readonly VALID_FOLDER_NAME: string = '- Folder can only contain alphanumeric, "-" and "_" characters';
     static readonly GENERATE_NEW_TEST_FILE: string = 'Generate new test file';
-    static readonly WALLET: string = 'Specify an existing file system wallet';
+    static readonly IMPORT_WALLET: string = 'Specify an existing file system wallet';
     static readonly WALLET_NEW_ID: string = 'Create a new wallet and add an identity';
     static readonly ADD_IDENTITY_METHOD: string = 'Choose a method for adding an identity';
     static readonly ADD_CERT_KEY_OPTION: string = 'Enter paths to certificate and private key files';
@@ -651,7 +651,7 @@ export class UserInputUtil {
     }
 
     public static async showAddWalletOptionsQuickPick(prompt: string): Promise<string | undefined> {
-        const addIdentityOptions: Array<string> = [this.WALLET, this.WALLET_NEW_ID];
+        const addIdentityOptions: Array<string> = [this.IMPORT_WALLET, this.WALLET_NEW_ID];
         const quickPickOptions: vscode.QuickPickOptions = {
             matchOnDetail: true,
             placeHolder: prompt,


### PR DESCRIPTION
Prevents creating and importing a wallet with the same name as an existing wallet (including the local_fabric_wallet).
Signed-off-by: Jake Turner <jaketurner25@live.com>