### PR TITLE
Empty array for generated tests (close #1002)

### DIFF
--- a/client/templates/jsTestSmartContractTemplate.ejs
+++ b/client/templates/jsTestSmartContractTemplate.ejs
@@ -99,6 +99,9 @@ describe('<%=chaincodeLabel%>' , () => {
                     <%_ } else if (parameter.schema.type === 'boolean') { _%>
                         <%_  params.push(` ${parameter.name.replace(`"`,'')}.toString()`) _%>
         const <%=parameter.name.replace(`"`,'')%> = true;
+                    <%_ } else if (parameter.schema.type === 'array') { _%>
+                        <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>
+        const <%=parameter.name.replace(`"`,'')%> = [];
                     <%_ } _%>
                 <%_ } else { _%>
                     <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>

--- a/client/templates/tsTestSmartContractTemplate.ejs
+++ b/client/templates/tsTestSmartContractTemplate.ejs
@@ -96,6 +96,9 @@ describe('<%=chaincodeLabel%>' , () => {
                     <%_ } else if (parameter.schema.type === 'boolean') { _%>
                         <%_  params.push(` ${parameter.name.replace(`"`,'')}.toString()`) _%>
         const <%=parameter.name.replace(`"`,'')%>: <%=parameter.schema.type.replace(`"`,'')%> = true;
+                    <%_ } else if (parameter.schema.type === 'array') { _%>
+                        <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>
+        const <%=parameter.name.replace(`"`,'')%>: any[] = [];
                     <%_ } _%>
                 <%_ } else { _%>
                     <%_  params.push(` JSON.stringify(${parameter.name.replace(`"`,'')})`) _%>

--- a/client/test/commands/testSmartContractCommand.test.ts
+++ b/client/test/commands/testSmartContractCommand.test.ts
@@ -153,6 +153,12 @@ describe('testSmartContractCommand', () => {
                                     },
                                     {
                                         name: 'butter',
+                                    },
+                                    {
+                                        name: 'milk',
+                                        schema: {
+                                            type: 'array'
+                                        }
                                     }
                                 ]
                             },
@@ -278,7 +284,8 @@ describe('testSmartContractCommand', () => {
             templateData.includes(`const ${transactionOne.parameters[2].name.replace(`"`, '')} = {};`).should.be.true;
             templateData.includes(`const ${transactionOne.parameters[3].name.replace(`"`, '')} = true;`).should.be.true;
             templateData.includes(`const ${transactionOne.parameters[4].name.replace(`"`, '')} = {};`).should.be.true;
-            templateData.includes(`const args = [ ${transactionOne.parameters[0].name.replace(`"`, '')}, ${transactionOne.parameters[1].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[2].name.replace(`"`, '')}), ${transactionOne.parameters[3].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[4].name.replace(`"`, '')})];`).should.be.true;
+            templateData.includes(`const ${transactionOne.parameters[5].name.replace(`"`, '')} = [];`).should.be.true;
+            templateData.includes(`const args = [ ${transactionOne.parameters[0].name.replace(`"`, '')}, ${transactionOne.parameters[1].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[2].name.replace(`"`, '')}), ${transactionOne.parameters[3].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[4].name.replace(`"`, '')}), JSON.stringify(${transactionOne.parameters[5].name.replace(`"`, '')})];`).should.be.true;
             templateData.includes('Admin').should.be.true;
             sendCommandStub.should.have.been.calledOnce;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, `testSmartContractCommand`);
@@ -322,7 +329,8 @@ describe('testSmartContractCommand', () => {
             templateData.includes(`const ${transactionOne.parameters[2].name.replace(`"`, '')} = {};`).should.be.true;
             templateData.includes(`const ${transactionOne.parameters[3].name.replace(`"`, '')}: ${transactionOne.parameters[3].schema.type.replace(`"`, '')} = true;`).should.be.true;
             templateData.includes(`const ${transactionOne.parameters[4].name.replace(`"`, '')} = {};`).should.be.true;
-            templateData.includes(`const args: string[] = [ ${transactionOne.parameters[0].name.replace(`"`, '')}, ${transactionOne.parameters[1].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[2].name.replace(`"`, '')}), ${transactionOne.parameters[3].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[4].name.replace(`"`, '')})`).should.be.true;
+            templateData.includes(`const ${transactionOne.parameters[5].name.replace(`"`, '')}: any[] = [];`).should.be.true;
+            templateData.includes(`const args: string[] = [ ${transactionOne.parameters[0].name.replace(`"`, '')}, ${transactionOne.parameters[1].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[2].name.replace(`"`, '')}), ${transactionOne.parameters[3].name.replace(`"`, '')}.toString(), JSON.stringify(${transactionOne.parameters[4].name.replace(`"`, '')}), JSON.stringify(${transactionOne.parameters[5].name.replace(`"`, '')})`).should.be.true;
             templateData.includes('Admin').should.be.true;
             sendCommandStub.should.have.been.calledOnce;
             workspaceConfigurationUpdateStub.should.have.been.calledOnce;


### PR DESCRIPTION
When generating functional tests for a contract, if we detect a parameter is an array type, we will create an empty array as the value.

Signed-off-by: Jake Turner <jaketurner25@live.com>