### PR TITLE
Fix generating connection profile

### DIFF
--- a/extension/fabric/FabricGatewayHelper.ts
+++ b/extension/fabric/FabricGatewayHelper.ts
@@ -78,7 +78,7 @@ export class FabricGatewayHelper {
 
         if (peerNode.ssl_target_name_override) {
             connectionProfile.peers[peerNode.name].grpcOptions = {
-                ssl_target_name_override: peerNode.ssl_target_name_override
+                'ssl-target-name-override': peerNode.ssl_target_name_override
             };
         }
 

--- a/test/fabric/FabricGatewayHelper.test.ts
+++ b/test/fabric/FabricGatewayHelper.test.ts
@@ -145,7 +145,7 @@ describe('FabricGatewayHelper', () => {
             connectionProfile.peers[securePeerNode.name].url.should.equal(securePeerNode.api_url);
 
             connectionProfile.peers[securePeerNode.name].tlsCACerts.pem.should.equal(Buffer.from(securePeerNode.pem, 'base64').toString());
-            connectionProfile.peers[securePeerNode.name].grpcOptions.ssl_target_name_override.should.equal(securePeerNode.ssl_target_name_override);
+            connectionProfile.peers[securePeerNode.name].grpcOptions['ssl-target-name-override'].should.equal(securePeerNode.ssl_target_name_override);
 
             connectionProfile.certificateAuthorities[secureCANode.name].tlsCACerts.pem.should.equal(Buffer.from(secureCANode.pem, 'base64').toString());
         });


### PR DESCRIPTION
Updated connection profile generation to include the correct name for ssl override property

closes #1525

Signed-off-by: Caroline Fletcher <caroline.fletcher@uk.ibm.com>