### PR TITLE
Return and show error when no open packages to chose from

### DIFF
--- a/extension/commands/UserInputUtil.ts
+++ b/extension/commands/UserInputUtil.ts
@@ -417,7 +417,13 @@ export class UserInputUtil {
     }
 
     public static async showSmartContractPackagesQuickPickBox(prompt: string, canPickMany: boolean): Promise<Array<IBlockchainQuickPickItem<PackageRegistryEntry>> | IBlockchainQuickPickItem<PackageRegistryEntry> | undefined> {
+        const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
         const packages: Array<PackageRegistryEntry> = await PackageRegistry.instance().getAll();
+
+        if (packages.length === 0) {
+            outputAdapter.log(LogType.ERROR, 'There are no open packages.');
+            return;
+        }
 
         const quickPickItems: IBlockchainQuickPickItem<PackageRegistryEntry>[] = packages.map((_package: PackageRegistryEntry) => {
             return { label: _package.name, description: _package.version, data: _package };

--- a/test/commands/UserInputUtil.test.ts
+++ b/test/commands/UserInputUtil.test.ts
@@ -567,6 +567,14 @@ describe('UserInputUtil', () => {
                 placeHolder: 'Choose the smart contract package that you want to delete'
             });
         });
+
+        it('should show error and return when there are no open packages', async () => {
+            await PackageRegistry.instance().clear();
+            const result: Array<IBlockchainQuickPickItem<PackageRegistryEntry>> = await UserInputUtil.showSmartContractPackagesQuickPickBox('Choose the smart contract package that you want to delete', true) as Array<IBlockchainQuickPickItem<PackageRegistryEntry>>;
+            should.equal(result, undefined);
+            quickPickStub.should.not.have.been.called;
+            logSpy.should.have.been.calledWith(LogType.ERROR, 'There are no open packages.');
+        });
     });
 
     describe('showLanguagesQuickPick', () => {


### PR DESCRIPTION
Closes #1567, #1599 

To test this fix, one should try to delete a package from the command palette with no packages present.
The expected result is that the user will no longer be asked to chose from an empty list, and instead an error toast message should appear saying that there are no open packages.

Signed-off-by: Leonor-Maria Quintais <leonor-maria@oc4444350811.ibm.com>