### PR TITLE
Run against insiders

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -33,22 +33,24 @@ npm run compile
 if [ "${TASK}" == "unit" ]; then
     TARGET=3.0.0
     ELECTRON=3.0
+    MODULES=64
     if [ "${VERSION}" == "insiders" ]; then
         TARGET=4.1.5
         ELECTRON=4.1
+        MODULES=69
     fi
 
     npm rebuild grpc --target=${TARGET} --runtime=electron --dist-url=https://atom.io/download/electron
 
     if [ $TRAVIS_OS_NAME == "linux" ]; then
         export CXX="g++-4.9" CC="gcc-4.9" DISPLAY=:99.0;
-        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v64-linux-x64-glibc
-        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-linux-x64-glibc ./node_modules/grpc/src/node/extension_binary/node-v64-linux-x64-glibc
+        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-linux-x64-glibc
+        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-linux-x64-glibc ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-linux-x64-glibc
     elif [ $TRAVIS_OS_NAME == "windows" ]; then
-        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v64-win32-x64-unknown
-        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-win32-x64-unknown ./node_modules/grpc/src/node/extension_binary/node-v64-win32-x64-unknown
+        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-win32-x64-unknown
+        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-win32-x64-unknown ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-win32-x64-unknown
     else
-        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v64-darwin-x64-unknown
-        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-darwin-x64-unknown ./node_modules/grpc/src/node/extension_binary/node-v64-darwin-x64-unknown
+        rm -rf ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-darwin-x64-unknown
+        mv ./node_modules/grpc/src/node/extension_binary/electron-v${ELECTRON}-darwin-x64-unknown ./node_modules/grpc/src/node/extension_binary/node-v${MODULES}-darwin-x64-unknown
     fi
 fi


### PR DESCRIPTION
Update to run against insiders
Also run against 1.32.3
Change min version of vscode to 1.32.3

contributes to #1022

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>