### PR TITLE
Adding skeleton for new tutorial page

### DIFF
--- a/packages/blockchain-ui/enzyme/tests/App.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/App.test.tsx
@@ -34,4 +34,16 @@ describe('App', () => {
         dispatchEvent(msg);
         component.state().redirectPath.should.equal('/home');
     });
+
+    it('should redirect to the tutorial page', async () => {
+        const component: any = mount(<App/>);
+
+        const msg: MessageEvent = new MessageEvent('message', {
+            data: {
+                path: '/tutorials'
+            }
+        });
+        dispatchEvent(msg);
+        component.state().redirectPath.should.equal('/tutorials');
+    });
 });

--- a/packages/blockchain-ui/enzyme/tests/CustomTile.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/CustomTile.test.tsx
@@ -7,7 +7,6 @@ import sinonChai from 'sinon-chai';
 
 import CustomTile from '../../src/components/elements/CustomTile/CustomTile';
 import Utils from '../../src/Utils';
-import { ExtensionCommands } from '../../src/ExtensionCommands';
 
 chai.should();
 chai.use(sinonChai);
@@ -15,10 +14,12 @@ chai.use(sinonChai);
 describe('CustomTile component', () => {
     let mySandBox: sinon.SinonSandbox;
     let postToVSCodeStub: sinon.SinonStub;
+    let changeRouteStub: sinon.SinonStub;
 
     beforeEach(() => {
         mySandBox = sinon.createSandbox();
         postToVSCodeStub = mySandBox.stub(Utils, 'postToVSCode').resolves();
+        changeRouteStub = mySandBox.stub(Utils, 'changeRoute').resolves();
     });
 
     afterEach(() => {
@@ -26,17 +27,38 @@ describe('CustomTile component', () => {
     });
 
     it('should render the expected snapshot', () => {
+        const options: {actionType: 'app' | 'vscode', command: string} = {
+            actionType: 'vscode',
+            command: 'some_command'
+        };
+
         const component: any = renderer
-            .create(<CustomTile title='My Tile' body='Some text I want to display in my tile'/>)
+            .create(<CustomTile title='My Tile' body='Some text I want to display in my tile' options={options}/>)
             .toJSON();
         expect(component).toMatchSnapshot();
     });
 
-    it('should post to VS Code when the tile is clicked', () => {
-        const component: any = mount(<CustomTile title='My Tile' body='Some text I want to display in my tile'/>);
+    it('should post to VS Code', () => {
+        const options: {actionType: 'app' | 'vscode', command: string} = {
+            actionType: 'vscode',
+            command: 'some_command'
+        };
+
+        const component: any = mount(<CustomTile title='My Tile' body='Some text I want to display in my tile' options={options}/>);
         component.find('.bx--tile').simulate('click');
         postToVSCodeStub.should.have.been.calledOnceWithExactly({
-            command: ExtensionCommands.OPEN_TUTORIAL_GALLERY
+            command: options.command
         });
+    });
+
+    it('should redirect to another link in the app', () => {
+        const options: {actionType: 'app' | 'vscode', path: string} = {
+            actionType: 'app',
+            path: 'some/path'
+        };
+
+        const component: any = mount(<CustomTile title='My Tile' body='Some text I want to display in my tile' options={options}/>);
+        component.find('.bx--tile').simulate('click');
+        changeRouteStub.should.have.been.calledOnceWithExactly(options.path);
     });
 });

--- a/packages/blockchain-ui/enzyme/tests/TutorialPage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TutorialPage.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+
+import TutorialPage from '../../src/components/pages/TutorialPage/TutorialPage';
+
+chai.should();
+chai.use(sinonChai);
+
+describe('TutorialPage component', () => {
+    it('should render the expected snapshot', () => {
+        const component: any = renderer
+            .create(<TutorialPage/>)
+            .toJSON();
+        expect(component).toMatchSnapshot();
+    });
+});

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TutorialPage.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TutorialPage.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TutorialPage component should render the expected snapshot 1`] = `
+<div
+  className="bx--grid tutorial-page-container"
+>
+  <div
+    className="bx--row"
+  >
+    <div
+      className="heading-combo-container"
+    >
+      <h3>
+        Blockchain Tutorials
+      </h3>
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/blockchain-ui/src/App.tsx
+++ b/packages/blockchain-ui/src/App.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import './App.scss';
 import { HashRouter as Router, Route, Redirect } from 'react-router-dom';
 import HomePage from './components/pages/HomePage/HomePage';
+import TutorialPage from './components/pages/TutorialPage/TutorialPage';
 
 interface AppState {
     redirectPath: string;
@@ -36,6 +37,9 @@ class App extends Component<{}, AppState> {
                         <Route render={(): JSX.Element => <Redirect push to={this.state.redirectPath}/>}></Route>
                         <Route exact path='/home' render={(): JSX.Element =>
                             <HomePage extensionVersion={this.state.extensionVersion}/>}>
+                        </Route>
+                        <Route exact path='/tutorials' render={(): JSX.Element =>
+                            <TutorialPage/>}>
                         </Route>
                     </div>
                 </Router>

--- a/packages/blockchain-ui/src/components/elements/CustomTile/CustomTile.tsx
+++ b/packages/blockchain-ui/src/components/elements/CustomTile/CustomTile.tsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Tile } from 'carbon-components-react';
 import HeadingCombo from '../HeadingCombo/HeadingCombo';
-import { ExtensionCommands } from '../../../ExtensionCommands';
 import Utils from '../../../Utils';
 import newTabImg from '../../../resources/new-tab.svg';
 import './CustomTile.scss';
@@ -9,6 +8,7 @@ import './CustomTile.scss';
 interface IProps {
     title: string;
     body: string;
+    options: { actionType: 'app' | 'vscode', command?: string, path?: string };
 }
 
 class CustomTile extends Component <IProps> {
@@ -19,9 +19,13 @@ class CustomTile extends Component <IProps> {
     }
 
     tileClickHandler(): void {
-        Utils.postToVSCode({
-            command: ExtensionCommands.OPEN_TUTORIAL_GALLERY
-        });
+        if (this.props.options.actionType === 'app') {
+            Utils.changeRoute(this.props.options.path);
+        } else {
+            Utils.postToVSCode({
+                command: this.props.options.command
+            });
+        }
     }
 
     render(): JSX.Element {

--- a/packages/blockchain-ui/src/components/pages/HomePage/HomePage.tsx
+++ b/packages/blockchain-ui/src/components/pages/HomePage/HomePage.tsx
@@ -18,6 +18,16 @@ class HomePage extends Component<IProps> {
     render(): JSX.Element {
         const tutorialTileString: string = 'Complete tutorials to level up your Fabric development skills. Earn rewards such as badges and access to our developer community by completing lessons.';
 
+        // to access the new react tutorial page, comment out the first customTileOptions and use the second one instead
+        const customTileOptions: {actionType: 'app' | 'vscode', command: string} = {
+            actionType: 'vscode',
+            command: ExtensionCommands.OPEN_TUTORIAL_GALLERY
+        };
+        // const customTileOptions: {actionType: 'app' | 'vscode', path: string} = {
+        //     actionType: 'app',
+        //     path: 'tutorials'
+        // };
+
         return (
             <div className='bx--grid home-page-container'>
                 <div className='bx--row'>
@@ -29,7 +39,7 @@ class HomePage extends Component<IProps> {
                             <p className='home-title-description'>This extension supports the complete development workflow for Hyperledger Fabric and IBM Blockchain Platform. Get started, learn best practices and earn developer qualifications with our tutorials.</p>
                         </div>
                         <div className='bx--row' id='tutorial-tile-container'>
-                            <CustomTile title='Tutorials' body={tutorialTileString}/>
+                            <CustomTile title='Tutorials' body={tutorialTileString} options={customTileOptions}/>
                         </div>
                         <HeadingCombo
                             comboStyle='bx--row resources-title-container'

--- a/packages/blockchain-ui/src/components/pages/TutorialPage/TutorialPage.scss
+++ b/packages/blockchain-ui/src/components/pages/TutorialPage/TutorialPage.scss
@@ -1,0 +1,7 @@
+@import '../../../mixins/layout-mixins.scss';
+
+.tutorial-page-container {
+    @include default-page-styling;
+    margin-left: $spacing-05;
+    margin-top: $spacing-05;
+}

--- a/packages/blockchain-ui/src/components/pages/TutorialPage/TutorialPage.tsx
+++ b/packages/blockchain-ui/src/components/pages/TutorialPage/TutorialPage.tsx
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import HeadingCombo from '../../elements/HeadingCombo/HeadingCombo';
+import './TutorialPage.scss';
+
+class TutorialPage extends Component {
+    render(): JSX.Element {
+        return (
+            <div className='bx--grid tutorial-page-container'>
+                <div className='bx--row'>
+                    <HeadingCombo
+                        headingText='Blockchain Tutorials'
+                        subheadingText='Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.'
+                    />
+                </div>
+            </div>
+        );
+    }
+}
+
+export default TutorialPage;


### PR DESCRIPTION
To access the (very limited) content on the new tutorial page, go to `HomePage.tsx`, comment out the first `customTileOptions` object, and uncomment the second one.

Closes #2133 

Signed-off-by: Erin Hughes <Erin.Hughes@ibm.com>