### PR TITLE
Add create to start fabric runtime

### DIFF
--- a/client/src/commands/startFabricRuntime.ts
+++ b/client/src/commands/startFabricRuntime.ts
@@ -33,6 +33,10 @@ export async function startFabricRuntime(): Promise<void> {
     }, async (progress: vscode.Progress<{ message: string }>) => {
         progress.report({ message: `Starting Fabric runtime ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME}` });
         try {
+            const isCreated: boolean = await runtime.isCreated();
+            if (!isCreated) {
+                await runtime.create();
+            }
             const generated: boolean = await runtime.isGenerated();
             if (!generated) {
                 await runtime.generate(outputAdapter);

--- a/client/test/commands/startFabricRuntime.test.ts
+++ b/client/test/commands/startFabricRuntime.test.ts
@@ -60,6 +60,8 @@ describe('startFabricRuntime', () => {
         mockRuntime = sinon.createStubInstance(FabricRuntime);
         mockRuntime.isGenerated.resolves(true);
         mockRuntime.generate.resolves();
+        mockRuntime.isCreated.resolves(true);
+        mockRuntime.create.resolves();
         mockRuntime.start.resolves();
         mockRuntime.importWalletsAndIdentities.resolves();
         sandbox.stub(FabricRuntimeManager.instance(), 'getRuntime').returns(mockRuntime);
@@ -96,9 +98,11 @@ describe('startFabricRuntime', () => {
         logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'startFabricRuntime');
     });
 
-    it('should generate and start a Fabric runtime', async () => {
+    it('should create, generate and start a Fabric runtime', async () => {
+        mockRuntime.isCreated.resolves(false);
         mockRuntime.isGenerated.resolves(false);
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
+        mockRuntime.create.should.have.been.calledOnce;
         mockRuntime.generate.should.have.been.called.calledOnceWithExactly(VSCodeBlockchainOutputAdapter.instance());
         mockRuntime.start.should.have.been.called.calledOnceWithExactly(VSCodeBlockchainOutputAdapter.instance());
         commandStub.should.have.been.calledWith(ExtensionCommands.REFRESH_ENVIRONMENTS);


### PR DESCRIPTION
Added create step if not created if for some reason it gets deleted and so therefore can't be started

closes #1276

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>