### PR TITLE
Delete Multiple Identities 

### DIFF
--- a/cucumber/helpers/walletAndIdentityHelper.ts
+++ b/cucumber/helpers/walletAndIdentityHelper.ts
@@ -93,7 +93,7 @@ export class WalletAndIdentityHelper {
                 label: FabricWalletUtil.LOCAL_WALLET,
                 data: walletEntry
             });
-            this.userInputUtilHelper.showIdentitiesQuickPickStub.withArgs('Choose the identity to delete').resolves(name);
+            this.userInputUtilHelper.showIdentitiesQuickPickStub.withArgs('Choose the identities to delete').resolves([name]);
             this.userInputUtilHelper.showConfirmationWarningMessageStub.withArgs(`This will delete ${name} from your file system. Do you want to continue?`).resolves(UserInputUtil.YES);
 
             await vscode.commands.executeCommand(ExtensionCommands.DELETE_IDENTITY);

--- a/extension/commands/UserInputUtil.ts
+++ b/extension/commands/UserInputUtil.ts
@@ -256,11 +256,11 @@ export class UserInputUtil {
         return dir;
     }
 
-    public static showIdentitiesQuickPickBox(prompt: string, identities: string[], showCreate: boolean = false): Thenable<string> {
+    public static showIdentitiesQuickPickBox(prompt: string, canPickMany: boolean, identities: string[], showCreate: boolean = false): Thenable<string | string[]> {
 
         const quickPickOptions: vscode.QuickPickOptions = {
             ignoreFocusOut: true,
-            canPickMany: false,
+            canPickMany: canPickMany,
             placeHolder: prompt
         };
 

--- a/extension/commands/associateIdentityWithNode.ts
+++ b/extension/commands/associateIdentityWithNode.ts
@@ -133,7 +133,7 @@ export async function associateIdentityWithNode(replace: boolean = false, enviro
                 // cas might not have msp id in
                 identityMessage = `Select the admin identity`;
             }
-            let chosenIdentity: string = await UserInputUtil.showIdentitiesQuickPickBox(identityMessage, identitiies, true);
+            let chosenIdentity: string = await UserInputUtil.showIdentitiesQuickPickBox(identityMessage, false, identitiies, true) as string;
 
             if (!chosenIdentity) {
                 return;

--- a/extension/commands/deleteIdentityCommand.ts
+++ b/extension/commands/deleteIdentityCommand.ts
@@ -34,7 +34,7 @@ export async function deleteIdentity(treeItem: IdentityTreeItem): Promise<void> 
     outputAdapter.log(LogType.INFO, undefined, `deleteIdentity`);
 
     let walletPath: string;
-    let identityName: string;
+    let identitiesToDelete: string[];
     if (!treeItem) {
         // Called from command palette
         const chosenWallet: IBlockchainQuickPickItem<FabricWalletRegistryEntry> = await UserInputUtil.showWalletsQuickPickBox('Choose the wallet containing the identity that you want to delete', false, true) as IBlockchainQuickPickItem<FabricWalletRegistryEntry>;
@@ -63,8 +63,8 @@ export async function deleteIdentity(treeItem: IdentityTreeItem): Promise<void> 
             return;
         }
 
-        identityName = await UserInputUtil.showIdentitiesQuickPickBox('Choose the identity to delete', identityNames);
-        if (!identityName) {
+        identitiesToDelete = await UserInputUtil.showIdentitiesQuickPickBox('Choose the identities to delete', true, identityNames) as string[];
+        if (!identitiesToDelete || identitiesToDelete.length === 0) {
             return;
         }
 
@@ -78,15 +78,30 @@ export async function deleteIdentity(treeItem: IdentityTreeItem): Promise<void> 
             walletPath = FabricWalletRegistry.instance().get(treeItem.walletName).walletPath;
         }
 
-        identityName = treeItem.label;
+        identitiesToDelete = [treeItem.label];
     }
 
-    const areYouSure: boolean = await UserInputUtil.showConfirmationWarningMessage(`This will delete ${identityName} from your file system. Do you want to continue?`);
+    let areYouSure: boolean;
 
-    if (areYouSure) {
-        await fs.remove(path.join(walletPath, identityName));
+    if (identitiesToDelete.length > 1) {
+        areYouSure = await UserInputUtil.showConfirmationWarningMessage(`This will delete the selected identities from your file system. Do you want to continue?`);
+    } else {
+        areYouSure = await UserInputUtil.showConfirmationWarningMessage(`This will delete ${identitiesToDelete[0]} from your file system. Do you want to continue?`);
+    }
+
+    if (!areYouSure) {
+        return;
+    }
+    for (const _identity of identitiesToDelete) {
+        await fs.remove(path.join(walletPath, _identity));
         await vscode.commands.executeCommand(ExtensionCommands.REFRESH_WALLETS);
-        outputAdapter.log(LogType.SUCCESS, `Successfully deleted identity: ${identityName}`, `Successfully deleted identity: ${identityName}`);
     }
+
+    if (identitiesToDelete.length > 1) {
+        outputAdapter.log(LogType.SUCCESS, `Successfully deleted selected identities.`);
+    } else {
+        outputAdapter.log(LogType.SUCCESS, `Successfully deleted identity: ${identitiesToDelete[0]}`);
+    }
+
     return;
 }

--- a/extension/commands/gatewayConnectCommand.ts
+++ b/extension/commands/gatewayConnectCommand.ts
@@ -110,7 +110,7 @@ export async function gatewayConnect(gatewayRegistryEntry: FabricGatewayRegistry
     // Get the identities
     const identityNames: string[] = await wallet.getIdentityNames();
     if (identityNames.length > 1) {
-        identityName = await UserInputUtil.showIdentitiesQuickPickBox('Choose an identity to connect with', identityNames);
+        identityName = await UserInputUtil.showIdentitiesQuickPickBox('Choose an identity to connect with', false, identityNames) as string;
         if (!identityName) {
             // User cancelled selecting an identity
             return;

--- a/test/commands/UserInputUtil.test.ts
+++ b/test/commands/UserInputUtil.test.ts
@@ -356,7 +356,7 @@ describe('UserInputUtil', () => {
 
         it('should show identity names in the quickpick box', async () => {
             quickPickStub.resolves(FabricRuntimeUtil.ADMIN_USER);
-            const result: string = await UserInputUtil.showIdentitiesQuickPickBox('choose an identity to connect with', identities);
+            const result: string = await UserInputUtil.showIdentitiesQuickPickBox('choose an identity to connect with', false, identities) as string;
 
             result.should.equal(FabricRuntimeUtil.ADMIN_USER);
             quickPickStub.should.have.been.calledWith([FabricRuntimeUtil.ADMIN_USER, 'Test@org1.example.com'], {
@@ -366,9 +366,25 @@ describe('UserInputUtil', () => {
             });
         });
 
+        it('should show multiple identity names in the quickpick box', async () => {
+            identities = [FabricRuntimeUtil.ADMIN_USER, 'bob', 'jack'];
+            quickPickStub.resolves([FabricRuntimeUtil.ADMIN_USER, 'bob', 'jack']);
+            const result: string[] = await UserInputUtil.showIdentitiesQuickPickBox('choose identity', true, identities) as string [];
+
+            result.length.should.equal(3);
+            result[0].should.equal(FabricRuntimeUtil.ADMIN_USER);
+            result[1].should.equal('bob');
+            result[2].should.equal('jack');
+            quickPickStub.should.have.been.calledWith([FabricRuntimeUtil.ADMIN_USER, 'bob', 'jack'], {
+                ignoreFocusOut: true,
+                canPickMany: true,
+                placeHolder: 'choose identity'
+            });
+        });
+
         it('should show identity names and add identity in the quickpick box', async () => {
             quickPickStub.resolves(FabricRuntimeUtil.ADMIN_USER);
-            const result: string = await UserInputUtil.showIdentitiesQuickPickBox('choose an identity to connect with', identities, true);
+            const result: string = await UserInputUtil.showIdentitiesQuickPickBox('choose an identity to connect with', false, identities, true) as string;
 
             result.should.equal(FabricRuntimeUtil.ADMIN_USER);
             quickPickStub.should.have.been.calledWith([FabricRuntimeUtil.ADMIN_USER, 'Test@org1.example.com', UserInputUtil.ADD_IDENTITY], {


### PR DESCRIPTION
Added functionality to allow the user to delete multiple identities at once.
Also written tests to check the additional piece of code.

Closes #1447.

Signed-off-by: Akshat Shah <akshatshah@akshats-mbp.hursley.uk.ibm.com>