### PR TITLE
FabricNodeQuickPick now only shows required nodes

### DIFF
--- a/packages/blockchain-extension/extension/commands/UserInputUtil.ts
+++ b/packages/blockchain-extension/extension/commands/UserInputUtil.ts
@@ -899,7 +899,7 @@ export class UserInputUtil {
         const environment: FabricEnvironment = new FabricEnvironment(environmentName);
         let nodes: FabricNode[] = await environment.getNodes(showUnassociatedNodes);
 
-        if (nodeTypefilter.length > 1) {
+        if (nodeTypefilter.length > 0) {
             nodes = nodes.filter((node: FabricNode) => nodeTypefilter.indexOf(node.type) !== -1);
         }
 

--- a/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
+++ b/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
@@ -2026,6 +2026,23 @@ describe('UserInputUtil', () => {
             });
         });
 
+        it('should show all nodes if type not specified', async () => {
+            quickPickStub.resolves({ data: nodes[0] });
+            const node: IBlockchainQuickPickItem<FabricNode> = await UserInputUtil.showFabricNodeQuickPick('Gimme a node', FabricRuntimeUtil.LOCAL_FABRIC, [] ) as IBlockchainQuickPickItem<FabricNode>;
+            node.data.should.equal(nodes[0]);
+            quickPickStub.should.have.been.calledOnceWithExactly([
+                { label: 'peer0.org1.example.com', data: nodes[0] },
+                { label: 'ca.org1.example.com', data: nodes[1] },
+                { label: 'orderer.example.com', data: nodes[2] },
+                { label: 'orderer1.example.com', data: nodes[3] },
+                { label: 'couchdb', data: nodes[4] }
+            ], {
+                ignoreFocusOut: true,
+                canPickMany: false,
+                placeHolder: 'Gimme a node'
+            });
+        });
+
         it('should allow the user to select a node with associated identity', async () => {
             quickPickStub.resolves({ data: nodes[0] });
             const node: IBlockchainQuickPickItem<FabricNode> = await UserInputUtil.showFabricNodeQuickPick('Gimme a node', FabricRuntimeUtil.LOCAL_FABRIC, [FabricNodeType.PEER, FabricNodeType.ORDERER], true) as IBlockchainQuickPickItem<FabricNode>;


### PR DESCRIPTION
Only show CA nodes when creating a gateway using an environment. 

closes #1733 
Signed-off-by: Akshat Shah <akshatshah@akshats-mbp.hursley.uk.ibm.com>