### PR TITLE
Fix duplicate installed contracts

### DIFF
--- a/extension/explorer/runtimeOps/connectedTree/InstalledChainCodeOpsTreeItem.ts
+++ b/extension/explorer/runtimeOps/connectedTree/InstalledChainCodeOpsTreeItem.ts
@@ -19,9 +19,16 @@ import { BlockchainExplorerProvider } from '../../BlockchainExplorerProvider';
 export class InstalledChainCodeOpsTreeItem extends BlockchainTreeItem {
     contextValue: string = 'blockchain-runtime-installed-chaincode-item';
 
-    constructor(provider: BlockchainExplorerProvider, name: string, public readonly version: string, peerName: string) {
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string, public readonly version: string, public peerNames: string[]) {
         super(provider, `${name}@${version}`, vscode.TreeItemCollapsibleState.None);
 
-        this.tooltip = `Installed on: ${peerName}`;
+        this.tooltip = `Installed on:`;
+        for (let i: number = 0; i < peerNames.length; i++) {
+            if (i === peerNames.length - 1) {
+                this.tooltip += ` ${peerNames[i]}`;
+            } else {
+                this.tooltip += ` ${peerNames[i]},`;
+            }
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1298,7 +1298,7 @@
         "vscode:prepublish": "npm run compile && npm run localize",
         "package": "node ./node_modules/vsce/out/vsce package",
         "compile": "rimraf build && npm run build",
-        "watch": "rimraf build && tsc -watch -p ./tsconfig.extension.json && tsc -watch -p ./tsconfig.json",
+        "watch": "rimraf build && tsc -watch -p ./tsconfig.extension.json",
         "pretest": "npm run compile && npm run lint && npm run licchk && npm run updatePackageJSON",
         "test": "node ./build/test/runTests.js",
         "posttest": "remap-istanbul -i ./coverage/coverage.json -o ./coverage/coverage-remap.json && istanbul check-coverage ./coverage/coverage-remap.json",

--- a/test/explorer/environmentExplorer.test.ts
+++ b/test/explorer/environmentExplorer.test.ts
@@ -50,6 +50,8 @@ import { FabricEnvironmentRegistry } from '../../extension/fabric/FabricEnvironm
 import { FabricEnvironment } from '../../extension/fabric/FabricEnvironment';
 import { EnvironmentConnectedTreeItem } from '../../extension/explorer/runtimeOps/connectedTree/EnvironmentConnectedTreeItem';
 import { ImportNodesTreeItem } from '../../extension/explorer/runtimeOps/connectedTree/ImportNodesTreeItem';
+import { InstalledChainCodeOpsTreeItem } from '../../extension/explorer/runtimeOps/connectedTree/InstalledChainCodeOpsTreeItem';
+import { InstallCommandTreeItem } from '../../extension/explorer/runtimeOps/connectedTree/InstallCommandTreeItem';
 
 chai.use(sinonChai);
 const should: Chai.Should = chai.should();
@@ -356,6 +358,7 @@ describe('environmentExplorer', () => {
 
                 const installedChaincodeMapTwo: Map<string, Array<string>> = new Map<string, Array<string>>();
                 installedChaincodeMapTwo.set('biscuit-network', ['0.7']);
+                installedChaincodeMapTwo.set('sample-food-network', ['0.6']);
                 fabricConnection.getInstalledChaincode.withArgs('peerTwo').returns(installedChaincodeMapTwo);
 
                 fabricConnection.getInstantiatedChaincode.withArgs(['peerOne'], 'channelOne').resolves([{
@@ -736,26 +739,27 @@ describe('environmentExplorer', () => {
                 const contractTreeItems: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(allChildren[1]);
                 const installedContractsTree: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(contractTreeItems[0]);
                 installedContractsTree.length.should.equal(5);
-                const installedContractOne: InstantiateCommandTreeItem = installedContractsTree[0] as InstantiateCommandTreeItem;
+                const installedContractOne: InstalledChainCodeOpsTreeItem = installedContractsTree[0] as InstalledChainCodeOpsTreeItem;
                 installedContractOne.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installedContractOne.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
                 installedContractOne.label.should.equal('sample-car-network@1.0');
                 installedContractOne.tooltip.should.equal('Installed on: peerOne');
-                const installedContractTwo: InstantiateCommandTreeItem = installedContractsTree[1] as InstantiateCommandTreeItem;
+                const installedContractTwo: InstalledChainCodeOpsTreeItem = installedContractsTree[1] as InstalledChainCodeOpsTreeItem;
                 installedContractTwo.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installedContractTwo.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
                 installedContractTwo.label.should.equal('sample-car-network@1.2');
                 installedContractTwo.tooltip.should.equal('Installed on: peerOne');
-                const installedContractThree: InstantiateCommandTreeItem = installedContractsTree[2] as InstantiateCommandTreeItem;
+                const installedContractThree: InstalledChainCodeOpsTreeItem = installedContractsTree[2] as InstalledChainCodeOpsTreeItem;
                 installedContractThree.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installedContractThree.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
-                installedContractThree.label.should.equal('sample-food-network@0.6');
-                installedContractThree.tooltip.should.equal('Installed on: peerOne');
-                const installedContractFour: InstantiateCommandTreeItem = installedContractsTree[3] as InstantiateCommandTreeItem;
+                installedContractThree.label.should.equal('biscuit-network@0.7');
+                installedContractThree.tooltip.should.equal('Installed on: peerTwo');
+                const installedContractFour: InstalledChainCodeOpsTreeItem = installedContractsTree[3] as InstalledChainCodeOpsTreeItem;
                 installedContractFour.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installedContractFour.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
-                installedContractFour.label.should.equal('biscuit-network@0.7');
-                const installCommandTreeItem: InstantiateCommandTreeItem = installedContractsTree[4] as InstantiateCommandTreeItem;
+                installedContractFour.label.should.equal('sample-food-network@0.6');
+                installedContractFour.tooltip.should.equal('Installed on: peerOne, peerTwo');
+                const installCommandTreeItem: InstallCommandTreeItem = installedContractsTree[4] as InstallCommandTreeItem;
                 installCommandTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installCommandTreeItem.contextValue.should.equal('blockchain-runtime-installed-command-item');
                 installCommandTreeItem.label.should.equal('+ Install');
@@ -776,14 +780,19 @@ describe('environmentExplorer', () => {
 
                 const contractTreeItems: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(allChildren[1]);
                 const installedContractsTree: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(contractTreeItems[0]);
-                installedContractsTree.length.should.equal(2);
+                installedContractsTree.length.should.equal(3);
 
-                const installedContractOne: InstantiateCommandTreeItem = installedContractsTree[0] as InstantiateCommandTreeItem;
+                const installedContractOne: InstalledChainCodeOpsTreeItem = installedContractsTree[0] as InstalledChainCodeOpsTreeItem;
                 installedContractOne.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installedContractOne.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
                 installedContractOne.label.should.equal('biscuit-network@0.7');
 
-                const installCommandTreeItem: InstantiateCommandTreeItem = installedContractsTree[1] as InstantiateCommandTreeItem;
+                const installedContractTwo: InstalledChainCodeOpsTreeItem = installedContractsTree[1] as InstalledChainCodeOpsTreeItem;
+                installedContractTwo.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
+                installedContractTwo.contextValue.should.equal('blockchain-runtime-installed-chaincode-item');
+                installedContractTwo.label.should.equal('sample-food-network@0.6');
+
+                const installCommandTreeItem: InstallCommandTreeItem = installedContractsTree[2] as InstallCommandTreeItem;
                 installCommandTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installCommandTreeItem.contextValue.should.equal('blockchain-runtime-installed-command-item');
                 installCommandTreeItem.label.should.equal('+ Install');
@@ -805,7 +814,7 @@ describe('environmentExplorer', () => {
                 const installedContractsTree: Array<BlockchainTreeItem> = await blockchainRuntimeExplorerProvider.getChildren(contractTreeItems[0]);
                 installedContractsTree.length.should.equal(1);
 
-                const installCommandTreeItem: InstantiateCommandTreeItem = installedContractsTree[0] as InstantiateCommandTreeItem;
+                const installCommandTreeItem: InstallCommandTreeItem = installedContractsTree[0] as InstallCommandTreeItem;
                 installCommandTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
                 installCommandTreeItem.contextValue.should.equal('blockchain-runtime-installed-command-item');
                 installCommandTreeItem.label.should.equal('+ Install');

--- a/test/explorer/runtimeOps/InstalledChainCodeOpsTreeItem.test.ts
+++ b/test/explorer/runtimeOps/InstalledChainCodeOpsTreeItem.test.ts
@@ -24,7 +24,7 @@ describe('InstalledChainCodeOpsTreeItem', () => {
 
     class TestInstalledChainCodeOpsTreeItem extends InstalledChainCodeOpsTreeItem {
         constructor(name: string, version: string, peerName: string) {
-            super(ExtensionUtil.getBlockchainGatewayExplorerProvider(), name, version, peerName);
+            super(ExtensionUtil.getBlockchainGatewayExplorerProvider(), name, version, [peerName]);
         }
     }
 


### PR DESCRIPTION
Updated so that if you have multiple peers with that same contract installed it will only show once
Updated to tooltip to show which peers a contract is installed on
Fixed linting

contributes to #1443

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>