### PR TITLE
Add environment using URL and Key

### DIFF
--- a/cucumber/helpers/environmentHelper.ts
+++ b/cucumber/helpers/environmentHelper.ts
@@ -60,6 +60,7 @@ export class EnvironmentHelper {
 
         if (!treeItem) {
             this.userInputUtilHelper.inputBoxStub.withArgs('Enter a name for the environment').resolves(name);
+            this.userInputUtilHelper.showQuickPickStub.withArgs('Choose a method to import nodes to an environment').resolves(UserInputUtil.ADD_ENVIRONMENT_FROM_NODES);
 
             const caUri: vscode.Uri = vscode.Uri.file(path.join(__dirname, '../../../cucumber/hlfv1/nodes/ca.example.com.json'));
             const ordererUri: vscode.Uri = vscode.Uri.file(path.join(__dirname, '../../../cucumber/hlfv1/nodes/orderer.example.com.json'));

--- a/extension/commands/UserInputUtil.ts
+++ b/extension/commands/UserInputUtil.ts
@@ -80,6 +80,8 @@ export class UserInputUtil {
     static readonly ADD_IDENTITY: string = '+ Add identity';
     static readonly ADD_GATEWAY_FROM_ENVIRONMENT: string = 'Create a gateway from a Fabric environment';
     static readonly ADD_GATEWAY_FROM_CCP: string = 'Create a gateway from a connection profile';
+    static readonly ADD_ENVIRONMENT_FROM_NODES: string = 'Add an environment from node definition files';
+    static readonly ADD_ENVIRONMENT_FROM_OPS_TOOLS: string = 'Add an environment from connecting to an ops tools instance';
 
     public static async showQuickPick(prompt: string, items: string[]): Promise<string> {
         const quickPickOptions: vscode.QuickPickOptions = {

--- a/extension/commands/importNodesToEnvironmentCommand.ts
+++ b/extension/commands/importNodesToEnvironmentCommand.ts
@@ -24,6 +24,7 @@ import { FabricNode } from '../fabric/FabricNode';
 import { FabricEnvironment } from '../fabric/FabricEnvironment';
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FileSystemUtil } from '../util/FileSystemUtil';
+import Axios from 'axios';
 
 export async function importNodesToEnvironment(environmentRegistryEntry: FabricEnvironmentRegistryEntry, fromAddEnvironment: boolean = false): Promise<boolean> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -40,93 +41,132 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
             environmentRegistryEntry = chosenEnvironment.data;
         }
 
-        const quickPickItems: string[] = [UserInputUtil.BROWSE_LABEL];
-        const openDialogOptions: vscode.OpenDialogOptions = {
-            canSelectFiles: true,
-            canSelectFolders: false,
-            canSelectMany: true,
-            openLabel: 'Select',
-            filters: {
-                'Node Files': ['json']
-            }
-        };
+        const createMethod: string = await UserInputUtil.showQuickPick('Choose a method to import nodes to an environment', [UserInputUtil.ADD_ENVIRONMENT_FROM_NODES, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS]);
 
-        const nodeUris: vscode.Uri[] = [];
-        let addMore: boolean = true;
-        do {
-            const selectedNodeUris: vscode.Uri[] = await UserInputUtil.browse('Select all the Fabric node (JSON) files you want to import', quickPickItems, openDialogOptions, true) as vscode.Uri[];
+        const nodesToUodate: FabricNode[] = [];
+        let addedAllNodes: boolean = true;
+        if (createMethod === UserInputUtil.ADD_ENVIRONMENT_FROM_NODES) {
+            const quickPickItems: string[] = [UserInputUtil.BROWSE_LABEL];
+            const openDialogOptions: vscode.OpenDialogOptions = {
+                canSelectFiles: true,
+                canSelectFolders: false,
+                canSelectMany: true,
+                openLabel: 'Select',
+                filters: {
+                    'Node Files': ['json']
+                }
+            };
 
-            if (selectedNodeUris) {
-                nodeUris.push(...selectedNodeUris);
-            }
+            const nodeUris: vscode.Uri[] = [];
+            let addMore: boolean = true;
+            do {
+                const selectedNodeUris: vscode.Uri[] = await UserInputUtil.browse('Select all the Fabric node (JSON) files you want to import', quickPickItems, openDialogOptions, true) as vscode.Uri[];
 
-            if (!nodeUris || nodeUris.length === 0) {
-                if (fromAddEnvironment) {
-                    return undefined;
-                } else {
+                if (selectedNodeUris) {
+                    nodeUris.push(...selectedNodeUris);
+                }
+
+                if (!nodeUris || nodeUris.length === 0) {
                     return;
                 }
-            }
 
-            const addMoreString: string = await UserInputUtil.addMoreNodes(`${nodeUris.length} JSON file(s) added successfully`);
-            if (addMoreString === UserInputUtil.ADD_MORE_NODES) {
-                addMore = true;
-            } else if (addMoreString === UserInputUtil.DONE_ADDING_NODES) {
-                addMore = false;
-            } else {
-                // cancelled so exit
-                return;
+                const addMoreString: string = await UserInputUtil.addMoreNodes(`${nodeUris.length} JSON file(s) added successfully`);
+                if (addMoreString === UserInputUtil.ADD_MORE_NODES) {
+                    addMore = true;
+                } else if (addMoreString === UserInputUtil.DONE_ADDING_NODES) {
+                    addMore = false;
+                } else {
+                    // cancelled so exit
+                    return;
+                }
+            } while (addMore);
+
+            for (const nodeUri of nodeUris) {
+                try {
+                    let nodes: FabricNode | Array<FabricNode> = await fs.readJson(nodeUri.fsPath);
+                    if (!Array.isArray(nodes)) {
+                        nodes = [nodes];
+                    }
+
+                    nodesToUodate.push(...nodes);
+                } catch (error) {
+                    addedAllNodes = false;
+                    outputAdapter.log(LogType.ERROR, `Error importing node file ${nodeUri.fsPath}: ${error.message}`, `Error importing node file ${nodeUri.fsPath}: ${error.toString()}`);
+                }
             }
-        } while (addMore);
+        } else {
+
+            const GET_ALL_COMPONENTS: string = '/ak/api/v1/components';
+            const url: string = await UserInputUtil.showInputBox('Enter the url of the ops tools you want to connect to');
+            const apiKey: string = await UserInputUtil.showInputBox('Enter the api key of the ops tools you want to connect to');
+
+            try {
+                const api: string = url.replace(/\/$/, '') + GET_ALL_COMPONENTS;
+                const response: any = await Axios.get(api, {
+                    headers: { Authorization: `Bearer ${apiKey}` }
+                });
+
+                const data: any = response.data;
+                const filteredData: FabricNode[] = data.filter((_data: any) => _data.api_url)
+                    .map((_data: any) => {
+                        if (_data.tls_cert) {
+                            _data.pem = _data.tls_cert;
+                            delete _data.tls_cert;
+                        }
+
+                        _data.name = _data.display_name;
+                        delete _data.display_name;
+                        return FabricNode.pruneNode(_data);
+                    });
+                nodesToUodate.push(...filteredData);
+            } catch (error) {
+                outputAdapter.log(LogType.ERROR, `Failed to connect to ${url}, with error ${error.message}`, `Failed to connect to ${url}, with error ${error.toString()}`);
+                if (fromAddEnvironment) {
+                    throw error;
+                }
+            }
+        }
 
         const dirPath: string = await vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_DIRECTORY) as string;
         const homeExtDir: string = FileSystemUtil.getDirPath(dirPath);
         const environmentPath: string = path.join(homeExtDir, 'environments', environmentRegistryEntry.name, 'nodes');
 
+        await fs.ensureDir(environmentPath);
+
         const environment: FabricEnvironment = new FabricEnvironment(environmentRegistryEntry.name);
         const oldNodes: FabricNode[] = await environment.getNodes();
 
-        await fs.ensureDir(environmentPath);
-        let addedAllNodes: boolean = true;
-        for (const nodeUri of nodeUris) {
+        for (const node of nodesToUodate) {
             try {
-                let nodes: FabricNode | Array<FabricNode> = await fs.readJson(nodeUri.fsPath);
-                if (!Array.isArray(nodes)) {
-                    nodes = [nodes];
+                const alreadyExists: boolean = oldNodes.some((_node: FabricNode) => _node.name === node.name);
+                if (alreadyExists && createMethod === UserInputUtil.ADD_ENVIRONMENT_FROM_NODES) {
+                    throw new Error(`Node with name ${node.name} already exists`);
                 }
-
-                for (const node of nodes) {
-                    try {
-                        const alreadyExists: boolean = oldNodes.some((_node: FabricNode) => _node.name === node.name);
-
-                        if (alreadyExists) {
-                            throw new Error(`Node with name ${node.name} already exists`);
-                        }
-                        await FabricNode.validateNode(node);
-                        await environment.updateNode(node);
-                    } catch (error) {
-                        addedAllNodes = false;
-                        if (!node.name) {
-                            outputAdapter.log(LogType.ERROR, `Error importing node from file ${nodeUri.fsPath}: ${error.message}`, `Error importing node from file ${nodeUri.fsPath}: ${error.toString()}`);
-                        } else {
-                            outputAdapter.log(LogType.ERROR, `Error importing node ${node.name} from file ${nodeUri.fsPath}: ${error.message}`, `Error importing node ${node.name} from file ${nodeUri.fsPath}: ${error.toString()}`);
-                        }
-                    }
-                }
+                await FabricNode.validateNode(node);
+                await environment.updateNode(node);
             } catch (error) {
                 addedAllNodes = false;
-                outputAdapter.log(LogType.ERROR, `Error importing node file ${nodeUri.fsPath}: ${error.message}`, `Error importing node file ${nodeUri.fsPath}: ${error.toString()}`);
+                if (!node.name) {
+                    outputAdapter.log(LogType.ERROR, `Error importing node: ${error.message}`, `Error importing node: ${error.toString()}`);
+                } else {
+                    outputAdapter.log(LogType.ERROR, `Error importing node ${node.name}: ${error.message}`, `Error importing node ${node.name}: ${error.toString()}`);
+                }
             }
         }
 
         // check if any nodes were added
-        const newNodes: FabricNode[] = await environment.getNodes();
-        if (newNodes.length === oldNodes.length) {
+
+        const newEnvironment: FabricEnvironment = new FabricEnvironment(environmentRegistryEntry.name);
+        const newNodes: FabricNode[] = await newEnvironment.getNodes();
+        if (newNodes.length === 0) {
+            await fs.remove(environmentPath);
+            throw new Error('no nodes were added');
+        } else if (newNodes.length === oldNodes.length) {
             throw new Error('no nodes were added');
         }
 
         if (addedAllNodes) {
-            outputAdapter.log(LogType.SUCCESS, 'Successfully imported all node files');
+            outputAdapter.log(LogType.SUCCESS, 'Successfully imported all nodes');
         } else {
             outputAdapter.log(LogType.WARNING, 'Finished importing nodes but some nodes could not be added');
         }
@@ -139,7 +179,7 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
         return addedAllNodes;
 
     } catch (error) {
-        outputAdapter.log(LogType.ERROR, `Error importing node files: ${error.message}`, `Error importing node files: ${error.toString()}`);
+        outputAdapter.log(LogType.ERROR, `Error importing nodes: ${error.message}`, `Error importing nodes: ${error.toString()}`);
         if (fromAddEnvironment) {
             throw error;
         }

--- a/extension/fabric/FabricNode.ts
+++ b/extension/fabric/FabricNode.ts
@@ -78,6 +78,32 @@ export class FabricNode {
         }
     }
 
+    public static pruneNode(data: any): FabricNode {
+        const node: FabricNode = new FabricNode({short_name: data.shoty_name, name: data.name, type: data.type, api_url: data.api_url});
+
+        if (data.msp_id) {
+            node.msp_id = data.msp_id;
+        }
+
+        if (data.ca_name) {
+            node.ca_name = data.ca_name;
+        }
+
+        if (data.pem) {
+            node.pem = data.pem;
+        }
+
+        if (data.ssl_target_name_override) {
+            node.ssl_target_name_override = data.ssl_target_name_override;
+        }
+
+        if (data.cluster_name) {
+            node.cluster_name = data.cluster_name;
+        }
+
+        return node;
+    }
+
     public short_name: string;
     public name: string;
     public type: FabricNodeType;


### PR DESCRIPTION
When a user clicks on the '+' sign in Environments and names the new environment, she will then get a choice on how to import this new environment, including the new method - providing a URL and key for an Ops Tool network.

The VSCode compatible nodes will then be added to the newly created environment, ready for setup.

Closes #1538

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>