### PR TITLE
[DO NOT MERGE] Setting to toggle Local Fabric functionality (close #1499)

### DIFF
--- a/configurations.ts
+++ b/configurations.ts
@@ -31,6 +31,7 @@ export class SettingConfigurations {
     // EXTENSION CONFIGURATIONS
     static readonly EXTENSION_DIRECTORY: string = 'ibm-blockchain-platform.ext.directory';
     static readonly EXTENSION_BYPASS_PREREQS: string = 'ibm-blockchain-platform.ext.bypassPreReqs';
+    static readonly EXTENSION_LOCAL_FABRIC: string = 'ibm-blockchain-platform.ext.enableLocalFabric';
 
     // HOME CONFIGURATIONS
     static readonly HOME_SHOW_ON_STARTUP: string = 'ibm-blockchain-platform.home.showOnStartup';

--- a/extension/debug/FabricDebugConfigurationProvider.ts
+++ b/extension/debug/FabricDebugConfigurationProvider.ts
@@ -27,6 +27,8 @@ import { FabricEnvironmentRegistryEntry } from '../registries/FabricEnvironmentR
 import { GlobalState, ExtensionData } from '../util/GlobalState';
 import { FabricChaincode } from '../fabric/FabricChaincode';
 import { FabricEnvironmentRegistry } from '../registries/FabricEnvironmentRegistry';
+import { SettingConfigurations } from '../../configurations';
+import { ExtensionUtil } from '../util/ExtensionUtil';
 
 export abstract class FabricDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -73,6 +75,11 @@ export abstract class FabricDebugConfigurationProvider implements vscode.DebugCo
     public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
         try {
+            const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
+            if (!localFabricEnabled) {
+                outputAdapter.log(LogType.ERROR, `Setting '${SettingConfigurations.EXTENSION_LOCAL_FABRIC}' must be set to 'true' to enable debugging.`);
+                return;
+            }
 
             const extensionData: ExtensionData = GlobalState.get();
 

--- a/extension/explorer/walletExplorer.ts
+++ b/extension/explorer/walletExplorer.ts
@@ -31,6 +31,7 @@ import { FabricCertificate, Attribute } from '../fabric/FabricCertificate';
 import { FabricRuntimeUtil } from '../fabric/FabricRuntimeUtil';
 import { FabricWalletUtil } from '../fabric/FabricWalletUtil';
 import { TextTreeItem } from './model/TextTreeItem';
+import { ExtensionUtil } from '../util/ExtensionUtil';
 
 export class BlockchainWalletExplorerProvider implements BlockchainExplorerProvider {
 
@@ -71,35 +72,39 @@ export class BlockchainWalletExplorerProvider implements BlockchainExplorerProvi
         const tree: Array<BlockchainTreeItem> = [];
 
         const walletRegistryEntries: FabricWalletRegistryEntry[] = await FabricWalletRegistry.instance().getAll();
+        const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
 
-        if (walletRegistryEntries.length === 0) {
-            tree.push(new TextTreeItem(this, 'No wallets found'));
-        } else {
-            // Populate the tree with the name of each wallet
-            for (const walletRegistryEntry of walletRegistryEntries) {
+        // Populate the tree with the name of each wallet
+        for (const walletRegistryEntry of walletRegistryEntries) {
 
-                if (walletRegistryEntry.walletPath) {
-                    // get identityNames in the wallet
-                    const walletGenerator: IFabricWalletGenerator = FabricWalletGeneratorFactory.createFabricWalletGenerator();
-                    const wallet: IFabricWallet = await walletGenerator.getWallet(walletRegistryEntry.name);
-                    const identityNames: string[] = await wallet.getIdentityNames();
+            if (walletRegistryEntry.walletPath) {
+                // get identityNames in the wallet
+                const walletGenerator: IFabricWalletGenerator = FabricWalletGeneratorFactory.createFabricWalletGenerator();
+                const wallet: IFabricWallet = await walletGenerator.getWallet(walletRegistryEntry.name);
+                const identityNames: string[] = await wallet.getIdentityNames();
 
-                    const treeState: vscode.TreeItemCollapsibleState = identityNames.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None;
+                const treeState: vscode.TreeItemCollapsibleState = identityNames.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None;
 
-                    let walletName: string;
-                    if (walletRegistryEntry.name === FabricWalletUtil.LOCAL_WALLET) {
-                        walletName = FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME;
-                    } else {
-                        walletName = walletRegistryEntry.name;
-                    }
-
-                    if (walletRegistryEntry.managedWallet) {
-                        tree.push(new LocalWalletTreeItem(this, walletName, identityNames, treeState, walletRegistryEntry));
-                    } else {
-                        tree.push(new WalletTreeItem(this, walletName, identityNames, treeState, walletRegistryEntry));
-                    }
+                let walletName: string;
+                if (walletRegistryEntry.name === FabricWalletUtil.LOCAL_WALLET) {
+                    walletName = FabricWalletUtil.LOCAL_WALLET_DISPLAY_NAME;
+                } else {
+                    walletName = walletRegistryEntry.name;
                 }
+
+                if (walletRegistryEntry.managedWallet) {
+                    if (localFabricEnabled) {
+                        tree.push(new LocalWalletTreeItem(this, walletName, identityNames, treeState, walletRegistryEntry));
+                    }
+                } else {
+                    tree.push(new WalletTreeItem(this, walletName, identityNames, treeState, walletRegistryEntry));
+                }
+
             }
+        }
+
+        if (tree.length === 0) {
+            tree.push(new TextTreeItem(this, 'No wallets found'));
         }
 
         return tree;

--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Bypass the prerequisites check"
+                },
+                "ibm-blockchain-platform.ext.enableLocalFabric": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Enable the Local Fabric functionality"
                 }
             }
         },
@@ -501,16 +506,20 @@
             ],
             "commandPalette": [
                 {
-                    "command": "environmentExplorer.startFabricRuntime"
+                    "command": "environmentExplorer.startFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.stopFabricRuntime"
+                    "command": "environmentExplorer.stopFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.restartFabricRuntime"
+                    "command": "environmentExplorer.restartFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.teardownFabricRuntime"
+                    "command": "environmentExplorer.teardownFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
                     "command": "environmentExplorer.openNewTerminal"
@@ -593,17 +602,17 @@
                 },
                 {
                     "command": "environmentExplorer.stopFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {
                     "command": "environmentExplorer.restartFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {
                     "command": "environmentExplorer.teardownFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {
@@ -644,15 +653,15 @@
                 },
                 {
                     "command": "environmentExplorer.stopFabricRuntime",
-                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item && local-fabric-enabled"
                 },
                 {
                     "command": "environmentExplorer.restartFabricRuntime",
-                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item && local-fabric-enabled"
                 },
                 {
                     "command": "environmentExplorer.teardownFabricRuntime",
-                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item"
+                    "when": "view == environmentExplorer && viewItem == blockchain-runtime-item && local-fabric-enabled"
                 },
                 {
                     "command": "environmentExplorer.deleteNodeEntry",

--- a/test/TestUtil.ts
+++ b/test/TestUtil.ts
@@ -34,6 +34,7 @@ export class TestUtil {
             await this.storeAll();
             await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_DIRECTORY, this.EXTENSION_TEST_DIR, vscode.ConfigurationTarget.Global);
             await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_BYPASS_PREREQS, true, vscode.ConfigurationTarget.Global);
+            await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_LOCAL_FABRIC, true, vscode.ConfigurationTarget.Global);
 
             if (!sandbox) {
                 sandbox = sinon.createSandbox();
@@ -41,7 +42,6 @@ export class TestUtil {
 
             const showConfirmationWarningMessage: SinonStub = sandbox.stub(UserInputUtil, 'showConfirmationWarningMessage');
             showConfirmationWarningMessage.withArgs(`The ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} configuration is out of date and must be torn down before updating. Do you want to teardown your ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} now?`).resolves(false);
-
             await ExtensionUtil.activateExtension();
         }
     }
@@ -51,6 +51,7 @@ export class TestUtil {
         await this.storeRuntimesConfig();
         await this.storeShowHomeOnStart();
         await this.storeBypassPreReqs();
+        await this.storeEnableLocalFabric();
         try {
             await this.storeGlobalState();
         } catch (error) {
@@ -63,6 +64,7 @@ export class TestUtil {
         await this.restoreRuntimesConfig();
         await this.restoreShowHomeOnStart();
         await this.restoreBypassPreReqs();
+        await this.restoreEnableLocalFabric();
         try {
             await this.restoreGlobalState();
         } catch (error) {
@@ -113,6 +115,16 @@ export class TestUtil {
         await GlobalState.update(this.GLOBAL_STATE);
     }
 
+    static async storeEnableLocalFabric(): Promise<void> {
+        this.ENABLE_LOCAL_FABRIC = await vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_LOCAL_FABRIC);
+        console.log('Storing enable Local Fabric:', this.ENABLE_LOCAL_FABRIC);
+    }
+
+    static async restoreEnableLocalFabric(): Promise<void> {
+        console.log('Restoring enable Local Fabric to settings:', this.ENABLE_LOCAL_FABRIC);
+        await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_LOCAL_FABRIC, this.ENABLE_LOCAL_FABRIC, vscode.ConfigurationTarget.Global);
+    }
+
     static async deleteTestFiles(deletePath: string): Promise<void> {
         try {
             await fs.remove(deletePath);
@@ -128,4 +140,5 @@ export class TestUtil {
     private static HOME_STARTUP: any;
     private static BYPASS_PREREQS: any;
     private static GLOBAL_STATE: ExtensionData;
+    private static ENABLE_LOCAL_FABRIC: boolean;
 }

--- a/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -30,6 +30,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -63,9 +64,13 @@ describe('FabricGoDebugConfigurationProvider', () => {
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
         let showInputBoxStub: sinon.SinonStub;
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
 
-        beforeEach(() => {
+        beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricGoDebugConfigurationProvider();
 

--- a/test/debug/FabricJavaDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricJavaDebugConfigurationProvider.test.ts
@@ -30,6 +30,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -63,9 +64,12 @@ describe('FabricJavaDebugConfigurationProvider', () => {
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
         let showInputBoxStub: sinon.SinonStub;
-
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
         beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricJavaDebugConfigurationProvider();
 

--- a/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -29,6 +29,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -61,9 +62,13 @@ describe('FabricNodeDebugConfigurationProvider', () => {
         let mockRuntimeConnection: sinon.SinonStubbedInstance<FabricEnvironmentConnection>;
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
 
         beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricNodeDebugConfigurationProvider();
 


### PR DESCRIPTION
This PR introduces the user setting `ibm-blockchain-platform.ext.enableLocalFabric` to toggle the Local Fabric functionality on and off.
This PR is part of the epic #1493, so isn't complete. We still need to allow the user to toggle this from the pre-req page.


Signed-off-by: Jake Turner <jaketurner25@live.com>