### PR TITLE
Use renamed tag for code-server image (contributes to #1818)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-FROM codercom/code-server:2.1704-vsc1.41.1
+FROM codercom/code-server:2.1698
 # Revert back to root
 USER root
 # Add essential build dependencies


### PR DESCRIPTION
The code-server team have renamed the tag for their VSCode 1.41 image, so need to update the Dockerfile to reflect the change.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>