### PR TITLE
Build - continue to try npm audit if appropriate

### DIFF
--- a/azure-templates/setup-steps.yml
+++ b/azure-templates/setup-steps.yml
@@ -33,12 +33,14 @@ steps:
   - script: |
       set -ev
       function runNpmAudit() {
-        local n=0; local rc=256; local out=""
+        local n=0; local rc=1; local out=""
         while [ "$n" -ne  10 ] && [ "$rc" -ne 0 ]; do
           echo ">>> run npm audit - Attempt $n"
-          out=$((npm audit) 2>&1)
-          rc=$?
-          echo $out
+          out=$((npm audit) 2>&1 | grep -e ".*")
+          if [[ $out == *"found 0 vulnerabilities"* ]]; then
+            rc=0
+          fi
+          echo "${out}"
           if [[ $rc -ne 0 ]] && [[ $out != *"code ENOAUDIT"* ]]; then
             break
           fi


### PR DESCRIPTION
Related to issue 1535.
Even with the subroutine inside 'script' instead of 'bash' there seems to be an immediate recognition of a failed return node. Therefore the output is now piped and stored, so that rc is 0, and further evaluation decides on success/failure of npm audit..

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>