### PR TITLE
Fix duplicate instantiated contracts

### DIFF
--- a/extension/commands/submitTransaction.ts
+++ b/extension/commands/submitTransaction.ts
@@ -66,7 +66,7 @@ export async function submitTransaction(evaluate: boolean, treeItem?: Instantiat
             channelName = chosenSmartContract.data.channel;
             smartContract = chosenSmartContract.data.name;
         } else if (treeItem instanceof InstantiatedTreeItem) {
-            channelName = treeItem.channel.label;
+            channelName = treeItem.channels[0].label;
             smartContract = treeItem.name;
         }
 

--- a/extension/commands/testSmartContractCommand.ts
+++ b/extension/commands/testSmartContractCommand.ts
@@ -68,13 +68,13 @@ export async function testSmartContract(allContracts: boolean, chaincode?: Insta
         if (chaincode instanceof ContractTreeItem) {
             chaincodeLabel = chaincode.instantiatedChaincode.label;
             chaincodeName = chaincode.instantiatedChaincode.name;
-            channelName = chaincode.instantiatedChaincode.channel.label;
+            channelName = chaincode.instantiatedChaincode.channels[0].label;
             chaincodeVersion = chaincode.instantiatedChaincode.version;
         } else {
             // Smart Contract selected from the tree item, so assign label and name
             chaincodeLabel = chaincode.label;
             chaincodeName = chaincode.name;
-            channelName = chaincode.channel.label;
+            channelName = chaincode.channels[0].label;
             chaincodeVersion = chaincode.version;
         }
     }

--- a/extension/commands/upgradeCommand.ts
+++ b/extension/commands/upgradeCommand.ts
@@ -52,8 +52,19 @@ export async function upgradeSmartContract(treeItem?: BlockchainTreeItem, channe
         // Called on instantiated chaincode tree item
         contractName = treeItem.name;
         contractVersion = treeItem.version;
-        channelName = treeItem.channel.label;
-        peerNames = treeItem.channel.peers;
+
+        const channelMap: Map<string, Array<string>> = new Map<string, Array<string>>();
+        treeItem.channels.map((channelTreeItem: ChannelTreeItem) => {
+            channelMap.set(channelTreeItem.label, channelTreeItem.peers);
+        });
+
+        const chosenChannel: IBlockchainQuickPickItem<Array<string>> = await UserInputUtil.showChannelQuickPickBox('Choose a channel to upgrade the smart contract on', channelMap);
+        if (!chosenChannel) {
+            return;
+        }
+
+        channelName = chosenChannel.label;
+        peerNames = chosenChannel.data;
 
     } else if ((treeItem instanceof ChannelTreeItem)) {
         // Called on a channel

--- a/extension/explorer/environmentExplorer.ts
+++ b/extension/explorer/environmentExplorer.ts
@@ -49,6 +49,7 @@ import { FabricEnvironmentTreeItem } from './runtimeOps/disconnectedTree/FabricE
 import { SetupTreeItem } from './runtimeOps/identitySetupTree/SetupTreeItem';
 import { FabricEnvironment } from '../fabric/FabricEnvironment';
 import { EnvironmentConnectedTreeItem } from './runtimeOps/connectedTree/EnvironmentConnectedTreeItem';
+import { FabricChaincode } from '../fabric/FabricChaincode';
 
 export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorerProvider {
 
@@ -344,6 +345,7 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
     private async createInstantiatedTree(): Promise<Array<BlockchainTreeItem>> {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
         const tree: Array<BlockchainTreeItem> = [];
+        const tempTree: InstantiatedChaincodeTreeItem[] = [];
 
         const command: vscode.Command = {
             command: ExtensionCommands.INSTANTIATE_SMART_CONTRACT,
@@ -355,18 +357,32 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
             const connection: IFabricEnvironmentConnection = await FabricEnvironmentManager.instance().getConnection();
             const channelMap: Map<string, Array<string>> = await connection.createChannelMap();
             for (const [channelName, peerNames] of channelMap) {
-                const chaincodes: any[] = await connection.getInstantiatedChaincode(peerNames, channelName);
+                const chaincodes: FabricChaincode[] = await connection.getInstantiatedChaincode(peerNames, channelName);
                 const channelTreeItem: ChannelTreeItem = new ChannelTreeItem(this, channelName, peerNames, chaincodes, vscode.TreeItemCollapsibleState.None);
                 for (const chaincode of chaincodes) {
                     // Doesn't matter if this is a chaincode or a contract as this is the ops view, and
                     // we shouldn't be exposing contracts or transaction functions in the ops view.
-                    tree.push(new InstantiatedChaincodeTreeItem(this, chaincode.name, channelTreeItem, chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
+                    const foundTreeItemNum: number = tempTree.findIndex((treeItem: InstantiatedChaincodeTreeItem) => {
+                        return treeItem.name === chaincode.name && treeItem.version === chaincode.version;
+                    });
+
+                    if (foundTreeItemNum > -1) {
+                        const tempTreeItem: InstantiatedChaincodeTreeItem = tempTree[foundTreeItemNum];
+                        const channels: ChannelTreeItem[] = tempTreeItem.channels;
+                        channels.push(channelTreeItem);
+                        tempTree.splice(foundTreeItemNum, 1);
+
+                        tempTree.push(new InstantiatedChaincodeTreeItem(this, chaincode.name, channels, chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
+                    } else {
+                        tempTree.push(new InstantiatedChaincodeTreeItem(this, chaincode.name, [channelTreeItem], chaincode.version, vscode.TreeItemCollapsibleState.None, null, false));
+                    }
                 }
             }
         } catch (error) {
             outputAdapter.log(LogType.ERROR, `Error populating instantiated smart contracts view: ${error.message}`, `Error populating instantiated smart contracts view: ${error.message}`);
 
         } finally {
+            tree.push(...tempTree);
             tree.push(new InstantiateCommandTreeItem(this, command));
         }
         return tree;

--- a/extension/explorer/model/InstantiatedTreeItem.ts
+++ b/extension/explorer/model/InstantiatedTreeItem.ts
@@ -27,10 +27,17 @@ export abstract class InstantiatedTreeItem extends BlockchainTreeItem {
         dark: path.join(__filename, '..', '..', '..', '..', '..', 'resources', 'dark', 'smart-contract.svg')
     };
 
-    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly channel: ChannelTreeItem, public readonly version: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly contracts?: string[], public readonly showIcon?: boolean) {
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly channels: ChannelTreeItem[], public readonly version: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState, public readonly contracts?: string[], public readonly showIcon?: boolean) {
         super(provider, `${name}@${version}`, collapsibleState);
 
-        this.tooltip = `Instantiated on: ${channel.label}`;
+        this.tooltip = `Instantiated on:`;
+        for (let i: number = 0; i < channels.length; i++) {
+            if (i === channels.length - 1) {
+                this.tooltip += ` ${channels[i].label}`;
+            } else {
+                this.tooltip += ` ${channels[i].label},`;
+            }
+        }
 
         if (!showIcon) {
             this.iconPath = null;

--- a/extension/fabric/FabricChaincode.ts
+++ b/extension/fabric/FabricChaincode.ts
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+// This is a JSON representation of a Fabric Chaincode.
+// tslint:disable variable-name
+export class FabricChaincode {
+    public constructor(public name: string, public version: string) {
+
+    }
+}

--- a/extension/fabric/FabricConnection.ts
+++ b/extension/fabric/FabricConnection.ts
@@ -20,6 +20,7 @@ import { ConsoleOutputAdapter } from '../logging/ConsoleOutputAdapter';
 import { FabricWallet } from './FabricWallet';
 import { URL } from 'url';
 import { FabricWalletRegistryEntry } from './FabricWalletRegistryEntry';
+import { FabricChaincode } from './FabricChaincode';
 
 export abstract class FabricConnection {
 
@@ -85,7 +86,7 @@ export abstract class FabricConnection {
         }
     }
 
-    public async getInstantiatedChaincode(channelName: string): Promise<Array<{ name: string, version: string }>> {
+    public async getInstantiatedChaincode(channelName: string): Promise<Array<FabricChaincode>> {
         const instantiatedChaincodes: Array<any> = [];
         const channel: Client.Channel = await this.getChannel(channelName);
         const chainCodeResponse: Client.ChaincodeQueryResponse = await channel.queryInstantiatedChaincodes(null);

--- a/extension/fabric/IFabricEnvironmentConnection.ts
+++ b/extension/fabric/IFabricEnvironmentConnection.ts
@@ -17,6 +17,7 @@ import { PackageRegistryEntry } from '../packages/PackageRegistryEntry';
 import { IFabricWallet } from './IFabricWallet';
 import { FabricNode } from './FabricNode';
 import { Attribute } from './FabricCertificate';
+import { FabricChaincode } from './FabricChaincode';
 
 export interface IFabricEnvironmentConnection {
 
@@ -28,7 +29,7 @@ export interface IFabricEnvironmentConnection {
 
     createChannelMap(): Promise<Map<string, Array<string>>>;
 
-    getInstantiatedChaincode(peerNames: Array<string>, channelName: string): Promise<Array<{name: string, version: string}>>;
+    getInstantiatedChaincode(peerNames: Array<string>, channelName: string): Promise<Array<FabricChaincode>>;
 
     getAllInstantiatedChaincodes(): Promise<Array<{name: string, version: string}>>;
 

--- a/extension/util/ExtensionUtil.ts
+++ b/extension/util/ExtensionUtil.ts
@@ -105,6 +105,7 @@ import { FabricRuntimeUtil } from '../fabric/FabricRuntimeUtil';
 import { FabricDebugConfigurationProvider } from '../debug/FabricDebugConfigurationProvider';
 import { importNodesToEnvironment } from '../commands/importNodesToEnvironmentCommand';
 import { deleteNode } from '../commands/deleteNodeCommand';
+import { FabricChaincode } from '../fabric/FabricChaincode';
 import { ReactView } from '../webview/ReactView';
 
 let blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider;
@@ -137,7 +138,7 @@ export class ExtensionUtil {
         return this.getExtension().extensionPath;
     }
 
-    public static async getContractNameAndVersion(folder: vscode.WorkspaceFolder): Promise<{ name: string, version: string }> {
+    public static async getContractNameAndVersion(folder: vscode.WorkspaceFolder): Promise<FabricChaincode> {
         try {
             const packageJson: any = await this.loadJSON(folder, 'package.json');
             return { name: packageJson.name, version: packageJson.version };
@@ -349,7 +350,7 @@ export class ExtensionUtil {
                 if (e.configuration.env && e.configuration.env.CORE_CHAINCODE_ID_NAME) {
                     const smartContractName: string = e.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[0];
                     const smartContractVersion: string = e.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[1];
-                    const instantiatedSmartContract: { name: string, version: string } = await FabricDebugConfigurationProvider.getInstantiatedChaincode(smartContractName);
+                    const instantiatedSmartContract: FabricChaincode = await FabricDebugConfigurationProvider.getInstantiatedChaincode(smartContractName);
 
                     if (!instantiatedSmartContract) {
                         await vscode.commands.executeCommand(ExtensionCommands.DEBUG_COMMAND_LIST, ExtensionCommands.INSTANTIATE_SMART_CONTRACT);

--- a/test/commands/UserInputUtil.test.ts
+++ b/test/commands/UserInputUtil.test.ts
@@ -206,7 +206,7 @@ describe('UserInputUtil', () => {
 
             result.data.name.should.equal(environmentRegistry.name);
 
-            quickPickStub.should.have.been.calledWith([{ label: environmentRegistry.name, data: environmentRegistry }, {label: environmentRegistry2.name, data: environmentRegistry2}], {
+            quickPickStub.should.have.been.calledWith([{ label: environmentRegistry.name, data: environmentRegistry }, { label: environmentRegistry2.name, data: environmentRegistry2 }], {
                 ignoreFocusOut: true,
                 canPickMany: false,
                 placeHolder: 'choose an environment'
@@ -294,12 +294,12 @@ describe('UserInputUtil', () => {
         it('should show multiple connections in the quickpick box', async () => {
             quickPickStub.resolves([
                 {
-                label: gatewayEntryOne.name,
-                data: gatewayEntryOne
-            }, {
-                label: gatewayEntryTwo.name,
-                data: gatewayEntryTwo
-            }]);
+                    label: gatewayEntryOne.name,
+                    data: gatewayEntryOne
+                }, {
+                    label: gatewayEntryTwo.name,
+                    data: gatewayEntryTwo
+                }]);
             const results: IBlockchainQuickPickItem<FabricGatewayRegistryEntry>[] = await UserInputUtil.showGatewayQuickPickBox('Choose a gateway', true) as IBlockchainQuickPickItem<FabricGatewayRegistryEntry>[];
 
             results[0].label.should.equal('myGatewayA');
@@ -638,7 +638,26 @@ describe('UserInputUtil', () => {
             const result: IBlockchainQuickPickItem<Array<string>> = await UserInputUtil.showChannelQuickPickBox('Choose a channel');
             result.should.deep.equal({ label: 'channelOne', data: ['myPeerOne', 'myPeerTwo'] });
 
-            quickPickStub.should.have.been.calledWith(sinon.match.any, {
+            quickPickStub.should.have.been.calledWith([{ label: 'channelOne', data: ['myPeerOne', 'myPeerTwo'] }, { label: 'channelTwo', data: ['myPeerOne'] }], {
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Choose a channel'
+            });
+        });
+
+        it('should use the channel map passed in', async () => {
+            const map: Map<string, Array<string>> = new Map<string, Array<string>>();
+            map.set('channelThree', ['myPeerOne', 'myPeerTwo']);
+            map.set('channelFour', ['myPeerOne']);
+            fabricRuntimeConnectionStub.createChannelMap.resolves(map);
+            quickPickStub.resolves({ label: 'channelThree', data: ['myPeerOne', 'myPeerTwo'] });
+
+            const result: IBlockchainQuickPickItem<Array<string>> = await UserInputUtil.showChannelQuickPickBox('Choose a channel', map);
+            result.should.deep.equal({ label: 'channelThree', data: ['myPeerOne', 'myPeerTwo'] });
+
+            fabricRuntimeConnectionStub.createChannelMap.should.not.have.been.called;
+
+            quickPickStub.should.have.been.calledWith([{ label: 'channelThree', data: ['myPeerOne', 'myPeerTwo'] }, { label: 'channelFour', data: ['myPeerOne'] }], {
                 ignoreFocusOut: true,
                 canPickMany: false,
                 placeHolder: 'Choose a channel'
@@ -1343,10 +1362,10 @@ describe('UserInputUtil', () => {
                         version: '0.0.3'
                     }
                 }], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Please choose instantiated smart contract to test'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Please choose instantiated smart contract to test'
+            });
         });
 
         it('should handle no instantiated chaincodes in connection', async () => {
@@ -1407,10 +1426,10 @@ describe('UserInputUtil', () => {
                         version: '0.0.3'
                     }
                 }], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Please choose instantiated smart contract to test'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Please choose instantiated smart contract to test'
+            });
         });
 
         it('should handle no instantiated chaincodes in connection', async () => {
@@ -1782,12 +1801,12 @@ describe('UserInputUtil', () => {
         it('should show multiple wallets to select', async () => {
             quickPickStub.resolves([
                 {
-                label: walletEntryOne.name,
-                data: walletEntryOne
-            }, {
-                label: walletEntryTwo.name,
-                data: walletEntryTwo
-            }]);
+                    label: walletEntryOne.name,
+                    data: walletEntryOne
+                }, {
+                    label: walletEntryTwo.name,
+                    data: walletEntryTwo
+                }]);
             const results: IBlockchainQuickPickItem<FabricWalletRegistryEntry>[] = await UserInputUtil.showWalletsQuickPickBox('Choose a wallet', true, false) as IBlockchainQuickPickItem<FabricWalletRegistryEntry>[];
 
             results[0].label.should.equal(walletEntryOne.name);
@@ -2085,10 +2104,10 @@ describe('UserInputUtil', () => {
                 { label: 'orderer.example.com', data: nodes[2] },
                 { label: 'orderer1.example.com', data: nodes[3] }
             ], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Gimme a node'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
         });
 
         it('should allow the user to select a node with associated identity', async () => {
@@ -2100,10 +2119,10 @@ describe('UserInputUtil', () => {
                 { label: 'orderer.example.com', data: nodes[2], description: `Associated with identity: ${nodes[0].identity} in wallet: ${nodes[2].wallet}` },
                 { label: 'orderer1.example.com', data: nodes[3], description: `Associated with identity: ${nodes[0].identity} in wallet: ${nodes[3].wallet}` },
             ], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Gimme a node'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
         });
 
         it('should not show quick pick if only one node', async () => {
@@ -2132,10 +2151,10 @@ describe('UserInputUtil', () => {
                 { label: 'orderer.example.com', data: nodes[2] },
                 { label: 'orderer1.example.com', data: nodes[3] }
             ], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Gimme a node'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
         });
 
         it('should show cluster name', async () => {
@@ -2148,10 +2167,10 @@ describe('UserInputUtil', () => {
                 { label: 'peer0.org1.example.com', data: nodes[0] },
                 { label: 'myCluster', data: nodes[2] }
             ], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Gimme a node'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
         });
 
         it('should show cluster name with associated identity', async () => {
@@ -2164,10 +2183,10 @@ describe('UserInputUtil', () => {
                 { label: 'peer0.org1.example.com', data: nodes[0], description: `Associated with identity: ${nodes[0].identity} in wallet: ${nodes[0].wallet}` },
                 { label: 'myCluster', data: nodes[2], description: `Associated with identity: ${nodes[2].identity} in wallet: ${nodes[2].wallet}` }
             ], {
-                    ignoreFocusOut: true,
-                    canPickMany: false,
-                    placeHolder: 'Gimme a node'
-                });
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
         });
 
         it('should handle no nodes found', async () => {
@@ -2269,13 +2288,13 @@ describe('UserInputUtil', () => {
 
             const pathOne: string = path.join('some', 'path');
             const uriOne: vscode.Uri = vscode.Uri.file(pathOne);
-            const folders: Array<any> = [ { name: 'project_1', uri: uriOne } ];
+            const folders: Array<any> = [{ name: 'project_1', uri: uriOne }];
             const showWorkspaceQuickPickBoxStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
-            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns( folders );
-            showWorkspaceQuickPickBoxStub.withArgs( 'Choose a workspace folder to package').resolves( {data: folders[0]} );
+            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns(folders);
+            showWorkspaceQuickPickBoxStub.withArgs('Choose a workspace folder to package').resolves({ data: folders[0] });
 
-            const result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace( true );
-            result.should.equal( folders[0] );
+            const result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace(true);
+            result.should.equal(folders[0]);
             showWorkspaceQuickPickBoxStub.should.not.have.been.called;
         });
 
@@ -2283,13 +2302,13 @@ describe('UserInputUtil', () => {
 
             const pathOne: string = path.join('some', 'path');
             const uriOne: vscode.Uri = vscode.Uri.file(pathOne);
-            const folders: Array<any> = [ { name: 'project_1', uri: uriOne } ];
-            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns( folders );
+            const folders: Array<any> = [{ name: 'project_1', uri: uriOne }];
+            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns(folders);
             const showWorkspaceQuickPickBoxStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
-            showWorkspaceQuickPickBoxStub.withArgs( 'Choose a workspace folder to create functional tests for').resolves( {data: folders[0]} );
+            showWorkspaceQuickPickBoxStub.withArgs('Choose a workspace folder to create functional tests for').resolves({ data: folders[0] });
 
-            const result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace( false );
-            result.should.equal( folders[0] );
+            const result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace(false);
+            result.should.equal(folders[0]);
             showWorkspaceQuickPickBoxStub.should.have.been.calledOnce;
         });
 
@@ -2303,17 +2322,17 @@ describe('UserInputUtil', () => {
                 { name: 'project_1', uri: uriOne },
                 { name: 'biscuit-network', uri: uriTwo }
             ];
-            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns( folders );
+            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns(folders);
             const showWorkspaceQuickPickBoxStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
-            showWorkspaceQuickPickBoxStub.withArgs( 'Choose a workspace folder to package').resolves( {data: folders[0]} );
-            showWorkspaceQuickPickBoxStub.withArgs( 'Choose a workspace folder to create functional tests for').resolves( {data: folders[1]} );
+            showWorkspaceQuickPickBoxStub.withArgs('Choose a workspace folder to package').resolves({ data: folders[0] });
+            showWorkspaceQuickPickBoxStub.withArgs('Choose a workspace folder to create functional tests for').resolves({ data: folders[1] });
 
-            let result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace( true );
-            result.should.equal( folders[0] );
+            let result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace(true);
+            result.should.equal(folders[0]);
             showWorkspaceQuickPickBoxStub.should.have.been.calledOnce;
 
-            result = await UserInputUtil.chooseWorkspace( false );
-            result.should.equal( folders[1] );
+            result = await UserInputUtil.chooseWorkspace(false);
+            result.should.equal(folders[1]);
             showWorkspaceQuickPickBoxStub.should.have.been.calledTwice;
         });
 
@@ -2327,22 +2346,22 @@ describe('UserInputUtil', () => {
                 { name: 'project_1', uri: uriOne },
                 { name: 'biscuit-network', uri: uriTwo }
             ];
-            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns( folders );
+            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns(folders);
             const showWorkspaceQuickPickBoxStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
             showWorkspaceQuickPickBoxStub.resolves();
 
-            let result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace( true );
+            let result: vscode.WorkspaceFolder = await UserInputUtil.chooseWorkspace(true);
             showWorkspaceQuickPickBoxStub.should.have.been.calledOnce;
             should.equal(result, undefined);
 
-            result = await UserInputUtil.chooseWorkspace( false );
+            result = await UserInputUtil.chooseWorkspace(false);
             showWorkspaceQuickPickBoxStub.should.have.been.calledTwice;
             should.equal(result, undefined);
         });
 
         it('should handle error from get workspace folders', async () => {
 
-            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns( [] );
+            mySandBox.stub(UserInputUtil, 'getWorkspaceFolders').returns([]);
             const showWorkspaceQuickPickBoxStub: sinon.SinonStub = mySandBox.stub(UserInputUtil, 'showWorkspaceQuickPickBox');
             showWorkspaceQuickPickBoxStub.resolves();
 
@@ -2352,7 +2371,7 @@ describe('UserInputUtil', () => {
             let result: vscode.WorkspaceFolder;
             let errorCount: number = 0;
             try {
-                result = await UserInputUtil.chooseWorkspace( true );
+                result = await UserInputUtil.chooseWorkspace(true);
             } catch (err) {
                 should.equal(result, undefined);
                 should.equal(err.message, errorPackage.message);
@@ -2360,7 +2379,7 @@ describe('UserInputUtil', () => {
             }
 
             try {
-                result = await UserInputUtil.chooseWorkspace( false );
+                result = await UserInputUtil.chooseWorkspace(false);
             } catch (err) {
                 should.equal(result, undefined);
                 should.equal(err.message, errorTests.message);

--- a/test/commands/testSmartContractCommand.test.ts
+++ b/test/commands/testSmartContractCommand.test.ts
@@ -39,7 +39,7 @@ import { ContractTreeItem } from '../../extension/explorer/model/ContractTreeIte
 import { FABRIC_CLIENT_VERSION, FABRIC_NETWORK_VERSION, ExtensionUtil } from '../../extension/util/ExtensionUtil';
 import { InstantiatedUnknownTreeItem } from '../../extension/explorer/model/InstantiatedUnknownTreeItem';
 import { FabricGatewayHelper } from '../../extension/fabric/FabricGatewayHelper';
-
+import { InstantiatedTreeItem } from '../../extension/explorer/model/InstantiatedTreeItem';
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
 // tslint:disable no-unused-expression
@@ -58,7 +58,6 @@ describe('testSmartContractCommand', () => {
     let allChildren: Array<BlockchainTreeItem>;
     let blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider;
     let fabricConnectionManager: FabricConnectionManager;
-    let chaincodes: any[];
     let instantiatedSmartContract: InstantiatedContractTreeItem;
     let smartContractName: string;
     let smartContractLabel: string;
@@ -252,8 +251,6 @@ describe('testSmartContractCommand', () => {
                 {
                     name: 'wagonwheel',
                     version: '0.0.1',
-                    label: 'wagonwheel@0.0.1',
-                    channel: 'myEnglishChannel'
                 }
             ]);
             // Wallet stubs
@@ -272,9 +269,9 @@ describe('testSmartContractCommand', () => {
             // Explorer provider stuff
             blockchainGatewayExplorerProvider = ExtensionUtil.getBlockchainGatewayExplorerProvider();
             allChildren = await blockchainGatewayExplorerProvider.getChildren();
-            const channelChildren: Array<ChannelTreeItem> = await blockchainGatewayExplorerProvider.getChildren(allChildren[2]) as Array<ChannelTreeItem>;
-            chaincodes = channelChildren[0].chaincodes;
-            instantiatedSmartContract = chaincodes[0] as InstantiatedContractTreeItem;
+            const channels: Array<ChannelTreeItem> = await blockchainGatewayExplorerProvider.getChildren(allChildren[2]) as Array<ChannelTreeItem>;
+            const contracts: Array<InstantiatedTreeItem> =  await blockchainGatewayExplorerProvider.getChildren(channels[0]) as Array<InstantiatedTreeItem>;
+            instantiatedSmartContract = contracts[0];
 
             smartContractLabel = instantiatedSmartContract.label;
             smartContractName = instantiatedSmartContract.name;

--- a/test/commands/upgradeCommand.test.ts
+++ b/test/commands/upgradeCommand.test.ts
@@ -299,6 +299,18 @@ describe('UpgradeCommand', () => {
             dockerLogSpy.should.have.been.called;
         });
 
+        it('should handle cancel choosing channel on upgrading from the contract on a tree', async () => {
+            showChannelQuickPickStub.resolves();
+
+            instantiatedSmartContractsList.length.should.equal(2);
+
+            await vscode.commands.executeCommand(ExtensionCommands.UPGRADE_SMART_CONTRACT, instantiatedSmartContractsList[0] as InstalledChainCodeOpsTreeItem);
+
+            fabricRuntimeMock.upgradeChaincode.should.not.have.been.called;
+
+            reporterStub.should.not.have.been.called;
+        });
+
         it('should upgrade smart contract through the tree by right-clicking on a channel in the runtime ops view', async () => {
 
             executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT, undefined, ['peerOne'], { name: 'biscuit-network', version: '0.0.2', path: undefined }).resolves({ name: 'biscuit-network', version: '0.0.2', path: undefined });

--- a/test/debug/FabricDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricDebugConfigurationProvider.test.ts
@@ -28,6 +28,7 @@ import { FabricEnvironmentRegistryEntry } from '../../extension/fabric/FabricEnv
 import { FabricWalletUtil } from '../../extension/fabric/FabricWalletUtil';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { GlobalState } from '../../extension/util/GlobalState';
+import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -102,7 +103,7 @@ describe('FabricDebugConfigurationProvider', () => {
 
             mockRuntimeConnection = sinon.createStubInstance(FabricEnvironmentConnection);
             mockRuntimeConnection.getAllPeerNames.resolves(['peerOne']);
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             getConnectionStub = mySandbox.stub(FabricEnvironmentManager.instance(), 'getConnection');
@@ -323,7 +324,7 @@ describe('FabricDebugConfigurationProvider', () => {
         });
 
         it('should restore from a previous debug session and use the last instantiated package of the same name', async () => {
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'mySmartContract', version: '0.0.1' }, { name: 'cake-network', version: '0.0.2' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'mySmartContract', version: '0.0.1' }, { name: 'cake-network', version: '0.0.2' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             runtimeStub.isRunning.onFirstCall().resolves(true);
@@ -345,7 +346,7 @@ describe('FabricDebugConfigurationProvider', () => {
         });
 
         it('should kill the container if there is a container running with the smart contract already', async () => {
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'mySmartContract', version: '0.0.1' }, { name: 'cake-network', version: '0.0.2' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'mySmartContract', version: '0.0.1' }, { name: 'cake-network', version: '0.0.2' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             runtimeStub.isRunning.resolves(true);

--- a/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -32,6 +32,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/fabric/FabricEnvironmentRegistryEntry';
 import { FabricWalletUtil } from '../../extension/fabric/FabricWalletUtil';
 import { GlobalState } from '../../extension/util/GlobalState';
+import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -123,7 +124,7 @@ describe('FabricGoDebugConfigurationProvider', () => {
             mockRuntimeConnection.connect.resolves();
             mockRuntimeConnection.getAllPeerNames.resolves('peerOne');
 
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             mySandbox.stub(FabricEnvironmentManager.instance(), 'getConnection').returns(mockRuntimeConnection);

--- a/test/debug/FabricJavaDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricJavaDebugConfigurationProvider.test.ts
@@ -32,6 +32,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/fabric/FabricEnvironmentRegistryEntry';
 import { FabricWalletUtil } from '../../extension/fabric/FabricWalletUtil';
 import { GlobalState } from '../../extension/util/GlobalState';
+import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -121,7 +122,7 @@ describe('FabricJavaDebugConfigurationProvider', () => {
             mockRuntimeConnection.connect.resolves();
             mockRuntimeConnection.getAllPeerNames.resolves('peerOne');
 
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             mySandbox.stub(FabricEnvironmentManager.instance(), 'getConnection').returns(mockRuntimeConnection);

--- a/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -32,6 +32,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/fabric/FabricEnvironmentRegistryEntry';
 import { FabricWalletUtil } from '../../extension/fabric/FabricWalletUtil';
 import { GlobalState } from '../../extension/util/GlobalState';
+import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -122,7 +123,7 @@ describe('FabricNodeDebugConfigurationProvider', () => {
             mockRuntimeConnection.connect.resolves();
             mockRuntimeConnection.getAllPeerNames.resolves('peerOne');
 
-            const instantiatedChaincodes: { name: string, version: string }[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
+            const instantiatedChaincodes: FabricChaincode[] = [{ name: 'myOtherContract', version: 'vscode-debug-13232112018' }, { name: 'cake-network', version: 'vscode-debug-174758735087' }];
             mockRuntimeConnection.getAllInstantiatedChaincodes.resolves(instantiatedChaincodes);
 
             mySandbox.stub(FabricEnvironmentManager.instance(), 'getConnection').returns(mockRuntimeConnection);

--- a/test/explorer/environmentExplorer.test.ts
+++ b/test/explorer/environmentExplorer.test.ts
@@ -362,13 +362,17 @@ describe('environmentExplorer', () => {
                     name: 'biscuit-network',
                     version: '0.7'
                 }]);
-                fabricConnection.getInstantiatedChaincode.withArgs(['peerOne', 'peerTwo'], 'channelTwo').resolves([{
-                    name: 'cake-network',
-                    version: '0.10'
-                }, {
-                    name: 'legacy-network',
-                    version: '2.34'
-                }]);
+                fabricConnection.getInstantiatedChaincode.withArgs(['peerOne', 'peerTwo'], 'channelTwo').resolves([
+                    {
+                        name: 'biscuit-network',
+                        version: '0.7'
+                    }, {
+                        name: 'cake-network',
+                        version: '0.10'
+                    }, {
+                        name: 'legacy-network',
+                        version: '2.34'
+                    }]);
 
                 fabricConnection.getAllOrganizationNames.returns(['Org1', 'Org2']);
 
@@ -828,7 +832,7 @@ describe('environmentExplorer', () => {
                 instantiatedChaincodeOne.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChaincodeOne.contextValue.should.equal('blockchain-instantiated-chaincode-item');
                 instantiatedChaincodeOne.label.should.equal('biscuit-network@0.7');
-                instantiatedChaincodeOne.tooltip.should.equal('Instantiated on: channelOne');
+                instantiatedChaincodeOne.tooltip.should.equal('Instantiated on: channelOne, channelTwo');
                 const instantiatedChaincodeTwo: InstantiatedChaincodeTreeItem = instantiatedChaincodes[1] as InstantiatedChaincodeTreeItem;
                 instantiatedChaincodeTwo.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChaincodeTwo.contextValue.should.equal('blockchain-instantiated-chaincode-item');

--- a/test/explorer/gatewayExplorer.test.ts
+++ b/test/explorer/gatewayExplorer.test.ts
@@ -516,7 +516,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedTreeItemOne.version.should.equal('0.7');
                 instantiatedTreeItemOne.label.should.equal('biscuit-network@0.7');
                 instantiatedTreeItemOne.contextValue.should.equal('blockchain-instantiated-multi-contract-item');
-                instantiatedTreeItemOne.channel.label.should.equal('channelOne');
+                instantiatedTreeItemOne.channels[0].label.should.equal('channelOne');
+                instantiatedTreeItemOne.channels.length.should.equal(1);
 
                 instantiatedUnknownChainCodes = await blockchainGatewayExplorerProvider.getChildren(channels[1]) as Array<InstantiatedUnknownTreeItem>;
                 instantiatedUnknownChainCodes.length.should.equal(2);
@@ -532,7 +533,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedTreeItemTwo.version.should.equal('0.10');
                 instantiatedTreeItemTwo.label.should.equal('cake-network@0.10');
                 instantiatedTreeItemTwo.contextValue.should.equal('blockchain-instantiated-contract-item');
-                instantiatedTreeItemTwo.channel.label.should.equal('channelTwo');
+                instantiatedTreeItemTwo.channels[0].label.should.equal('channelTwo');
+                instantiatedTreeItemTwo.channels.length.should.equal(1);
 
                 const instantiatedTreeItemThree: InstantiatedChaincodeTreeItem = channelChildrenTwo[1] as InstantiatedChaincodeTreeItem;
                 instantiatedTreeItemThree.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
@@ -540,7 +542,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedTreeItemThree.version.should.equal('2.34');
                 instantiatedTreeItemThree.label.should.equal('legacy-network@2.34');
                 instantiatedTreeItemThree.contextValue.should.equal('blockchain-instantiated-chaincode-item');
-                instantiatedTreeItemThree.channel.label.should.equal('channelTwo');
+                instantiatedTreeItemThree.channels[0].label.should.equal('channelTwo');
+                instantiatedTreeItemThree.channels.length.should.equal(1);
             });
 
             it('should not create anything if no peers', async () => {
@@ -609,7 +612,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedTreeItemTwo.version.should.equal('0.10');
                 instantiatedTreeItemTwo.label.should.equal('cake-network@0.10');
                 instantiatedTreeItemTwo.contextValue.should.equal('blockchain-instantiated-contract-item');
-                instantiatedTreeItemTwo.channel.label.should.equal('channelTwo');
+                instantiatedTreeItemTwo.channels[0].label.should.equal('channelTwo');
+                instantiatedTreeItemTwo.channels.length.should.equal(1);
 
                 const instantiatedTreeItemThree: InstantiatedChaincodeTreeItem = channelChildrenTwo[1] as InstantiatedChaincodeTreeItem;
                 instantiatedTreeItemThree.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
@@ -617,7 +621,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedTreeItemThree.version.should.equal('2.34');
                 instantiatedTreeItemThree.label.should.equal('legacy-network@2.34');
                 instantiatedTreeItemThree.contextValue.should.equal('blockchain-instantiated-chaincode-item');
-                instantiatedTreeItemThree.channel.label.should.equal('channelTwo');
+                instantiatedTreeItemThree.channels[0].label.should.equal('channelTwo');
+                instantiatedTreeItemThree.channels.length.should.equal(1);
 
                 logSpy.should.not.have.been.calledWith(LogType.ERROR);
             });
@@ -643,7 +648,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedChaincodeItemOne.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.Collapsed);
                 instantiatedChaincodeItemOne.contextValue.should.equal('blockchain-instantiated-multi-contract-item');
                 instantiatedChaincodeItemOne.label.should.equal('biscuit-network@0.7');
-                instantiatedChaincodeItemOne.channel.should.equal(channelOne);
+                instantiatedChaincodeItemOne.channels[0].should.equal(channelOne);
+                instantiatedChaincodeItemOne.channels.length.should.equal(1);
                 instantiatedChaincodeItemOne.version.should.equal('0.7');
                 instantiatedChaincodeItemOne.contracts.should.deep.equal(['my-contract', 'someOtherContract']);
 
@@ -662,7 +668,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedChaincodeItemTwo.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChaincodeItemTwo.contextValue.should.equal('blockchain-instantiated-contract-item');
                 instantiatedChaincodeItemTwo.label.should.equal('cake-network@0.10');
-                instantiatedChaincodeItemTwo.channel.should.equal(channelTwo);
+                instantiatedChaincodeItemTwo.channels[0].should.equal(channelTwo);
+                instantiatedChaincodeItemTwo.channels.length.should.equal(1);
                 instantiatedChaincodeItemTwo.version.should.equal('0.10');
                 instantiatedChaincodeItemTwo.contracts.should.deep.equal([]);
 
@@ -671,7 +678,8 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 instantiatedChaincodeItemThree.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 instantiatedChaincodeItemThree.contextValue.should.equal('blockchain-instantiated-chaincode-item');
                 instantiatedChaincodeItemThree.label.should.equal('legacy-network@2.34');
-                instantiatedChaincodeItemThree.channel.should.equal(channelTwo);
+                instantiatedChaincodeItemThree.channels[0].should.equal(channelTwo);
+                instantiatedChaincodeItemThree.channels.length.should.equal(1);
                 instantiatedChaincodeItemThree.version.should.equal('2.34');
                 should.equal(instantiatedChaincodeItemThree.contracts, null);
 
@@ -699,11 +707,13 @@ ${FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME}`);
                 contractsOne.length.should.equal(2);
                 contractsOne[0].label.should.equal('my-contract');
                 contractsOne[0].instantiatedChaincode.name.should.equal('biscuit-network');
-                contractsOne[0].instantiatedChaincode.channel.label.should.equal('channelOne');
+                contractsOne[0].instantiatedChaincode.channels[0].label.should.equal('channelOne');
+                contractsOne[0].instantiatedChaincode.channels.length.should.equal(1);
                 contractsOne[0].collapsibleState.should.equal(vscode.TreeItemCollapsibleState.Collapsed);
                 contractsOne[1].label.should.equal('someOtherContract');
                 contractsOne[1].instantiatedChaincode.name.should.equal('biscuit-network');
-                contractsOne[1].instantiatedChaincode.channel.label.should.equal('channelOne');
+                contractsOne[1].instantiatedChaincode.channels[0].label.should.equal('channelOne');
+                contractsOne[1].instantiatedChaincode.channels.length.should.equal(1);
                 contractsOne[1].collapsibleState.should.equal(vscode.TreeItemCollapsibleState.Collapsed);
 
                 const channelTwo: ChannelTreeItem = channels[1] as ChannelTreeItem;

--- a/test/fabric/FabricEnvironmentConnection.test.ts
+++ b/test/fabric/FabricEnvironmentConnection.test.ts
@@ -38,6 +38,7 @@ import { FabricConnectionFactory } from '../../extension/fabric/FabricConnection
 import { IFabricEnvironmentConnection } from '../../extension/fabric/IFabricEnvironmentConnection';
 import { FabricWalletRegistryEntry } from '../../extension/fabric/FabricWalletRegistryEntry';
 import { FabricWalletRegistry } from '../../extension/fabric/FabricWalletRegistry';
+import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -424,7 +425,7 @@ describe('FabricEnvironmentConnection', () => {
         });
 
         it('should return the list of instantiated chaincodes', async () => {
-            const chaincodes: Array<{ name: string, version: string }> = await connection.getInstantiatedChaincode(['peer0.org1.example.com'], 'mychannel');
+            const chaincodes: Array<FabricChaincode> = await connection.getInstantiatedChaincode(['peer0.org1.example.com'], 'mychannel');
             chaincodes.should.deep.equal([
                 {
                     name: 'myChaincode',
@@ -505,7 +506,7 @@ describe('FabricEnvironmentConnection', () => {
         });
 
         it('should return the list of instantiated chaincodes on all channels', async () => {
-            const chaincodes: Array<{ name: string, version: string }> = await connection.getAllInstantiatedChaincodes();
+            const chaincodes: Array<FabricChaincode> = await connection.getAllInstantiatedChaincodes();
             chaincodes.should.deep.equal([
                 {
                     name: 'kittyChaincode',


### PR DESCRIPTION
Updated so that if you have the same contract deployed on two channels it will only show once in the tree
Updated tooltip to show which channels it's instantiated on

contributes to #1443

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>