### PR TITLE
Fixed this.runtime.busy() is not a function

### DIFF
--- a/packages/blockchain-extension/extension/commands/environmentConnectCommand.ts
+++ b/packages/blockchain-extension/extension/commands/environmentConnectCommand.ts
@@ -43,7 +43,7 @@ export async function fabricEnvironmentConnect(fabricEnvironmentRegistryEntry: F
             fabricEnvironmentRegistryEntry = chosenEntry.data;
         }
 
-        fabricEnvironment = EnvironmentFactory.getEnvironment(fabricEnvironmentRegistryEntry);
+        fabricEnvironment = await EnvironmentFactory.getEnvironment(fabricEnvironmentRegistryEntry);
         if (fabricEnvironmentRegistryEntry.managedRuntime) {
 
             let running: boolean = await (fabricEnvironment as LocalEnvironment | ManagedAnsibleEnvironment).isRunning();

--- a/packages/blockchain-extension/extension/commands/restartFabricRuntime.ts
+++ b/packages/blockchain-extension/extension/commands/restartFabricRuntime.ts
@@ -40,7 +40,7 @@ export async function restartFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): P
     } else {
         registryEntry = runtimeTreeItem.environmentRegistryEntry;
     }
-    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
+    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = await EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
     const associatedGateways: string[] = registryEntry.associatedGateways ? registryEntry.associatedGateways : [];
 
     await vscode.window.withProgress({

--- a/packages/blockchain-extension/extension/commands/startFabricRuntime.ts
+++ b/packages/blockchain-extension/extension/commands/startFabricRuntime.ts
@@ -35,7 +35,7 @@ export async function startFabricRuntime(registryEntry?: FabricEnvironmentRegist
 
     }
 
-    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
+    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = await EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
     VSCodeBlockchainOutputAdapter.instance().show();
 
     await vscode.window.withProgress({

--- a/packages/blockchain-extension/extension/commands/stopFabricRuntime.ts
+++ b/packages/blockchain-extension/extension/commands/stopFabricRuntime.ts
@@ -40,7 +40,7 @@ export async function stopFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Prom
     } else {
         registryEntry = runtimeTreeItem.environmentRegistryEntry;
     }
-    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
+    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = await EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
     const associatedGateways: string[] = registryEntry.associatedGateways ? registryEntry.associatedGateways : [];
 
     await vscode.window.withProgress({

--- a/packages/blockchain-extension/extension/commands/teardownFabricRuntime.ts
+++ b/packages/blockchain-extension/extension/commands/teardownFabricRuntime.ts
@@ -40,7 +40,7 @@ export async function teardownFabricRuntime(runtimeTreeItem: RuntimeTreeItem, fo
     } else {
         registryEntry = runtimeTreeItem.environmentRegistryEntry;
     }
-    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
+    const runtime: ManagedAnsibleEnvironment | LocalEnvironment = await EnvironmentFactory.getEnvironment(registryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
     const associatedGateways: string[] = registryEntry.associatedGateways ? registryEntry.associatedGateways : [];
     if (!force) {
         const reallyDoIt: boolean = await UserInputUtil.showConfirmationWarningMessage(`All world state and ledger data for the Fabric runtime ${runtime.getDisplayName()} will be destroyed. Do you want to continue?`);

--- a/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
+++ b/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
@@ -190,7 +190,7 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
             } else {
                 for (const environmentEntry of environmentEntries) {
                     if (environmentEntry.managedRuntime) {
-                        const runtime: ManagedAnsibleEnvironment = EnvironmentFactory.getEnvironment(environmentEntry) as ManagedAnsibleEnvironment;
+                        const runtime: ManagedAnsibleEnvironment = await EnvironmentFactory.getEnvironment(environmentEntry) as ManagedAnsibleEnvironment;
                         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(this,
                             runtime.getName(),
                             environmentEntry,

--- a/packages/blockchain-extension/extension/explorer/runtimeOps/disconnectedTree/RuntimeTreeItem.ts
+++ b/packages/blockchain-extension/extension/explorer/runtimeOps/disconnectedTree/RuntimeTreeItem.ts
@@ -27,6 +27,10 @@ export class RuntimeTreeItem extends FabricEnvironmentTreeItem {
 
     static async newRuntimeTreeItem(provider: BlockchainExplorerProvider, label: string, environmentRegistryEntry: FabricEnvironmentRegistryEntry, command: vscode.Command): Promise<RuntimeTreeItem> {
         const treeItem: RuntimeTreeItem = new RuntimeTreeItem(provider, label, environmentRegistryEntry, command);
+        treeItem.runtime = await EnvironmentFactory.getEnvironment(environmentRegistryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
+        treeItem.runtime.on('busy', () => {
+            treeItem.safelyUpdateProperties();
+        });
         await treeItem.updateProperties();
         return treeItem;
     }
@@ -40,10 +44,6 @@ export class RuntimeTreeItem extends FabricEnvironmentTreeItem {
     private constructor(provider: BlockchainExplorerProvider, public readonly label: string, environmentRegistryEntry: FabricEnvironmentRegistryEntry, public readonly command: vscode.Command) {
         super(provider, label, environmentRegistryEntry, command);
         this.name = label;
-        this.runtime = EnvironmentFactory.getEnvironment(environmentRegistryEntry) as ManagedAnsibleEnvironment | LocalEnvironment;
-        this.runtime.on('busy', () => {
-            this.safelyUpdateProperties();
-        });
     }
 
     private safelyUpdateProperties(): void {

--- a/packages/blockchain-extension/test/commands/environmentConnectCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/environmentConnectCommand.test.ts
@@ -111,10 +111,10 @@ describe('EnvironmentConnectCommand', () => {
 
             beforeEach(async () => {
 
-                fabricEnvironment = EnvironmentFactory.getEnvironment(environmentRegistryEntry);
+                fabricEnvironment = await EnvironmentFactory.getEnvironment(environmentRegistryEntry);
                 getEnvironmentStub = mySandBox.stub(EnvironmentFactory, 'getEnvironment');
                 getEnvironmentStub.callThrough();
-                getEnvironmentStub.withArgs(environmentRegistryEntry).returns(fabricEnvironment);
+                getEnvironmentStub.withArgs(environmentRegistryEntry).resolves(fabricEnvironment);
                 requireSetupStub = mySandBox.stub(fabricEnvironment, 'requireSetup').resolves(false);
             });
 
@@ -204,13 +204,13 @@ describe('EnvironmentConnectCommand', () => {
                     data: localFabricRegistryEntry
                 });
 
-                localEnvironment = EnvironmentFactory.getEnvironment(localFabricRegistryEntry) as LocalEnvironment;
+                localEnvironment = await EnvironmentFactory.getEnvironment(localFabricRegistryEntry) as LocalEnvironment;
 
                 isRunningStub = mySandBox.stub(localEnvironment, 'isRunning').resolves(true);
 
                 getEnvironmentStub = mySandBox.stub(EnvironmentFactory, 'getEnvironment');
                 getEnvironmentStub.callThrough();
-                getEnvironmentStub.withArgs(localFabricRegistryEntry).returns(localEnvironment);
+                getEnvironmentStub.withArgs(localFabricRegistryEntry).resolves(localEnvironment);
                 requireSetupStub = mySandBox.stub(localEnvironment, 'requireSetup').resolves(false);
             });
 

--- a/packages/blockchain-extension/test/commands/restartFabricRuntime.test.ts
+++ b/packages/blockchain-extension/test/commands/restartFabricRuntime.test.ts
@@ -83,7 +83,7 @@ describe('restartFabricRuntime', () => {
 
     it('should restart a Fabric environment from the tree', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         restartStub = sandbox.stub(environment, 'restart').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -96,7 +96,7 @@ describe('restartFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -112,7 +112,7 @@ describe('restartFabricRuntime', () => {
 
     it('should restart a Fabric runtime, disconnect from gateway and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         restartStub = sandbox.stub(environment, 'restart').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -125,7 +125,7 @@ describe('restartFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.RESTART_FABRIC, treeItem);
@@ -140,7 +140,7 @@ describe('restartFabricRuntime', () => {
 
     it('should restart a Fabric runtime, disconnect from environment and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         restartStub = sandbox.stub(environment, 'restart').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -153,7 +153,7 @@ describe('restartFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.RESTART_FABRIC, treeItem);
@@ -170,7 +170,7 @@ describe('restartFabricRuntime', () => {
         const error: Error = new Error('what the fabric has happened');
 
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         restartStub = sandbox.stub(environment, 'restart').throws(error);
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -183,7 +183,7 @@ describe('restartFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -201,9 +201,9 @@ describe('restartFabricRuntime', () => {
     it('should be able to restart the an environment from the command', async () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME, data: localRegistryEntry} as IBlockchainQuickPickItem<FabricEnvironmentRegistryEntry>);
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         restartStub = sandbox.stub(environment, 'restart').resolves();
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -247,7 +247,7 @@ describe('restartFabricRuntime', () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: 'managedAnsibleEntry', data: managedAnsibleEntry});
         getEnvironmentStub.callThrough();
 
-        const environment: ManagedAnsibleEnvironment = EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
+        const environment: ManagedAnsibleEnvironment = await EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
         restartStub = sandbox.stub(environment, 'restart').resolves();
         getEnvironmentStub.withArgs(managedAnsibleEntry).returns(environment);
 

--- a/packages/blockchain-extension/test/commands/startFabricRuntime.test.ts
+++ b/packages/blockchain-extension/test/commands/startFabricRuntime.test.ts
@@ -97,7 +97,7 @@ describe('startFabricRuntime', () => {
     it('should start a Local environment from the command palette if created and generated', async () => {
         mockLocalRuntime.isCreated.resolves(true);
         mockLocalRuntime.isGenerated.resolves(true);
-        getEnvironmentStub.returns(mockLocalRuntime);
+        getEnvironmentStub.resolves(mockLocalRuntime);
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
         showFabricEnvironmentQuickPickBoxStub.should.have.been.calledOnceWithExactly('Select an environment to start', false, true, true, true);
         mockLocalRuntime.create.should.not.have.been.called;
@@ -121,7 +121,7 @@ describe('startFabricRuntime', () => {
     it('should create, generate and start a Local environment', async () => {
         mockLocalRuntime.isCreated.resolves(false);
         mockLocalRuntime.isGenerated.resolves(false);
-        getEnvironmentStub.returns(mockLocalRuntime);
+        getEnvironmentStub.resolves(mockLocalRuntime);
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
         showFabricEnvironmentQuickPickBoxStub.should.have.been.calledOnceWithExactly('Select an environment to start', false, true, true, true);
         mockLocalRuntime.create.should.have.been.calledOnce;
@@ -137,7 +137,7 @@ describe('startFabricRuntime', () => {
     it('should be able to pass in an environment registry', async () => {
         mockLocalRuntime.isCreated.resolves(false);
         mockLocalRuntime.isGenerated.resolves(false);
-        getEnvironmentStub.returns(mockLocalRuntime);
+        getEnvironmentStub.resolves(mockLocalRuntime);
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC, localRegistryEntry);
         showFabricEnvironmentQuickPickBoxStub.should.not.have.been.called;
         mockLocalRuntime.create.should.have.been.calledOnce;
@@ -152,7 +152,7 @@ describe('startFabricRuntime', () => {
 
     it('should generate and start a managed environment', async () => {
         mockManagedEnvironment.isGenerated.resolves(false);
-        getEnvironmentStub.returns(mockManagedEnvironment);
+        getEnvironmentStub.resolves(mockManagedEnvironment);
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
         showFabricEnvironmentQuickPickBoxStub.should.have.been.calledOnceWithExactly('Select an environment to start', false, true, true, true);
         mockManagedEnvironment.generate.should.have.been.called.calledOnceWithExactly(VSCodeBlockchainOutputAdapter.instance());
@@ -168,7 +168,7 @@ describe('startFabricRuntime', () => {
         mockLocalRuntime.isGenerated.resolves(true);
         const error: Error = new Error('who ate all the cakes?');
         mockLocalRuntime.start.rejects(error);
-        getEnvironmentStub.returns(mockLocalRuntime);
+        getEnvironmentStub.resolves(mockLocalRuntime);
 
         await vscode.commands.executeCommand(ExtensionCommands.START_FABRIC);
         mockLocalRuntime.start.should.have.been.called.calledOnceWithExactly(VSCodeBlockchainOutputAdapter.instance());

--- a/packages/blockchain-extension/test/commands/stopFabricRuntime.test.ts
+++ b/packages/blockchain-extension/test/commands/stopFabricRuntime.test.ts
@@ -83,7 +83,7 @@ describe('stopFabricRuntime', () => {
 
     it('should stop a Fabric environment from the tree', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         stopStub = sandbox.stub(environment, 'stop').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -96,7 +96,7 @@ describe('stopFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -114,7 +114,7 @@ describe('stopFabricRuntime', () => {
 
     it('should stop a Fabric runtime, disconnect from gateway and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         stopStub = sandbox.stub(environment, 'stop').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -127,7 +127,7 @@ describe('stopFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.STOP_FABRIC, treeItem);
@@ -144,7 +144,7 @@ describe('stopFabricRuntime', () => {
 
     it('should stop a Fabric runtime, disconnect from environment and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         stopStub = sandbox.stub(environment, 'stop').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -157,7 +157,7 @@ describe('stopFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.STOP_FABRIC, treeItem);
@@ -176,7 +176,7 @@ describe('stopFabricRuntime', () => {
         const error: Error = new Error('what the fabric has happened');
 
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         stopStub = sandbox.stub(environment, 'stop').throws(error);
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
         const treeItem: RuntimeTreeItem = await RuntimeTreeItem.newRuntimeTreeItem(blockchainEnvironmentExplorerProvider,
@@ -189,7 +189,7 @@ describe('stopFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -209,9 +209,9 @@ describe('stopFabricRuntime', () => {
     it('should be able to stop the an environment from the command', async () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME, data: localRegistryEntry} as IBlockchainQuickPickItem<FabricEnvironmentRegistryEntry>);
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         stopStub = sandbox.stub(environment, 'stop').resolves();
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -257,7 +257,7 @@ describe('stopFabricRuntime', () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: 'managedAnsibleEntry', data: managedAnsibleEntry});
         getEnvironmentStub.callThrough();
 
-        const environment: ManagedAnsibleEnvironment = EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
+        const environment: ManagedAnsibleEnvironment = await EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
         stopStub = sandbox.stub(environment, 'stop').resolves();
         getEnvironmentStub.withArgs(managedAnsibleEntry).returns(environment);
 

--- a/packages/blockchain-extension/test/commands/teardownFabricRuntime.test.ts
+++ b/packages/blockchain-extension/test/commands/teardownFabricRuntime.test.ts
@@ -88,7 +88,7 @@ describe('teardownFabricRuntime', () => {
 
     it('should teardown a Fabric environment from the tree', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
@@ -102,7 +102,7 @@ describe('teardownFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -123,7 +123,7 @@ describe('teardownFabricRuntime', () => {
 
     it('should teardown a Fabric runtime, disconnect from gateway and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
@@ -137,7 +137,7 @@ describe('teardownFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.TEARDOWN_FABRIC, treeItem);
@@ -158,7 +158,7 @@ describe('teardownFabricRuntime', () => {
 
     it('should teardown a Fabric runtime, disconnect from environment and refresh the view', async () => {
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
@@ -172,7 +172,7 @@ describe('teardownFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
 
         await vscode.commands.executeCommand(ExtensionCommands.TEARDOWN_FABRIC, treeItem);
@@ -195,7 +195,7 @@ describe('teardownFabricRuntime', () => {
         const error: Error = new Error('what the fabric has happened');
 
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').throws(error);
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
         const blockchainEnvironmentExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
@@ -209,7 +209,7 @@ describe('teardownFabricRuntime', () => {
             }
         );
 
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -233,10 +233,10 @@ describe('teardownFabricRuntime', () => {
     it('should be able to teardown the an environment from the command', async () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME, data: localRegistryEntry} as IBlockchainQuickPickItem<FabricEnvironmentRegistryEntry>);
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -281,10 +281,10 @@ describe('teardownFabricRuntime', () => {
     it('should be able to cancel when asked if you want to teardown the selected environment', async () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME, data: localRegistryEntry} as IBlockchainQuickPickItem<FabricEnvironmentRegistryEntry>);
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 
@@ -320,7 +320,7 @@ describe('teardownFabricRuntime', () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: 'managedAnsibleEntry', data: managedAnsibleEntry});
         getEnvironmentStub.callThrough();
 
-        const environment: ManagedAnsibleEnvironment = EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
+        const environment: ManagedAnsibleEnvironment = await EnvironmentFactory.getEnvironment(managedAnsibleEntry) as ManagedAnsibleEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
         getEnvironmentStub.withArgs(managedAnsibleEntry).returns(environment);
@@ -349,10 +349,10 @@ describe('teardownFabricRuntime', () => {
     it('should be able to force teardown', async () => {
         showFabricEnvironmentQuickPickBoxStub.resolves({label: FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME, data: localRegistryEntry} as IBlockchainQuickPickItem<FabricEnvironmentRegistryEntry>);
         getEnvironmentStub.callThrough();
-        const environment: LocalEnvironment = EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
+        const environment: LocalEnvironment = await EnvironmentFactory.getEnvironment(localRegistryEntry) as LocalEnvironment;
         teardownStub = sandbox.stub(environment, 'teardown').resolves();
         deleteWalletsAndIdentitiesStub = sandbox.stub(environment, 'deleteWalletsAndIdentities').resolves();
-        getEnvironmentStub.returns(environment);
+        getEnvironmentStub.resolves(environment);
         getGatewayRegistryEntryStub.returns(undefined);
         getEnvironmentRegistryEntryStub.returns(undefined);
 

--- a/packages/blockchain-extension/test/fabric/environments/EnvironmentFactory.test.ts
+++ b/packages/blockchain-extension/test/fabric/environments/EnvironmentFactory.test.ts
@@ -16,7 +16,7 @@ import * as chai from 'chai';
 import * as sinon from 'sinon';
 import { TestUtil } from '../../TestUtil';
 import { EnvironmentFactory } from '../../../extension/fabric/environments/EnvironmentFactory';
-import { FabricRuntimeUtil, FabricEnvironmentRegistryEntry, EnvironmentType } from 'ibm-blockchain-platform-common';
+import { FabricRuntimeUtil, FabricEnvironmentRegistryEntry, EnvironmentType, FabricEnvironmentRegistry } from 'ibm-blockchain-platform-common';
 import { LocalEnvironment } from '../../../extension/fabric/environments/LocalEnvironment';
 import { ManagedAnsibleEnvironment } from '../../../extension/fabric/environments/ManagedAnsibleEnvironment';
 import { AnsibleEnvironment } from '../../../extension/fabric/environments/AnsibleEnvironment';
@@ -119,6 +119,49 @@ describe('EnvironmentFactory', () => {
 
         const environment: LocalEnvironment | ManagedAnsibleEnvironment | AnsibleEnvironment | FabricEnvironment = await EnvironmentFactory.getEnvironment(registryEntry);
         environment.should.be.an.instanceOf(AnsibleEnvironment);
+    });
+
+    it(`should set the associated gateways for the ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} if not already set`, async () => {
+        await LocalEnvironmentManager.instance().initialize();
+
+        const updateSpy: sinon.SinonSpy = sandbox.spy(FabricEnvironmentRegistry.instance(), 'update');
+
+        const getRuntimeSpy: sinon.SinonSpy = sandbox.spy(LocalEnvironmentManager.instance(), 'getRuntime');
+
+        const registryEntry: FabricEnvironmentRegistryEntry = new FabricEnvironmentRegistryEntry();
+        registryEntry.name = FabricRuntimeUtil.LOCAL_FABRIC;
+        registryEntry.managedRuntime = true;
+        registryEntry.environmentType = EnvironmentType.ANSIBLE_ENVIRONMENT;
+
+        const environment: LocalEnvironment | ManagedAnsibleEnvironment | AnsibleEnvironment | FabricEnvironment = await EnvironmentFactory.getEnvironment(registryEntry);
+        environment.should.be.an.instanceOf(LocalEnvironment);
+
+        getRuntimeSpy.should.have.been.calledOnce;
+
+        registryEntry.associatedGateways = [FabricRuntimeUtil.LOCAL_FABRIC];
+        updateSpy.should.have.been.calledWith(registryEntry);
+    });
+
+    it(`should set the environment type for the ${FabricRuntimeUtil.LOCAL_FABRIC_DISPLAY_NAME} if not already set`, async () => {
+        await LocalEnvironmentManager.instance().initialize();
+
+        const updateSpy: sinon.SinonSpy = sandbox.spy(FabricEnvironmentRegistry.instance(), 'update');
+
+        const getRuntimeSpy: sinon.SinonSpy = sandbox.spy(LocalEnvironmentManager.instance(), 'getRuntime');
+
+        const registryEntry: FabricEnvironmentRegistryEntry = new FabricEnvironmentRegistryEntry();
+        registryEntry.name = FabricRuntimeUtil.LOCAL_FABRIC;
+        registryEntry.managedRuntime = true;
+        registryEntry.associatedGateways = [FabricRuntimeUtil.LOCAL_FABRIC];
+
+        const environment: LocalEnvironment | ManagedAnsibleEnvironment | AnsibleEnvironment | FabricEnvironment = await EnvironmentFactory.getEnvironment(registryEntry);
+        environment.should.be.an.instanceOf(LocalEnvironment);
+
+        getRuntimeSpy.should.have.been.calledOnce;
+
+        registryEntry.environmentType = EnvironmentType.ANSIBLE_ENVIRONMENT;
+
+        updateSpy.should.have.been.calledWith(registryEntry);
     });
 
 });


### PR DESCRIPTION
To test this fix, change `~/.fabric-vscode/environments/local_fabric/.config.json` to be:
```
{"name":"local_fabric","managedRuntime":true}
```

This value will get updated with values for `environmentType` and `associatedGateways`. 
Signed-off-by: Jake Turner <jaketurner25@live.com>