### PR TITLE
Install on multiple peers

### DIFF
--- a/client/cucumber/steps/steps.ts
+++ b/client/cucumber/steps/steps.ts
@@ -60,7 +60,7 @@ let showLanguagesQuickPickStub: sinon.SinonStub;
 let inputBoxStub: sinon.SinonStub;
 let browseStub: sinon.SinonStub;
 let showFolderOptionsStub: sinon.SinonStub;
-let showPeerQuickPickStub: sinon.SinonStub;
+let showPeersQuickPickStub: sinon.SinonStub;
 let showInstallableStub: sinon.SinonStub;
 let showChannelStub: sinon.SinonStub;
 let showChaincodeAndVersionStub: sinon.SinonStub;
@@ -86,7 +86,7 @@ showLanguagesQuickPickStub = mySandBox.stub(UserInputUtil, 'showLanguagesQuickPi
 inputBoxStub = mySandBox.stub(UserInputUtil, 'showInputBox').callThrough();
 browseStub = mySandBox.stub(UserInputUtil, 'browse').callThrough();
 showFolderOptionsStub = mySandBox.stub(UserInputUtil, 'showFolderOptions').callThrough();
-showPeerQuickPickStub = mySandBox.stub(UserInputUtil, 'showPeerQuickPickBox').callThrough();
+showPeersQuickPickStub = mySandBox.stub(UserInputUtil, 'showPeersQuickPickBox').callThrough();
 showInstallableStub = mySandBox.stub(UserInputUtil, 'showInstallableSmartContractsQuickPick').callThrough();
 showChannelStub = mySandBox.stub(UserInputUtil, 'showChannelQuickPickBox').callThrough();
 showChaincodeAndVersionStub = mySandBox.stub(UserInputUtil, 'showChaincodeAndVersionQuickPick').callThrough();
@@ -604,7 +604,7 @@ module.exports = function(): any {
     }
 
     async function installSmartContract(name: string, version: string): Promise<void> {
-        showPeerQuickPickStub.resolves('peer0.org1.example.com');
+        showPeersQuickPickStub.resolves(['peer0.org1.example.com']);
         const _package: PackageRegistryEntry = await PackageRegistry.instance().get(name, version);
 
         should.exist(_package);

--- a/client/integrationTest/integrationTestUtil.ts
+++ b/client/integrationTest/integrationTestUtil.ts
@@ -66,7 +66,7 @@ export class IntegrationTestUtil {
     public findFilesStub: sinon.SinonStub;
     public inputBoxStub: sinon.SinonStub;
     public browseStub: sinon.SinonStub;
-    public showPeerQuickPickStub: sinon.SinonStub;
+    public showPeersQuickPickStub: sinon.SinonStub;
     public showInstallableStub: sinon.SinonStub;
     public showChannelStub: sinon.SinonStub;
     public showChaincodeAndVersionStub: sinon.SinonStub;
@@ -99,7 +99,7 @@ export class IntegrationTestUtil {
         this.gatewayRegistry = FabricGatewayRegistry.instance();
         this.walletRegistry = FabricWalletRegistry.instance();
         this.browseStub = this.mySandBox.stub(UserInputUtil, 'browse');
-        this.showPeerQuickPickStub = this.mySandBox.stub(UserInputUtil, 'showPeerQuickPickBox');
+        this.showPeersQuickPickStub = this.mySandBox.stub(UserInputUtil, 'showPeersQuickPickBox');
         this.showInstallableStub = this.mySandBox.stub(UserInputUtil, 'showInstallableSmartContractsQuickPick');
         this.showClientInstantiatedSmartContractsStub = this.mySandBox.stub(UserInputUtil, 'showClientInstantiatedSmartContractsQuickPick');
         this.showRuntimeInstantiatedSmartContractsStub = this.mySandBox.stub(UserInputUtil, 'showRuntimeInstantiatedSmartContractsQuickPick');
@@ -252,7 +252,7 @@ export class IntegrationTestUtil {
     }
 
     public async installSmartContract(name: string, version: string): Promise<void> {
-        this.showPeerQuickPickStub.resolves('peer0.org1.example.com');
+        this.showPeersQuickPickStub.resolves(['peer0.org1.example.com']);
         const allPackages: Array<PackageRegistryEntry> = await this.packageRegistry.getAll();
 
         const packageToInstall: PackageRegistryEntry = allPackages.find((packageEntry: PackageRegistryEntry): boolean => {

--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -188,17 +188,19 @@ export class UserInputUtil {
         return vscode.window.showQuickPick(options, quickPickOptions);
     }
 
-    public static async showPeerQuickPickBox(prompt: string): Promise<string | undefined> {
+    public static async showPeersQuickPickBox(prompt: string): Promise<string[] | undefined> {
         const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const peerNames: Array<string> = connection.getAllPeerNames();
 
-        const quickPickOptions: vscode.QuickPickOptions = {
-            ignoreFocusOut: false,
-            canPickMany: false,
-            placeHolder: prompt
-        };
-
-        return vscode.window.showQuickPick(peerNames, quickPickOptions);
+        if (peerNames.length > 1) {
+            return vscode.window.showQuickPick(peerNames,  {
+                ignoreFocusOut: false,
+                canPickMany: true,
+                placeHolder: prompt
+            });
+        } else {
+            return peerNames;
+        }
     }
 
     public static async showChaincodeAndVersionQuickPick(prompt: string, peers: Array<string>, contractName?: string, contractVersion?: string): Promise<IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }> | undefined> {

--- a/client/src/commands/installCommand.ts
+++ b/client/src/commands/installCommand.ts
@@ -28,28 +28,29 @@ export async function installSmartContract(treeItem?: BlockchainTreeItem, peerNa
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
     outputAdapter.log(LogType.INFO, undefined, 'installSmartContract');
 
-    if ((treeItem instanceof PeerTreeItem)) {
-        // Clicked on peer in runtimes view to install
-        peerNames = new Set([treeItem.peerName]);
-    } else {
-        // Called from command, or runtimes installed tree
-        const isRunning: boolean = await FabricRuntimeManager.instance().getRuntime().isRunning();
-        if (!isRunning) {
-            // Start local_fabric to connect
-            await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
-            if (!(await FabricRuntimeManager.instance().getRuntime().isRunning())) {
-                // Start local_fabric failed so return
+    try {
+
+        if ((treeItem instanceof PeerTreeItem)) {
+            // Clicked on peer in runtimes view to install
+            peerNames = new Set([treeItem.peerName]);
+        } else {
+            // Called from command, or runtimes installed tree
+            const isRunning: boolean = await FabricRuntimeManager.instance().getRuntime().isRunning();
+            if (!isRunning) {
+                // Start local_fabric to connect
+                await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
+                if (!(await FabricRuntimeManager.instance().getRuntime().isRunning())) {
+                    // Start local_fabric failed so return
+                    return;
+                }
+            }
+            const chosenPeerNames: string[] = await UserInputUtil.showPeersQuickPickBox('Choose which peers to install the smart contract on');
+            if (!chosenPeerNames || chosenPeerNames.length === 0) {
                 return;
             }
+            peerNames = new Set(chosenPeerNames);
         }
-        const chosenPeerName: string = await UserInputUtil.showPeerQuickPickBox('Choose a peer to install the smart contract on');
-        if (!chosenPeerName) {
-            return;
-        }
-        peerNames = new Set([chosenPeerName]);
-    }
 
-    try {
         if (!chosenPackage) {
             const chosenInstallable: IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }> = await UserInputUtil.showInstallableSmartContractsQuickPick('Choose which package to install on the peer', peerNames) as IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>;
             if (!chosenInstallable) {
@@ -67,53 +68,44 @@ export async function installSmartContract(treeItem?: BlockchainTreeItem, peerNa
             } else {
                 chosenPackage = chosenInstallable.data.packageEntry;
             }
-
         }
 
         const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
 
-        const promises: Promise<string | void>[] = [];
-        for (const peer of peerNames) {
-            const install: Promise<string | void> = connection.installChaincode(chosenPackage, peer).catch((error: Error) => {
-                return error.message as string; // We return the error message so we can display it to the user
-            });
-            promises.push(install); // All successful installs will return undefined
-        }
+        await vscode.window.withProgress({
+            location: vscode.ProgressLocation.Notification,
+            title: 'IBM Blockchain Platform Extension',
+            cancellable: false
+        }, async (progress: vscode.Progress<{ message: string }>) => {
+            VSCodeBlockchainDockerOutputAdapter.instance().show();
 
-        let successfulInstall: boolean = true; // Have all packages been installed successfully
-
-        const peerSet: IterableIterator<string> = peerNames.values(); // Values in the peerNames set
-
-        VSCodeBlockchainDockerOutputAdapter.instance().show();
-        await Promise.all(promises).then((result: string[]) => {
-            let counter: number = 0; // Used for iterating through installChaincode results
-            for (const peer of peerSet) {
-                if (!result[counter]) {
+            let successfulInstall: boolean = true; // Have all packages been installed successfully
+            for (const peer of peerNames) {
+                progress.report({message: `Installing Smart Contract on peer ${peer}`});
+                try {
+                    await connection.installChaincode(chosenPackage, peer);
                     outputAdapter.log(LogType.SUCCESS, `Successfully installed on peer ${peer}`);
-                    counter++;
-                } else {
-                    successfulInstall = false; // Install on peer failed
-                    outputAdapter.log(LogType.ERROR, `Failed to install on peer ${peer} with reason: ${result[counter]}`);
-                    counter++;
+                } catch (error) {
+                    outputAdapter.log(LogType.ERROR, `Failed to install on peer ${peer} with reason: ${error.message}`, `Failed to install on peer ${peer} with reason: ${error.toString()}`);
+                    successfulInstall = false;
                 }
             }
+
+            await vscode.commands.executeCommand(ExtensionCommands.REFRESH_GATEWAYS);
+            await vscode.commands.executeCommand(ExtensionCommands.REFRESH_LOCAL_OPS);
+
+            if (successfulInstall) {
+                // Package was installed on all peers successfully
+                if (peerNames.size > 1) {
+                    // If the package has only been installed on one peer, we disregard this success message
+                    outputAdapter.log(LogType.SUCCESS, 'Successfully installed smart contract on all peers');
+                }
+                return chosenPackage;
+            } else {
+                // Failed to install package on all peers
+                return;
+            }
         });
-
-        await vscode.commands.executeCommand(ExtensionCommands.REFRESH_GATEWAYS);
-        await vscode.commands.executeCommand(ExtensionCommands.REFRESH_LOCAL_OPS);
-
-        if (successfulInstall) {
-            // Package was installed on all peers successfully
-            // if (peerNames.size !== 1) {
-            //     // If the package has only been installed on one peer, we disregard this success message
-            //     outputAdapter.log(LogType.SUCCESS, 'Successfully installed smart contract on all peers');
-            // }
-            return chosenPackage;
-        } else {
-            // Failed to install package on all peers
-            return;
-        }
-
     } catch (error) {
         outputAdapter.log(LogType.ERROR, `Error installing smart contract: ${error.message}`, `Error installing smart contract: ${error.toString()}`);
         return;

--- a/client/test/commands/UserInputUtil.test.ts
+++ b/client/test/commands/UserInputUtil.test.ts
@@ -357,13 +357,25 @@ describe('UserInputUtil', () => {
         });
     });
 
-    describe('showPeerQuickPickBox', () => {
+    describe('showPeersQuickPickBox', () => {
         it('should show the peer names', async () => {
-            quickPickStub.resolves('myPeerOne');
-            const result: string = await UserInputUtil.showPeerQuickPickBox('Choose a peer');
-            result.should.equal('myPeerOne');
+            quickPickStub.resolves(['myPeerOne']);
+            const result: string[] = await UserInputUtil.showPeersQuickPickBox('Choose a peer');
+            quickPickStub.should.have.been.calledWith(['myPeerOne', 'myPeerTwo'],  {
+                ignoreFocusOut: false,
+                canPickMany: true,
+                placeHolder: 'Choose a peer'
+            });
+            result.should.deep.equal(['myPeerOne']);
         });
 
+        it('should not show quickPick if only one peer', async () => {
+            fabricRuntimeConnectionStub.getAllPeerNames.returns(['myPeerOne']);
+
+            const result: string[] = await UserInputUtil.showPeersQuickPickBox('Choose a peer');
+            result.should.deep.equal(['myPeerOne']);
+            quickPickStub.should.not.have.been.called;
+        });
     });
 
     describe('showSmartContractPackagesQuickPickBox', () => {


### PR DESCRIPTION
Allow a user to select which peers to install on
This doesn't do them all at once to allow for installing on different orgs

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>