### PR TITLE
Updated OpenSSL check (close #1654)

### DIFF
--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -250,13 +250,19 @@ export class DependencyManager {
                 dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively' };
                 dependencies.buildTools = { name: 'C++ Build Tools', required: true, version: undefined, url: 'https://github.com/felixrieseberg/windows-build-tools#windows-build-tools', requiredVersion: undefined, requiredLabel: undefined };
                 try {
-                    const opensslResult: string = await CommandUtil.sendCommand('openssl version -v'); // Format: OpenSSL 1.0.2k  26 Jan 2017
-                    if (this.isCommandFound(opensslResult)) {
-                        const opensslMatchedVersion: string = opensslResult.match(/OpenSSL (\S*)/)[1]; // Format: 1.0.2k
-                        const opensslVersionCoerced: semver.SemVer = semver.coerce(opensslMatchedVersion); // Format: X.Y.Z
-                        const opensslVersion: string = semver.valid(opensslVersionCoerced); // Returns version
-                        if (opensslVersion) {
-                            dependencies.openssl.version = opensslVersion;
+                    const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);
+                    const win64: boolean = await fs.pathExists(`C:\\OpenSSL-Win64`);
+                    if (win32 || win64) {
+                        const arch: string = (win32) ? '32' : '64';
+                        const binPath: string = path.win32.join(`C:\\OpenSSL-Win${arch}`, 'bin', 'openssl.exe');
+                        const opensslResult: string = await CommandUtil.sendCommand(`${binPath} version`); // Format: OpenSSL 1.0.2k  26 Jan 2017
+                        if (this.isCommandFound(opensslResult)) {
+                            const opensslMatchedVersion: string = opensslResult.match(/OpenSSL (\S*)/)[1]; // Format: 1.0.2k
+                            const opensslVersionCoerced: semver.SemVer = semver.coerce(opensslMatchedVersion); // Format: X.Y.Z
+                            const opensslVersion: string = semver.valid(opensslVersionCoerced); // Returns version
+                            if (opensslVersion) {
+                                dependencies.openssl.version = opensslVersion;
+                            }
                         }
                     }
                 } catch (error) {

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -2045,20 +2045,49 @@ describe('DependencyManager Tests', () => {
         });
 
         describe('Windows', () => {
+            let existsStub: sinon.SinonStub;
+            beforeEach(async () => {
+                existsStub = mySandBox.stub(fs, 'pathExists');
+            });
 
-            it('should get version of OpenSSL', async () => {
+            it('should check if OpenSSL (32-bit) is installed', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                sendCommandStub.withArgs('openssl version -v').resolves('OpenSSL 1.0.2k  26 Jan 2017');
+                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2k  26 Jan 2017');
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 result.openssl.version.should.equal('1.0.2');
             });
 
+            it('should check if OpenSSL (64-bit) is installed', async () => {
+                mySandBox.stub(process, 'platform').value('win32');
+
+                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(false);
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('OpenSSL 1.1.1d  26 Jan 2017');
+
+                const result: any = await dependencyManager.getPreReqVersions();
+                result.openssl.version.should.equal('1.1.1');
+            });
+
             it('should not get version of OpenSSL if command not found', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                sendCommandStub.withArgs('openssl version -v').resolves('openssl not recognized');
+                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('openssl not recognized');
+
+                const result: any = await dependencyManager.getPreReqVersions();
+                should.not.exist(result.openssl.version);
+            });
+
+            it('should not get version of OpenSSL if installation path(s) not found', async () => {
+                mySandBox.stub(process, 'platform').value('win32');
+
+                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(false);
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
@@ -2067,12 +2096,13 @@ describe('DependencyManager Tests', () => {
             it('should not get version of OpenSSL if unexpected format is returned', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                sendCommandStub.withArgs('openssl version -v').resolves('OpenSSL version 1.2.3');
+                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL version 1.2.3');
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
             });
-
             it('should get version of Windows Build Tools', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 


### PR DESCRIPTION
We now check that `C:\OpenSSL-Win32` or `C:\OpenSSL-Win64` exist, and if so we attempt to get the version using the binary by doing something such as:
`C:\OpenSSL-Win32\bin\openssl.exe version`

Signed-off-by: Jake Turner <jaketurner25@live.com>