### PR TITLE
Update DependencyManager.ts

### DIFF
--- a/extension/dependencies/DependencyManager.ts
+++ b/extension/dependencies/DependencyManager.ts
@@ -557,7 +557,7 @@ export class DependencyManager {
 
                 for (const _version of filteredVersions) {
                     try {
-                        const preBuiltBinarypath: string = `https://node-precompiled-binaries.grpc.io/grpc/v1.23.3/electron-v${_version.shortVersion}-${os}-${arch}-${thing}.tar.gz`;
+                        const preBuiltBinarypath: string = `https://storage.googleapis.com/node-precompiled-binaries.grpc.io/grpc/v1.23.3/electron-v${_version.shortVersion}-${os}-${arch}-${thing}.tar.gz`;
                         await Axios.get(preBuiltBinarypath);
                         // found one that exists so use it
                         version = _version;


### PR DESCRIPTION
replaced node-precompiled-binaries.grpc.io by storage.googleapis.com mirror