### PR TITLE
Fix error when no instantiated smart contracts to upgrade

### DIFF
--- a/packages/blockchain-extension/extension/commands/UserInputUtil.ts
+++ b/packages/blockchain-extension/extension/commands/UserInputUtil.ts
@@ -614,7 +614,8 @@ export class UserInputUtil {
         }
 
         if (instantiatedChaincodes.length === 0) {
-            outputAdapter.log(LogType.ERROR, 'Local runtime has no instantiated chaincodes');
+            const gatewayRegistryEntry: FabricGatewayRegistryEntry = await FabricGatewayConnectionManager.instance().getGatewayRegistryEntry();
+            outputAdapter.log(LogType.ERROR, `${gatewayRegistryEntry.name} has no instantiated chaincodes`);
             return;
         }
 
@@ -657,7 +658,8 @@ export class UserInputUtil {
         }
 
         if (instantiatedChaincodes.length === 0) {
-            outputAdapter.log(LogType.ERROR, 'Local runtime has no instantiated chaincodes');
+            const environmentName: string = FabricEnvironmentManager.instance().getEnvironmentRegistryEntry().name;
+            outputAdapter.log(LogType.ERROR, `${environmentName} has no instantiated chaincodes`);
             return;
         }
 

--- a/packages/blockchain-extension/extension/commands/upgradeCommand.ts
+++ b/packages/blockchain-extension/extension/commands/upgradeCommand.ts
@@ -87,6 +87,9 @@ export async function upgradeSmartContract(treeItem?: BlockchainTreeItem, channe
         peerNames = chosenChannel.data;
         // We should now ask for the instantiated smart contract to upgrade
         const initialSmartContract: IBlockchainQuickPickItem<{ name: string, channel: string, version: string }> = await UserInputUtil.showRuntimeInstantiatedSmartContractsQuickPick('Select the instantiated smart contract to upgrade', channelName);
+        if (!initialSmartContract) {
+            return;
+        }
         contractName = initialSmartContract.data.name;
         contractVersion = initialSmartContract.data.version;
 
@@ -98,9 +101,9 @@ export async function upgradeSmartContract(treeItem?: BlockchainTreeItem, channe
         let chosenChaincode: IBlockchainQuickPickItem<{ packageEntry: PackageRegistryEntry, workspace: vscode.WorkspaceFolder }>;
 
         if (vscode.debug.activeDebugSession && vscode.debug.activeDebugSession.configuration.debugEvent === FabricDebugConfigurationProvider.debugEvent) {
-             // Upgrade command called from debug session - get the chaincode ID name
-             smartContractName = vscode.debug.activeDebugSession.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[0];
-             smartContractVersion = vscode.debug.activeDebugSession.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[1];
+            // Upgrade command called from debug session - get the chaincode ID name
+            smartContractName = vscode.debug.activeDebugSession.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[0];
+            smartContractVersion = vscode.debug.activeDebugSession.configuration.env.CORE_CHAINCODE_ID_NAME.split(':')[1];
         } else {
             // If not called from debug session, ask for smart contract to upgrade with
             chosenChaincode = await UserInputUtil.showChaincodeAndVersionQuickPick('Select the smart contract version to perform an upgrade with', channelName, peerNames, contractName, contractVersion);

--- a/packages/blockchain-extension/test/commands/upgradeCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/upgradeCommand.test.ts
@@ -69,6 +69,7 @@ describe('UpgradeCommand', () => {
         let openDialogOptions: any;
         let policyObject: any;
         let policyString: string;
+        let showRuntimeInstantiatedSmartContractsQuickPickStub: sinon.SinonStub;
         beforeEach(async function(): Promise<void> {
 
             // TODO JAKE: does this actually work though
@@ -122,7 +123,7 @@ describe('UpgradeCommand', () => {
                 }
             );
 
-            mySandBox.stub(UserInputUtil, 'showRuntimeInstantiatedSmartContractsQuickPick').withArgs('Select the instantiated smart contract to upgrade', 'channelOne').resolves(
+            showRuntimeInstantiatedSmartContractsQuickPickStub = mySandBox.stub(UserInputUtil, 'showRuntimeInstantiatedSmartContractsQuickPick').withArgs('Select the instantiated smart contract to upgrade', 'channelOne').resolves(
                 { label: 'biscuit-network@0.0.1', data: { name: 'biscuit-network', channel: 'channelOne', version: '0.0.1' } }
             );
 
@@ -372,6 +373,15 @@ describe('UpgradeCommand', () => {
         });
 
         it('should handle choosing channel being cancelled', async () => {
+            showRuntimeInstantiatedSmartContractsQuickPickStub.resolves();
+
+            await vscode.commands.executeCommand(ExtensionCommands.UPGRADE_SMART_CONTRACT);
+
+            fabricRuntimeMock.upgradeChaincode.should.not.have.been.called;
+            dockerLogSpy.should.not.have.been.called;
+        });
+
+        it('should handle choosing cancel when choosing contract to upgrade', async () => {
             showChannelQuickPickStub.resolves();
 
             await vscode.commands.executeCommand(ExtensionCommands.UPGRADE_SMART_CONTRACT);


### PR DESCRIPTION
Fixed the error so it will exit out of the command when no smart contracts
Fixed the message as it mentioned Local runtime rather than environment name
Fixed erorr message when no contracts in a gateway to choose from as that also mentioned local runtime

closes #1970
Signed-off-by: Caroline Fletcher <cazfletch@gmail.com>