### PR TITLE
Setting to toggle Local Fabric functionality (close #1499)

### DIFF
--- a/packages/blockchain-extension/configurations.ts
+++ b/packages/blockchain-extension/configurations.ts
@@ -31,6 +31,7 @@ export class SettingConfigurations {
     // EXTENSION CONFIGURATIONS
     static readonly EXTENSION_DIRECTORY: string = 'ibm-blockchain-platform.ext.directory';
     static readonly EXTENSION_BYPASS_PREREQS: string = 'ibm-blockchain-platform.ext.bypassPreReqs';
+    static readonly EXTENSION_LOCAL_FABRIC: string = 'ibm-blockchain-platform.ext.enableLocalFabric';
 
     // HOME CONFIGURATIONS
     static readonly HOME_SHOW_ON_STARTUP: string = 'ibm-blockchain-platform.home.showOnStartup';

--- a/packages/blockchain-extension/extension/commands/UserInputUtil.ts
+++ b/packages/blockchain-extension/extension/commands/UserInputUtil.ts
@@ -178,6 +178,10 @@ export class UserInputUtil {
 
         allGateways.push(...gateways);
 
+        if (allGateways.length === 0) {
+            throw new Error('Error when choosing gateway, no gateway found to choose from.');
+        }
+
         const gatewaysQuickPickItems: Array<IBlockchainQuickPickItem<FabricGatewayRegistryEntry>> = allGateways.map((gateway: FabricGatewayRegistryEntry) => {
             const gatewayDispalyName: string = (gateway.name === FabricRuntimeUtil.LOCAL_FABRIC) ? FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME : gateway.name;
             return { label: gatewayDispalyName, data: gateway };

--- a/packages/blockchain-extension/extension/commands/deleteEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/deleteEnvironmentCommand.ts
@@ -35,7 +35,7 @@ export async function deleteEnvironment(environment: FabricEnvironmentTreeItem |
             // First check there is at least one that isn't local_fabric
             const environments: Array<FabricEnvironmentRegistryEntry> = await FabricEnvironmentRegistry.instance().getAll(false);
             if (environments.length === 0) {
-                outputAdapter.log(LogType.ERROR, `No environments to delete. ${FabricRuntimeUtil.LOCAL_FABRIC} cannot be deleted.`);
+                outputAdapter.log(LogType.ERROR, `No environments to delete. ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} cannot be deleted.`);
                 return;
             }
 

--- a/packages/blockchain-extension/extension/debug/FabricDebugConfigurationProvider.ts
+++ b/packages/blockchain-extension/extension/debug/FabricDebugConfigurationProvider.ts
@@ -27,6 +27,8 @@ import { FabricEnvironmentRegistryEntry } from '../registries/FabricEnvironmentR
 import { GlobalState, ExtensionData } from '../util/GlobalState';
 import { FabricChaincode } from '../fabric/FabricChaincode';
 import { FabricEnvironmentRegistry } from '../registries/FabricEnvironmentRegistry';
+import { SettingConfigurations } from '../../configurations';
+import { ExtensionUtil } from '../util/ExtensionUtil';
 
 export abstract class FabricDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
 
@@ -73,6 +75,11 @@ export abstract class FabricDebugConfigurationProvider implements vscode.DebugCo
     public async resolveDebugConfiguration(folder: vscode.WorkspaceFolder | undefined, config: vscode.DebugConfiguration, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration> {
         const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
         try {
+            const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
+            if (!localFabricEnabled) {
+                outputAdapter.log(LogType.ERROR, `Setting '${SettingConfigurations.EXTENSION_LOCAL_FABRIC}' must be set to 'true' to enable debugging.`);
+                return;
+            }
 
             const extensionData: ExtensionData = GlobalState.get();
 

--- a/packages/blockchain-extension/package.json
+++ b/packages/blockchain-extension/package.json
@@ -180,6 +180,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Bypass the prerequisites check"
+                },
+                "ibm-blockchain-platform.ext.enableLocalFabric": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Allow this extension to use Docker and Docker Compose to run a simple pre-configured local Hyperledger Fabric network"
                 }
             }
         },
@@ -501,16 +506,20 @@
             ],
             "commandPalette": [
                 {
-                    "command": "environmentExplorer.startFabricRuntime"
+                    "command": "environmentExplorer.startFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.stopFabricRuntime"
+                    "command": "environmentExplorer.stopFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.restartFabricRuntime"
+                    "command": "environmentExplorer.restartFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
-                    "command": "environmentExplorer.teardownFabricRuntime"
+                    "command": "environmentExplorer.teardownFabricRuntime",
+                    "when": "local-fabric-enabled"
                 },
                 {
                     "command": "environmentExplorer.openNewTerminal"
@@ -593,17 +602,17 @@
                 },
                 {
                     "command": "environmentExplorer.stopFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {
                     "command": "environmentExplorer.restartFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {
                     "command": "environmentExplorer.teardownFabricRuntime",
-                    "when": "view == environmentExplorer && blockchain-runtime-connected",
+                    "when": "view == environmentExplorer && blockchain-runtime-connected && local-fabric-enabled",
                     "group": "blockchain"
                 },
                 {

--- a/packages/blockchain-extension/test/TestUtil.ts
+++ b/packages/blockchain-extension/test/TestUtil.ts
@@ -34,6 +34,7 @@ export class TestUtil {
             await this.storeAll();
             await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_DIRECTORY, this.EXTENSION_TEST_DIR, vscode.ConfigurationTarget.Global);
             await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_BYPASS_PREREQS, true, vscode.ConfigurationTarget.Global);
+            await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_LOCAL_FABRIC, true, vscode.ConfigurationTarget.Global);
 
             if (!sandbox) {
                 sandbox = sinon.createSandbox();
@@ -41,7 +42,6 @@ export class TestUtil {
 
             const showConfirmationWarningMessage: SinonStub = sandbox.stub(UserInputUtil, 'showConfirmationWarningMessage');
             showConfirmationWarningMessage.withArgs(`The ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} configuration is out of date and must be torn down before updating. Do you want to teardown your ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} now?`).resolves(false);
-
             await ExtensionUtil.activateExtension();
         }
     }
@@ -51,6 +51,7 @@ export class TestUtil {
         await this.storeRuntimesConfig();
         await this.storeShowHomeOnStart();
         await this.storeBypassPreReqs();
+        await this.storeEnableLocalFabric();
         try {
             await this.storeGlobalState();
         } catch (error) {
@@ -63,6 +64,7 @@ export class TestUtil {
         await this.restoreRuntimesConfig();
         await this.restoreShowHomeOnStart();
         await this.restoreBypassPreReqs();
+        await this.restoreEnableLocalFabric();
         try {
             await this.restoreGlobalState();
         } catch (error) {
@@ -113,6 +115,16 @@ export class TestUtil {
         await GlobalState.update(this.GLOBAL_STATE);
     }
 
+    static async storeEnableLocalFabric(): Promise<void> {
+        this.ENABLE_LOCAL_FABRIC = await vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_LOCAL_FABRIC);
+        console.log('Storing enable Local Fabric to settings:', this.ENABLE_LOCAL_FABRIC);
+    }
+
+    static async restoreEnableLocalFabric(): Promise<void> {
+        console.log('Restoring enable Local Fabric to settings:', this.ENABLE_LOCAL_FABRIC);
+        await vscode.workspace.getConfiguration().update(SettingConfigurations.EXTENSION_LOCAL_FABRIC, this.ENABLE_LOCAL_FABRIC, vscode.ConfigurationTarget.Global);
+    }
+
     static async deleteTestFiles(deletePath: string): Promise<void> {
         try {
             await fs.remove(deletePath);
@@ -128,4 +140,5 @@ export class TestUtil {
     private static HOME_STARTUP: any;
     private static BYPASS_PREREQS: any;
     private static GLOBAL_STATE: ExtensionData;
+    private static ENABLE_LOCAL_FABRIC: boolean;
 }

--- a/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
+++ b/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
@@ -322,6 +322,18 @@ describe('UserInputUtil', () => {
             result.label.should.equal('myGatewayB');
             result.data.should.deep.equal(gatewayEntryTwo);
         });
+
+        it('should throw an error if there are no gateways', async () => {
+            await FabricGatewayRegistry.instance().clear();
+
+            await UserInputUtil.showGatewayQuickPickBox('Choose a gateway', true).should.be.rejectedWith(`Error when choosing gateway, no gateway found to choose from.`);
+
+            quickPickStub.should.not.have.been.calledWith(sinon.match.any, {
+                ignoreFocusOut: true,
+                canPickMany: true,
+                placeHolder: 'Choose a gateway'
+            });
+        });
     });
 
     describe('showIdentitiesQuickPickBox', () => {

--- a/packages/blockchain-extension/test/commands/deleteEnvironmentCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/deleteEnvironmentCommand.test.ts
@@ -225,7 +225,7 @@ describe('DeleteEnvironmentCommand', () => {
 
             showFabricEnvironmentQuickPickBoxStub.should.not.have.been.called;
             logSpy.getCall(0).should.have.been.calledWithExactly(LogType.INFO, undefined, `delete environment`);
-            logSpy.getCall(1).should.have.been.calledWithExactly(LogType.ERROR, `No environments to delete. ${FabricRuntimeUtil.LOCAL_FABRIC} cannot be deleted.`);
+            logSpy.getCall(1).should.have.been.calledWithExactly(LogType.ERROR, `No environments to delete. ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} cannot be deleted.`);
         });
 
         it('should handle no from confirmation message', async () => {

--- a/packages/blockchain-extension/test/debug/FabricGoDebugConfigurationProvider.test.ts
+++ b/packages/blockchain-extension/test/debug/FabricGoDebugConfigurationProvider.test.ts
@@ -30,6 +30,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -63,9 +64,13 @@ describe('FabricGoDebugConfigurationProvider', () => {
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
         let showInputBoxStub: sinon.SinonStub;
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
 
-        beforeEach(() => {
+        beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricGoDebugConfigurationProvider();
 

--- a/packages/blockchain-extension/test/debug/FabricJavaDebugConfigurationProvider.test.ts
+++ b/packages/blockchain-extension/test/debug/FabricJavaDebugConfigurationProvider.test.ts
@@ -30,6 +30,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -63,9 +64,12 @@ describe('FabricJavaDebugConfigurationProvider', () => {
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
         let showInputBoxStub: sinon.SinonStub;
-
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
         beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricJavaDebugConfigurationProvider();
 

--- a/packages/blockchain-extension/test/debug/FabricNodeDebugConfigurationProvider.test.ts
+++ b/packages/blockchain-extension/test/debug/FabricNodeDebugConfigurationProvider.test.ts
@@ -29,6 +29,7 @@ import { FabricEnvironmentManager } from '../../extension/fabric/FabricEnvironme
 import { FabricEnvironmentRegistryEntry } from '../../extension/registries/FabricEnvironmentRegistryEntry';
 import { GlobalState } from '../../extension/util/GlobalState';
 import { FabricChaincode } from '../../extension/fabric/FabricChaincode';
+import { ExtensionUtil } from '../../extension/util/ExtensionUtil';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -61,9 +62,13 @@ describe('FabricNodeDebugConfigurationProvider', () => {
         let mockRuntimeConnection: sinon.SinonStubbedInstance<FabricEnvironmentConnection>;
         let startDebuggingStub: sinon.SinonStub;
         let sendTelemetryEventStub: sinon.SinonStub;
+        let getExtensionLocalFabricSetting: sinon.SinonStub;
 
         beforeEach(async () => {
+
             mySandbox = sinon.createSandbox();
+            getExtensionLocalFabricSetting = mySandbox.stub(ExtensionUtil, 'getExtensionLocalFabricSetting');
+            getExtensionLocalFabricSetting.returns(true);
 
             fabricDebugConfig = new FabricNodeDebugConfigurationProvider();
 

--- a/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
@@ -58,6 +58,7 @@ const should: Chai.Should = chai.should();
 // tslint:disable no-unused-expression
 describe('environmentExplorer', () => {
     let mySandBox: sinon.SinonSandbox;
+
     before(async () => {
         mySandBox = sinon.createSandbox();
         await TestUtil.setupTests(mySandBox);

--- a/packages/blockchain-extension/test/explorer/gatewayExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/gatewayExplorer.test.ts
@@ -60,7 +60,6 @@ describe('gatewayExplorer', () => {
     });
 
     beforeEach(async () => {
-
         logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
     });
 
@@ -116,7 +115,6 @@ describe('gatewayExplorer', () => {
     });
 
     describe('getChildren', () => {
-
         describe('unconnected tree', () => {
 
             let getConnectionStub: sinon.SinonStub;

--- a/packages/blockchain-extension/test/explorer/walletExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/walletExplorer.test.ts
@@ -59,6 +59,7 @@ describe('walletExplorer', () => {
     });
 
     beforeEach(async () => {
+
         logSpy = mySandBox.spy(VSCodeBlockchainOutputAdapter.instance(), 'log');
         blockchainWalletExplorerProvider = ExtensionUtil.getBlockchainWalletExplorerProvider();
 


### PR DESCRIPTION
This PR introduces the user setting ibm-blockchain-platform.ext.enableLocalFabric to toggle the Local Fabric functionality on and off.
This PR is part of the epic #1497, so isn't complete. We still need to allow the user to toggle this from the pre-req page.

Signed-off-by: Jake Turner <jaketurner25@live.com>