### PR TITLE
Bump generator version to 0.1.4

### DIFF
--- a/packages/blockchain-extension/package-lock.json
+++ b/packages/blockchain-extension/package-lock.json
@@ -2343,9 +2343,9 @@
 			"dev": true
 		},
 		"generator-fabric": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/generator-fabric/-/generator-fabric-0.1.3.tgz",
-			"integrity": "sha512-RbKp/0Roo21Cs2rDR/T6fhtWw2fKVtxKh27fVCP8Z0xvbM0Q3+zhp02fgRoXI90Ss7aRJC8tH9vsVEtrV2muGg==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/generator-fabric/-/generator-fabric-0.1.4.tgz",
+			"integrity": "sha512-o5QNzHdxzC1eTUFqNLC3NJO7S2s7BSLfcs5/zWJGfYxePsx0lEJNLukHGCRPIZzYU0SO6M0VB/Vp4b7JUfj14w==",
 			"requires": {
 				"camelcase": "^5.3.1",
 				"decamelize": "^4.0.0",

--- a/packages/blockchain-extension/package.json
+++ b/packages/blockchain-extension/package.json
@@ -1308,7 +1308,7 @@
         "ejs": "^2.6.1",
         "find-free-port": "^2.0.0",
         "fs-extra": "^7.0.1",
-        "generator-fabric": "0.1.3",
+        "generator-fabric": "0.1.4",
         "handlebars": "^4.5.3",
         "home-dir": "1.0.0",
         "ibm-blockchain-platform-common": "^1.0.19",


### PR DESCRIPTION
The new generator version no longer uses nexus.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>