### PR TITLE
Cancelling importing nodes during environment creation no longer errors

### DIFF
--- a/src/commands/addEnvironmentCommand.ts
+++ b/src/commands/addEnvironmentCommand.ts
@@ -43,6 +43,9 @@ export async function addEnvironment(): Promise<void> {
         fabricEnvironmentEntry.name = environmentName;
 
         const addedAllNodes: boolean = await vscode.commands.executeCommand(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT, fabricEnvironmentEntry, true) as boolean;
+        if (addedAllNodes === undefined) {
+            return;
+        }
 
         await fabricEnvironmentRegistry.add(fabricEnvironmentEntry);
 

--- a/src/commands/importNodesToEnvironmentCommand.ts
+++ b/src/commands/importNodesToEnvironmentCommand.ts
@@ -61,7 +61,7 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
 
             if (!nodeUris || nodeUris.length === 0) {
                 if (fromAddEnvironment) {
-                    throw new Error('no node files were provided');
+                    return undefined;
                 } else {
                     return;
                 }

--- a/test/commands/addEnvironmentCommand.test.ts
+++ b/test/commands/addEnvironmentCommand.test.ts
@@ -191,5 +191,18 @@ describe('AddEnvironmentCommand', () => {
             logSpy.should.have.been.calledWith(LogType.WARNING, 'Added a new environment, but some nodes could not be added');
             sendTelemetryEventStub.should.have.been.calledOnceWithExactly('addEnvironmentCommand');
         });
+
+        it('should cancel environment creation if no nodes have been added', async () => {
+            showInputBoxStub.onFirstCall().resolves('myEnvironment');
+
+            executeCommandStub.withArgs(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT).resolves(undefined);
+
+            await vscode.commands.executeCommand(ExtensionCommands.ADD_ENVIRONMENT);
+
+            const environments: Array<any> = vscode.workspace.getConfiguration().get(SettingConfigurations.FABRIC_ENVIRONMENTS);
+            environments.length.should.equal(0);
+            logSpy.should.have.been.calledOnceWithExactly(LogType.INFO, undefined, 'Add environment');
+            sendTelemetryEventStub.should.not.have.been.called;
+        });
     });
 });

--- a/test/commands/importNodesToEnvironmentCommand.test.ts
+++ b/test/commands/importNodesToEnvironmentCommand.test.ts
@@ -286,17 +286,14 @@ describe('ImportNodesToEnvironmentCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Import nodes to environment');
         });
 
-        it('should return an error if adding nodes is cancelled when creating a new environment', async () => {
+        it('should test importing nodes can be cancelled from adding an environment', async () => {
             browseStub.onFirstCall().resolves();
 
-            const error: Error = new Error('no node files were provided');
-
-            await vscode.commands.executeCommand(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT, undefined, true).should.eventually.be.rejectedWith(error.message);
+            await vscode.commands.executeCommand(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT, environmentRegistryEntry, true);
 
             browseStub.should.have.been.calledOnce;
             updateNodeStub.should.not.have.been.called;
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Import nodes to environment');
-            logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Error importing node files: ${error.message}`, `Error importing node files: ${error.toString()}`);
         });
 
         it('should handle errors when importing nodes', async () => {


### PR DESCRIPTION
Steps to test:

1. Add a new environment, give it a name
2. Press escape when prompted to browse for node files in order to cancel the environment creation. Your environment won't be created and no errors will be thrown

Closes #1446 

Signed-off-by: Erin <Erin.Hughes@ibm.com>