### PR TITLE
Add 'hidden' field to FabricNode

### DIFF
--- a/packages/blockchain-extension/extension/fabric/FabricEnvironment.ts
+++ b/packages/blockchain-extension/extension/fabric/FabricEnvironment.ts
@@ -52,13 +52,16 @@ export class FabricEnvironment extends EventEmitter {
         return Array.from(mspIDs).sort();
     }
 
-    public async getNodes(withoutIdentities: boolean = false): Promise<FabricNode[]> {
+    public async getNodes(withoutIdentities: boolean = false, showAll: boolean = false): Promise<FabricNode[]> {
         const rootNodesPath: string = path.resolve(this.path, 'nodes');
         const nodes: FabricNode[] = await this.loadNodes(rootNodesPath);
+        const nodesToUse: FabricNode[] = showAll ? nodes : nodes.filter((_node: FabricNode) => {
+            return _node.hidden === undefined || _node.hidden === false;
+        });
         if (withoutIdentities) {
-            return nodes.filter((node: FabricNode) => (!node.wallet || !node.identity));
+            return nodesToUse.filter((node: FabricNode) => (!node.wallet || !node.identity));
         } else {
-            return nodes;
+            return nodesToUse;
         }
     }
 

--- a/packages/blockchain-extension/extension/fabric/FabricNode.ts
+++ b/packages/blockchain-extension/extension/fabric/FabricNode.ts
@@ -24,36 +24,36 @@ export enum FabricNodeType {
 // tslint:disable variable-name
 export class FabricNode {
 
-    public static newPeer(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.PEER, api_url, wallet, identity, msp_id });
+    public static newPeer(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.PEER, api_url, wallet, identity, msp_id, hidden });
     }
 
-    public static newSecurePeer(short_name: string, name: string, api_url: string, pem: string, wallet: string, identity: string, msp_id: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.PEER, api_url, pem, wallet, identity, msp_id });
+    public static newSecurePeer(short_name: string, name: string, api_url: string, pem: string, wallet: string, identity: string, msp_id: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.PEER, api_url, pem, wallet, identity, msp_id, hidden });
     }
 
-    public static newOrderer(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string, cluster_name: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.ORDERER, api_url, wallet, identity, msp_id, cluster_name });
+    public static newOrderer(short_name: string, name: string, api_url: string, wallet: string, identity: string, msp_id: string, cluster_name: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.ORDERER, api_url, wallet, identity, msp_id, cluster_name, hidden });
     }
 
-    public static newSecureOrderer(short_name: string, name: string, api_url: string, pem: string, wallet: string, identity: string, msp_id: string, cluster_name: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.ORDERER, api_url, pem, wallet, identity, msp_id, cluster_name });
+    public static newSecureOrderer(short_name: string, name: string, api_url: string, pem: string, wallet: string, identity: string, msp_id: string, cluster_name: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.ORDERER, api_url, pem, wallet, identity, msp_id, cluster_name, hidden });
     }
 
-    public static newCouchDB(short_name: string, name: string, api_url: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.COUCHDB, api_url });
+    public static newCouchDB(short_name: string, name: string, api_url: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.COUCHDB, api_url, hidden });
     }
 
-    public static newLogspout(short_name: string, name: string, api_url: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.LOGSPOUT, api_url });
+    public static newLogspout(short_name: string, name: string, api_url: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.LOGSPOUT, api_url, hidden });
     }
 
-    public static newCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, wallet: string, identity: string, msp_id: string, enroll_id: string, enroll_secret: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, wallet, identity, msp_id, enroll_id, enroll_secret });
+    public static newCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, wallet: string, identity: string, msp_id: string, enroll_id: string, enroll_secret: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, wallet, identity, msp_id, enroll_id, enroll_secret, hidden });
     }
 
-    public static newSecureCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, pem: string, wallet: string, identity: string, msp_id: string, enroll_id: string, enroll_secret: string): FabricNode {
-        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, pem, wallet, identity, msp_id, enroll_id, enroll_secret });
+    public static newSecureCertificateAuthority(short_name: string, name: string, api_url: string, ca_name: string, pem: string, wallet: string, identity: string, msp_id: string, enroll_id: string, enroll_secret: string, hidden: boolean = false): FabricNode {
+        return new FabricNode({ short_name, name, type: FabricNodeType.CERTIFICATE_AUTHORITY, api_url, ca_name, pem, wallet, identity, msp_id, enroll_id, enroll_secret, hidden });
     }
 
     public static validateNode(node: FabricNode): void {
@@ -79,7 +79,8 @@ export class FabricNode {
     }
 
     public static pruneNode(data: any): FabricNode {
-        const node: FabricNode = new FabricNode({short_name: data.shoty_name, name: data.name, type: data.type, api_url: data.api_url});
+        const hidden: boolean = data.hidden === undefined ? false : data.hidden;
+        const node: FabricNode = new FabricNode({short_name: data.short_name, name: data.name, type: data.type, api_url: data.api_url, hidden: hidden});
 
         if (data.msp_id) {
             node.msp_id = data.msp_id;
@@ -119,6 +120,7 @@ export class FabricNode {
     public enroll_secret?: string;
     public enroll_id?: string;
     public cluster_name?: string;
+    public hidden: boolean;
 
     private constructor(fields: FabricNode) {
         Object.assign(this, fields);

--- a/packages/blockchain-extension/test/data/environment/nodes/peer1.org1.example.com.json
+++ b/packages/blockchain-extension/test/data/environment/nodes/peer1.org1.example.com.json
@@ -5,5 +5,6 @@
     "chaincode_url": "grpc://localhost:17052",
     "type": "fabric-peer",
     "msp_id": "Org1MSP",
-    "container_name": "yofn_peer1.org1.example.com"
+    "container_name": "yofn_peer1.org1.example.com",
+    "hidden": false
 }

--- a/packages/blockchain-extension/test/data/environment/nodes/peer2.org1.example.com.json
+++ b/packages/blockchain-extension/test/data/environment/nodes/peer2.org1.example.com.json
@@ -1,0 +1,10 @@
+{
+    "short_name": "peer2.org1.example.com",
+    "name": "peer2.org1.example.com",
+    "api_url": "grpc://localhost:17051",
+    "chaincode_url": "grpc://localhost:17052",
+    "type": "fabric-peer",
+    "msp_id": "Org1MSP",
+    "container_name": "yofn_peer2.org1.example.com",
+    "hidden": true
+}

--- a/packages/blockchain-extension/test/fabric/FabricEnvironment.test.ts
+++ b/packages/blockchain-extension/test/fabric/FabricEnvironment.test.ts
@@ -27,6 +27,7 @@ chai.should();
 describe('FabricEnvironment', () => {
 
     const rootPath: string = path.dirname(__dirname);
+
     const environmentPath: string = path.resolve(rootPath, '..', '..', 'test', 'data', 'environment');
 
     let environment: FabricEnvironment;
@@ -125,7 +126,8 @@ describe('FabricEnvironment', () => {
                     chaincode_url: 'grpc://localhost:17052',
                     type: 'fabric-peer',
                     msp_id: 'Org1MSP',
-                    container_name: 'yofn_peer1.org1.example.com'
+                    container_name: 'yofn_peer1.org1.example.com',
+                    hidden: false
                 }
             ]);
         });
@@ -153,7 +155,46 @@ describe('FabricEnvironment', () => {
                     chaincode_url: 'grpc://localhost:17052',
                     type: 'fabric-peer',
                     msp_id: 'Org1MSP',
-                    container_name: 'yofn_peer1.org1.example.com'
+                    container_name: 'yofn_peer1.org1.example.com',
+                    hidden: false
+                }
+            ]);
+        });
+        it('should return hidden nodes if showAll is true', async () => {
+            await environment.getNodes(true, true).should.eventually.deep.equal([
+                {
+                    short_name: 'couchdb',
+                    name: 'couchdb',
+                    api_url: 'http://localhost:17055',
+                    type: 'couchdb',
+                    container_name: 'yofn_couchdb'
+                },
+                {
+                    short_name: 'logspout',
+                    name: 'logspout',
+                    api_url: 'http://localhost:17056',
+                    type: 'logspout',
+                    container_name: 'yofn_logspout'
+                },
+                {
+                    short_name: 'peer1.org1.example.com',
+                    name: 'peer1.org1.example.com',
+                    api_url: 'grpc://localhost:17051',
+                    chaincode_url: 'grpc://localhost:17052',
+                    type: 'fabric-peer',
+                    msp_id: 'Org1MSP',
+                    container_name: 'yofn_peer1.org1.example.com',
+                    hidden: false
+                },
+                {
+                    short_name: 'peer2.org1.example.com',
+                    name: 'peer2.org1.example.com',
+                    api_url: 'grpc://localhost:17051',
+                    chaincode_url: 'grpc://localhost:17052',
+                    type: 'fabric-peer',
+                    msp_id: 'Org1MSP',
+                    container_name: 'yofn_peer2.org1.example.com',
+                    hidden: true
                 }
             ]);
         });

--- a/packages/blockchain-extension/test/fabric/FabricNode.test.ts
+++ b/packages/blockchain-extension/test/fabric/FabricNode.test.ts
@@ -124,4 +124,17 @@ describe('FabricNode', () => {
             }
         });
     });
+
+    describe('pruneNode', () => {
+        it('should set hidden to false when undefined', () => {
+            try {
+                peerNode.hidden = undefined;
+                const prunedNode: FabricNode = FabricNode.pruneNode(peerNode);
+                prunedNode.hidden.should.equal(false);
+            } catch (error) {
+                throw new Error('should not get here ' + error.message);
+            }
+        });
+    });
+
 });

--- a/packages/blockchain-ui/package-lock.json
+++ b/packages/blockchain-ui/package-lock.json
@@ -3835,7 +3835,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -3856,12 +3857,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -3876,17 +3879,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -4003,7 +4009,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -4015,6 +4022,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -4029,6 +4037,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -4036,12 +4045,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -4060,6 +4071,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -4140,7 +4152,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -4152,6 +4165,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -4237,7 +4251,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -4273,6 +4288,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -4292,6 +4308,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -4335,12 +4352,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				},
@@ -9346,7 +9365,8 @@
 						"ansi-regex": {
 							"version": "2.1.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"aproba": {
 							"version": "1.2.0",
@@ -9367,12 +9387,14 @@
 						"balanced-match": {
 							"version": "1.0.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"brace-expansion": {
 							"version": "1.1.11",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"balanced-match": "^1.0.0",
 								"concat-map": "0.0.1"
@@ -9387,17 +9409,20 @@
 						"code-point-at": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"concat-map": {
 							"version": "0.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"console-control-strings": {
 							"version": "1.1.0",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"core-util-is": {
 							"version": "1.0.2",
@@ -9514,7 +9539,8 @@
 						"inherits": {
 							"version": "2.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"ini": {
 							"version": "1.3.5",
@@ -9526,6 +9552,7 @@
 							"version": "1.0.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"number-is-nan": "^1.0.0"
 							}
@@ -9540,6 +9567,7 @@
 							"version": "3.0.4",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"brace-expansion": "^1.1.7"
 							}
@@ -9547,12 +9575,14 @@
 						"minimist": {
 							"version": "0.0.8",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"minipass": {
 							"version": "2.3.5",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"safe-buffer": "^5.1.2",
 								"yallist": "^3.0.0"
@@ -9571,6 +9601,7 @@
 							"version": "0.5.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"minimist": "0.0.8"
 							}
@@ -9651,7 +9682,8 @@
 						"number-is-nan": {
 							"version": "1.0.1",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"object-assign": {
 							"version": "4.1.1",
@@ -9663,6 +9695,7 @@
 							"version": "1.4.0",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"wrappy": "1"
 							}
@@ -9748,7 +9781,8 @@
 						"safe-buffer": {
 							"version": "5.1.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"safer-buffer": {
 							"version": "2.1.2",
@@ -9784,6 +9818,7 @@
 							"version": "1.0.2",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"code-point-at": "^1.0.0",
 								"is-fullwidth-code-point": "^1.0.0",
@@ -9803,6 +9838,7 @@
 							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
+							"optional": true,
 							"requires": {
 								"ansi-regex": "^2.0.0"
 							}
@@ -9846,12 +9882,14 @@
 						"wrappy": {
 							"version": "1.0.2",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						},
 						"yallist": {
 							"version": "3.0.3",
 							"bundled": true,
-							"dev": true
+							"dev": true,
+							"optional": true
 						}
 					}
 				}


### PR DESCRIPTION
This new field will allow the extension to write all nodes to file, while only presenting to the client the non-hidden nodes.

All nodes are visible by default (hidden = false).

Closes #1542 
Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>