### PR TITLE
Enroll on multiple CAs

### DIFF
--- a/client/src/commands/UserInputUtil.ts
+++ b/client/src/commands/UserInputUtil.ts
@@ -194,7 +194,7 @@ export class UserInputUtil {
         const peerNames: Array<string> = connection.getAllPeerNames();
 
         if (peerNames.length > 1) {
-            return vscode.window.showQuickPick(peerNames,  {
+            return vscode.window.showQuickPick(peerNames, {
                 ignoreFocusOut: false,
                 canPickMany: true,
                 placeHolder: prompt
@@ -704,7 +704,11 @@ export class UserInputUtil {
             placeHolder: prompt
         };
 
-        return vscode.window.showQuickPick(caNames, quickPickOptions);
+        if (caNames.length > 1) {
+            return vscode.window.showQuickPick(caNames, quickPickOptions);
+        } else {
+            return caNames[0];
+        }
     }
 
     public static async showWalletsQuickPickBox(prompt: string, showLocalWallet?: boolean): Promise<IBlockchainQuickPickItem<FabricWalletRegistryEntry> | undefined> {

--- a/client/src/commands/createNewIdentityCommand.ts
+++ b/client/src/commands/createNewIdentityCommand.ts
@@ -22,6 +22,7 @@ import { UserInputUtil } from './UserInputUtil';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { IFabricWallet } from '../fabric/IFabricWallet';
 import { IFabricRuntimeConnection } from '../fabric/IFabricRuntimeConnection';
+import { FabricNode } from '../fabric/FabricNode';
 
 export async function createNewIdentity(certificateAuthorityTreeItem?: CertificateAuthorityTreeItem): Promise<void> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -56,8 +57,6 @@ export async function createNewIdentity(certificateAuthorityTreeItem?: Certifica
     }
 
     try {
-        const mspid: string = 'Org1MSP';
-        const affiliation: string = 'org1.department1'; // Currently works for org1.department1, org1.department2
         // check to see if identity of same name exists
         const connection: IFabricRuntimeConnection = await FabricRuntimeManager.instance().getConnection();
         const wallet: IFabricWallet = await connection.getWallet(certificateAuthorityName);
@@ -66,6 +65,20 @@ export async function createNewIdentity(certificateAuthorityTreeItem?: Certifica
             outputAdapter.log(LogType.ERROR, `An identity called ${identityName} already exists in the runtime wallet`, `An identity called ${identityName} already exists in the runtime wallet`);
             return;
         }
+
+        const caNode: FabricNode = connection.getNode(certificateAuthorityName);
+        let mspid: string = caNode.msp_id;
+
+        if (!mspid) {
+            const chosenMspid: string = await UserInputUtil.showInputBox('Enter MSPID');
+            if (!chosenMspid) {
+                return;
+            }
+
+            mspid = chosenMspid;
+        }
+
+        const affiliation: string = ''; // Give it the same affiliation as the identity registrar
 
         // Register the user
         const secret: string = await connection.register(certificateAuthorityName, identityName, affiliation);

--- a/client/src/fabric/FabricNode.ts
+++ b/client/src/fabric/FabricNode.ts
@@ -32,12 +32,12 @@ export class FabricNode {
         return new FabricNode({ short_name, name, type: FabricNodeType.PEER, api_url, pem, wallet, identity, msp_id });
     }
 
-    public static newCertificateAuthority(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, wallet, identity, msp_id });
+    public static newCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, wallet: string, identity: string, msp_id: string): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, wallet, identity, msp_id });
     }
 
-    public static newSecureCertificateAuthority(short_name: string, name: string, api_url: string, pem: string, wallet: string, identity: string, msp_id: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, pem, wallet, identity, msp_id });
+    public static newSecureCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, pem: string, wallet: string, identity: string, msp_id: string): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, pem, wallet, identity, msp_id });
     }
 
     public static newOrderer(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string): FabricNode {
@@ -60,6 +60,7 @@ export class FabricNode {
     public name: string;
     public type: FabricNodeType;
     public api_url: string;
+    public ca_name?: string;
     public pem?: string;
     public ssl_target_name_override?: string;
     public wallet?: string;

--- a/client/src/fabric/FabricRuntimeConnection.ts
+++ b/client/src/fabric/FabricRuntimeConnection.ts
@@ -88,7 +88,9 @@ export class FabricRuntimeConnection implements IFabricRuntimeConnection {
                     if (node.pem) {
                         trustedRoots = Buffer.from(node.pem, 'base64');
                     }
-                    const certificateAuthority: FabricCAServices = new FabricCAServices(node.api_url, { trustedRoots, verify: false }, node.name, this.client.getCryptoSuite());
+
+                    const caName: string = node.ca_name || node.name;
+                    const certificateAuthority: FabricCAServices = new FabricCAServices(node.api_url, { trustedRoots, verify: false }, caName, this.client.getCryptoSuite());
                     this.certificateAuthorities.set(node.name, certificateAuthority);
                     break;
                 }

--- a/client/test/commands/UserInputUtil.test.ts
+++ b/client/test/commands/UserInputUtil.test.ts
@@ -164,7 +164,7 @@ describe('UserInputUtil', () => {
         fabricRuntimeConnectionStub.getInstalledChaincode.withArgs('myPeerOne').resolves(chaincodeMap);
         fabricRuntimeConnectionStub.getInstalledChaincode.withArgs('myPeerTwo').resolves(new Map<string, Array<string>>());
         fabricRuntimeConnectionStub.getInstantiatedChaincode.withArgs(['myPeerOne', 'myPeerTwo'], 'channelOne').resolves([{ name: 'biscuit-network', channel: 'channelOne', version: '0.0.1' }, { name: 'cake-network', channel: 'channelOne', version: '0.0.3' }]);
-        fabricRuntimeConnectionStub.getAllCertificateAuthorityNames.resolves('ca.example.cake.com');
+        fabricRuntimeConnectionStub.getAllCertificateAuthorityNames.returns(['ca.example.cake.com', 'ca1.example.cake.com']);
         const map: Map<string, Array<string>> = new Map<string, Array<string>>();
         map.set('channelOne', ['myPeerOne', 'myPeerTwo']);
         fabricRuntimeConnectionStub.createChannelMap.resolves(map);
@@ -931,11 +931,19 @@ describe('UserInputUtil', () => {
             const result: string = await UserInputUtil.showCertificateAuthorityQuickPickBox('Please choose a CA');
 
             result.should.deep.equal('ca.example.cake.com');
-            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+            quickPickStub.should.have.been.calledWith(['ca.example.cake.com', 'ca1.example.cake.com'], {
                 ignoreFocusOut: false,
                 canPickMany: false,
                 placeHolder: 'Please choose a CA'
             });
+        });
+
+        it('should not show quick pick if only one certificate authority', async () => {
+            fabricRuntimeConnectionStub.getAllCertificateAuthorityNames.returns(['ca.example.cake.com']);
+            const result: string = await UserInputUtil.showCertificateAuthorityQuickPickBox('Please choose a CA');
+
+            result.should.deep.equal('ca.example.cake.com');
+            quickPickStub.should.not.have.been.called;
         });
     });
 
@@ -1795,7 +1803,7 @@ describe('UserInputUtil', () => {
 
         const nodes: FabricNode[] = [
             FabricNode.newPeer('peer0.org1.example.com', 'peer0.org1.example.com', 'grpc://localhost:7051', 'local_fabric_wallet', 'admin', 'Org1MSP'),
-            FabricNode.newCertificateAuthority('ca.org1.example.com', 'ca.org1.example.com', 'http://localhost:7054', 'local_fabric_wallet', 'admin', 'Org1MSP'),
+            FabricNode.newCertificateAuthority('ca.org1.example.com', 'ca.org1.example.com', 'http://localhost:7054', 'ca_name', 'local_fabric_wallet', 'admin', 'Org1MSP'),
             FabricNode.newOrderer('orderer.example.com', 'orderer.example.com', 'grpc://localhost:7050', 'local_fabric_wallet', 'admin', 'OrdererMSP'),
             FabricNode.newCouchDB('couchdb', 'couchdb', 'http://localhost:5984')
         ];

--- a/client/test/explorer/runtimeOpsExplorer.test.ts
+++ b/client/test/explorer/runtimeOpsExplorer.test.ts
@@ -274,7 +274,7 @@ describe('runtimeOpsExplorer', () => {
                 fabricConnection.getAllCertificateAuthorityNames.returns(['ca-name']);
                 fabricConnection.getNode.withArgs('peerOne').returns(FabricNode.newPeer('peerOne', 'peerOne', 'grpc://localhost:7051', 'wallet', 'identity', 'Org1MSP'));
                 fabricConnection.getNode.withArgs('peerTwo').returns(FabricNode.newPeer('peerTwo', 'peerTwo', 'grpc://localhost:8051', 'wallet', 'identity', 'Org1MSP'));
-                fabricConnection.getNode.withArgs('ca-name').returns(FabricNode.newCertificateAuthority('ca-name', 'ca-name', 'http://localhost:7054', 'wallet', 'identity', 'Org1MSP'));
+                fabricConnection.getNode.withArgs('ca-name').returns(FabricNode.newCertificateAuthority('ca-name', 'ca-name', 'http://localhost:7054', 'ca_name', 'wallet', 'identity', 'Org1MSP'));
                 fabricConnection.getNode.withArgs('orderer1').returns(FabricNode.newOrderer('orderer1', 'orderer1', 'grpc://localhost:7050', 'wallet', 'identity', 'Org1MSP'));
 
                 allChildren = await blockchainRuntimeExplorerProvider.getChildren();


### PR DESCRIPTION
Allow a user to register and enroll an identity on multiple CAs
Also if only one CA don't let user choose

contributes to #1008

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>