### PR TITLE
create ops tool environment without nodes closes #1721

### DIFF
--- a/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
@@ -175,7 +175,7 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
                 // Ask user to chose which nodes to add to the environemnt.
                 let chosenNodes: IBlockchainQuickPickItem<FabricNode>[] = await UserInputUtil.showNodesQuickPickBox('Which nodes would you like to import?', filteredData, true) as IBlockchainQuickPickItem<FabricNode>[];
                 if (!chosenNodes || chosenNodes.length === 0) {
-                    return;
+                    return true;
                 } else if (!Array.isArray(chosenNodes)) {
                     chosenNodes = [chosenNodes];
                 }


### PR DESCRIPTION
closes #1721  

The extra functionality needed for the correct behavior, ie., not allowing to connect until there are nodes in the environment, will be delivered in #1775 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>