### PR TITLE
update perf link to match new target

### DIFF
--- a/blockchain-extension/templates/HomeView.ejs
+++ b/blockchain-extension/templates/HomeView.ejs
@@ -350,7 +350,7 @@
                         <h2 id="help-support-title">Help & Support</h2>
                         <p class="docLink"><a href="https://www.ibm.com/account/reg/signup?formid=urx-38322&cm_mmc=OSocial_Googleplus-_-Blockchain+and+Watson+Financial+Services_Blockchain-_-WW_WW-_-VS+code+link+-+Oreilly+book+promo&cm_mmca1=000026VG&cm_mmca2=10008691" onclick="openUrl('E-book: Getting Started with Enterprise Blockchain')">Free e-book: Getting Started with Enterprise Blockchain</a></p>
                         <p class="docLink"><a href="https://github.com/IBM-Blockchain/blockchain-vscode-extension/blob/master/README.md#features">Read the documentation</a></p>
-                        <p class="docLink"><a href="https://hyperledger.github.io/caliper-benchmarks/content/fabric-performance/approach/">Hyperledger Fabric performance reports</a></p>
+                        <p class="docLink"><a href="https://hyperledger.github.io/caliper-benchmarks/fabric/performance/">Hyperledger Fabric performance reports</a></p>
                         <p class="docLink"><a href="https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues" onclick="#">Raise a GitHub issue</a></p>
                         <p class="docLink"><a href="https://stackoverflow.com/questions/tagged/ibp-vscode-extension" onclick="#">Search Stack Overflow</a></p>
                     </div>


### PR DESCRIPTION
Signed-off-by: nkl199@yahoo.co.uk <nkl199@yahoo.co.uk>

The base url for fabric performance tests have been moved to a new permanent home. This PR updates the VS Code link to match the new location, which is: 

https://hyperledger.github.io/caliper-benchmarks/fabric/performance/