### PR TITLE
Add build scripts for Eclipse Che (contributes to #1071)

### DIFF
--- a/che/.gitignore
+++ b/che/.gitignore
@@ -1,0 +1,5 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+*.vsix
+*.yaml

--- a/che/build.sh
+++ b/che/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -ex
+ROOT=$(git rev-parse --show-toplevel)
+cd ${ROOT}
+cp -f ./packages/blockchain-extension/package.json ./packages/blockchain-extension/package.json.orig
+trap "cd ${ROOT}; cp -f ./packages/blockchain-extension/package.json.orig ./packages/blockchain-extension/package.json; rm -f ./packages/blockchain-extension/package.json.orig" EXIT
+npm install lerna
+node ./node_modules/lerna/cli.js bootstrap
+node ./node_modules/lerna/cli.js run compile
+node ./node_modules/lerna/cli.js run createModule
+cp ./README.md ./packages/blockchain-extension/README.md
+cp ./CHANGELOG.md ./packages/blockchain-extension/CHANGELOG.md
+cp -r ./media ./packages/blockchain-extension/media
+cd ./packages/blockchain-extension
+npm install vsce
+npm install ../blockchain-ui/ibm-blockchain-platform-ui-*.tgz
+npm install ../blockchain-common/ibm-blockchain-platform-common-*.tgz
+npm install ../blockchain-wallet/ibm-blockchain-platform-wallet-*.tgz
+npm install ../blockchain-environment-v1/ibm-blockchain-platform-environment-v1-*.tgz
+npm install ../blockchain-gateway-v1/ibm-blockchain-platform-gateway-v1-*.tgz
+npm run compile
+npm run productionFlag
+cat package.json.orig \
+    | jq '.contributes.configuration.properties."ibm-blockchain-platform.ext.bypassPreReqs".default = true' \
+    | jq '.contributes.configuration.properties."ibm-blockchain-platform.home.showOnStartup".default = false' \
+    | jq '.contributes.configuration.properties."ibm-blockchain-platform.ext.enableLocalFabric".default = false' \
+    | jq '(.actualActivationEvents.onView | map("onView:" + .)) as $onView |
+          (.actualActivationEvents.onCommand | map("onCommand:" + .)) as $onCommand |
+          (.actualActivationEvents.other) as $other |
+          .activationEvents = $onView + $onCommand + $other' \
+    > package.json
+npm rebuild --update-binary --runtime=node --target=10.0.0 --target_platform=linux --target_arch=x64 --target_libc=musl
+npm run package
+cd ${ROOT}
+mv ./packages/blockchain-extension/ibm-blockchain-platform-*.vsix che/ibm-blockchain-platform-che.vsix
+export VERSION=$(jq -r .version lerna.json)
+cd che
+cat > ibm-blockchain-platform-che.yaml <<EOF
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+apiVersion: v2
+publisher: ibm
+name: blockchain-platform
+version: ${VERSION}
+type: VS Code extension
+displayName: IBM Blockchain Platform
+title: IBM Blockchain Platform
+description: End to end extension for Hyperledger Fabric developers. Develop and test your blockchain smart contracts and client applications on your local machine, and package your projects for deployment into IBM Blockchain Platform runtimes.
+icon: https://raw.githubusercontent.com/IBM-Blockchain/blockchain-vscode-extension/master/packages/blockchain-extension/resources/logo.svg
+repository: https://github.com/IBM-Blockchain/blockchain-vscode-extension
+category: Other
+firstPublicationDate: 2019-04-19
+spec:
+  extensions:
+  - https://github.com/IBM-Blockchain/blockchain-vscode-extension/releases/download/v${VERSION}/ibm-blockchain-platform-che.vsix
+EOF

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ RUN code-server --extensions-dir /usr/local/extensions --install-extension ms-vs
 COPY ibm-blockchain-platform-docker.vsix /tmp/
 RUN code-server --extensions-dir /usr/local/extensions --install-extension /tmp/ibm-blockchain-platform-docker.vsix && \
     cd /usr/local/extensions/ibmblockchain.ibm-blockchain-platform-* && \
-    npm rebuild --runtime=node --target=12.0.0 --arch=x64
+    npm rebuild --update-binary --runtime=node --target=12.0.0
 # Install our settings for Visual Studio Code
 COPY settings.json /etc/skel/.local/share/code-server/User/
 RUN for i in environments gateways packages wallets; do \


### PR DESCRIPTION
Add a build script that will generate a VSIX and metadata YAML file suitable for use with Eclipse Che.

The VSIX has to be custom built to include gRPC binaries suitable for use the version of Node.js included with Eclipse Che (Node.js v10 on Alpine). We cannot rebuild at runtime in this environment, as the way Eclipse Che works means that the rebuild would happen every time the user accessed their Eclipse Che workspace.

Also, similar to the Docker image using code-server, we change several default settings to better suit this environment (no pre-reqs page, no Local Fabric, etc).

CI, documentation and samples will follow, but in the mean time - this will be referenced by a Eclipse Che "devfile" with content similar to:

```
#
# SPDX-License-Identifier: Apache-2.0
#
---
apiVersion: 1.0.0
metadata:
  name: hyperledger-fabric
components:
  - type: chePlugin
    alias: ibm-blockchain-platform
    reference: https://github.com/IBM-Blockchain/blockchain-vscode-extension/releases/download/v1.0.18/ibm-blockchain-platform-che.yaml
```

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>