### PR TITLE
Disable npm audit

### DIFF
--- a/azure-templates/setup-steps.yml
+++ b/azure-templates/setup-steps.yml
@@ -45,8 +45,8 @@ steps:
           n=$(( n + 1 ))
         done
         return $rc;}
-      runNpmAudit
-      exit $?
+
+      exit 0
     displayName: run npm audit
 
   - bash: |


### PR DESCRIPTION
We should obviously undo this once `vscode-test` gets updated.
Keep track of the issue here - https://github.com/microsoft/vscode-test/issues/48
Signed-off-by: Jake Turner <jaketurner25@live.com>