### PR TITLE
IBM OpsTools - use current login when adding environment. Closes #2171

### DIFF
--- a/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
@@ -315,7 +315,7 @@ export async function addEnvironment(): Promise<void> {
 
     async function getOpsToolsAccessInfoSaaS(): Promise<string[]> {
         const ibpResources: IBlockchainQuickPickItem<string>[] = [];
-        const accessToken: string = await ExtensionsInteractionUtil.cloudAccountGetAccessToken(true);
+        const accessToken: string = await ExtensionsInteractionUtil.cloudAccountGetAccessToken();
         if (!accessToken) {
             return;
         }


### PR DESCRIPTION
Also throws error if cloud login extension not installed.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>