### PR TITLE
Connect to IBM cloud - multi-node orderer fixes and word changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,9 @@ The extension allow you to connect to any Hyperledger Fabric instance and perfor
 
 To connect to a Hyperledger Fabric instance on the `Fabric Environments` panel click the `+` button. This will ask you for JSON node files that describe how to connect to a Hyperledger Fabric Node i.e. peer, orderer, or certificate authority.
 
-If you are connecting to an instance of IBM Blockchain Platform console on IBM Cloud the JSON node files can be exported, (see the tutorials for more information).
+If you are connecting to an instance of IBM Blockchain Platform console on IBM Cloud, you can add an environment by connecting directly to the console. You will be able to login to IBM Cloud using username and password, API key or single sign-on, as well as create a new account if you don't already have one. Once the environment is created, if you prefer to work whilst logged out and do not want to be prompted to login on connect, you can disable 'Poll For Config Updates When Connected To IBM Blockchain Platform On IBM Cloud Environments' in the user settings.
 
-If connecting to an IBM Blockchain Platform console software version, you can add an environment by connecting directly to the console. When prompted for authentication credentials you can either provide User ID and password, or API key and API secret.
+If connecting to an IBM Blockchain Platform console software version, you can also add an environment by connecting directly to the console. When prompted for authentication credentials you can either provide User ID and password, or API key and API secret.
 
 For other instances of Hyperledger Fabric you can create the JSON node files yourself.
 

--- a/azure-templates/extension-unit-test-steps.yml
+++ b/azure-templates/extension-unit-test-steps.yml
@@ -17,7 +17,6 @@ steps:
       npm test
     env:
       DISPLAY: ':99.0'
-      JSON_DIR: $(Agent.TempDirectory)
     displayName: Run unit tests
     condition: succeeded()
 

--- a/packages/blockchain-common/src/environments/FabricEnvironment.ts
+++ b/packages/blockchain-common/src/environments/FabricEnvironment.ts
@@ -74,6 +74,26 @@ export class FabricEnvironment extends EventEmitter {
         const nodesToUpdate: FabricNode[] = [];
         const allNodes: FabricNode[] = await this.getNodes(false, true);
 
+        if (isOpsTools) {
+            // If this node already exists keep wallet and identity properties.
+            // Check name matches, if not rename the node JSON file.
+            const allUrls: string[] = allNodes.map((_node: FabricNode) => _node.api_url);
+            const index: number = allUrls.indexOf(node.api_url);
+            if (index > -1) {
+                if (allNodes[index].wallet !== undefined) {
+                    node.wallet = allNodes[index].wallet;
+                }
+                if (allNodes[index].identity !== undefined) {
+                    node.identity = allNodes[index].identity;
+                }
+                if (allNodes[index].name !== undefined && node.name !== allNodes[index].name) {
+                    const newNodePath: string = path.resolve(nodesPath, `${node.name}.json`);
+                    const oldNodePath: string = path.resolve(nodesPath, `${allNodes[index].name}.json`);
+                    await fs.move(oldNodePath, newNodePath);
+                }
+            }
+        }
+
         if (node.type === FabricNodeType.ORDERER) {
             // need to also update all the nodes in the same cluster
             const ordererNodes: FabricNode[] = allNodes.filter((_node: FabricNode) => {
@@ -81,31 +101,13 @@ export class FabricEnvironment extends EventEmitter {
             }).map((_node: FabricNode) => {
                 _node.wallet = node.wallet;
                 _node.identity = node.identity;
+                _node.hidden = node.hidden;
                 return _node;
             });
 
             nodesToUpdate.push(...ordererNodes);
         }
 
-        if (isOpsTools) {
-            // If this node already exists keep wallet and identity properties.
-            // Check name matches, if not rename the node JSON file.
-            const allUrls: string[] = allNodes.map((_node: FabricNode) => _node.api_url);
-            const index: number = allUrls.indexOf(node.api_url);
-            if (index > -1) {
-                if (allNodes[index].wallet) {
-                    node.wallet = allNodes[index].wallet;
-                }
-                if (allNodes[index].identity) {
-                    node.identity = allNodes[index].identity;
-                }
-                if (node.name !== allNodes[index].name) {
-                    const newNodePath: string = path.resolve(nodesPath, `${node.name}.json`);
-                    const oldNodePath: string = path.resolve(nodesPath, `${allNodes[index].name}.json`);
-                    await fs.move(oldNodePath, newNodePath);
-                }
-            }
-        }
         // always needs to update itself
         nodesToUpdate.push(node);
 

--- a/packages/blockchain-common/test/environments/FabricEnvironment.test.ts
+++ b/packages/blockchain-common/test/environments/FabricEnvironment.test.ts
@@ -309,6 +309,46 @@ describe('FabricEnvironment', () => {
             moveStub.should.not.have.been.called;
             writeStub.should.have.been.calledWith(nodePath, updatedNode);
         });
+
+        it('should update node with wallet and identity of existing Ops Tools node if those fields no not exist on new version of the node - multi-node orderer ', async () => {
+            const existingNode1: FabricNode = FabricNode.newOrderer('order1', 'orderer1.example.com', 'http://localhost:17056', 'myWallet', 'myIdentity', 'osmsp', 'myCluster');
+            const existingNode2: FabricNode = FabricNode.newOrderer('order2', 'orderer2.example.com', 'http://localhost:17057', 'myWallet', 'myIdentity', 'osmsp', 'myCluster');
+            const newVersionNode1: FabricNode = FabricNode.newOrderer('order1', 'orderer1.example.com', 'http://localhost:17056', undefined, undefined, 'osmsp', 'myCluster');
+
+            sandbox.stub(environment, 'getNodes').resolves([existingNode1, existingNode2]);
+
+            const nodePath1: string = path.join(environmentPath, 'nodes', 'orderer1.example.com.json');
+            const nodePath2: string = path.join(environmentPath, 'nodes', 'orderer2.example.com.json');
+            const moveStub: sinon.SinonStub = sandbox.stub(fs, 'move');
+            const writeStub: sinon.SinonStub = sandbox.stub(fs, 'writeJson');
+
+            await environment.updateNode(newVersionNode1, true);
+
+            moveStub.should.not.have.been.called;
+            writeStub.should.have.been.calledWith(nodePath1, existingNode1);
+            writeStub.should.have.been.calledWith(nodePath2, existingNode2);
+        });
+
+        it('should hide all nodes in multi-node orderer on ops tools environment', async () => {
+            const existingNode1: FabricNode = FabricNode.newOrderer('order1', 'orderer1.example.com', 'http://localhost:17056', 'myWallet', 'myIdentity', 'osmsp', 'myCluster');
+            const existingNode2: FabricNode = FabricNode.newOrderer('order2', 'orderer2.example.com', 'http://localhost:17057', 'myWallet', 'myIdentity', 'osmsp', 'myCluster');
+            const newVersionNode1: FabricNode = FabricNode.newOrderer('order1', 'orderer1.example.com', 'http://localhost:17056', 'myWallet', 'myIdentity', 'osmsp', 'myCluster', true);
+            const expectedNode1: FabricNode = FabricNode.newOrderer('order1', 'orderer1.example.com', 'http://localhost:17056', 'myWallet', 'myIdentity', 'osmsp', 'myCluster', true);
+            const expectedNode2: FabricNode = FabricNode.newOrderer('order2', 'orderer2.example.com', 'http://localhost:17057', 'myWallet', 'myIdentity', 'osmsp', 'myCluster', true);
+
+            sandbox.stub(environment, 'getNodes').resolves([existingNode1, existingNode2]);
+
+            const nodePath1: string = path.join(environmentPath, 'nodes', 'orderer1.example.com.json');
+            const nodePath2: string = path.join(environmentPath, 'nodes', 'orderer2.example.com.json');
+            const moveStub: sinon.SinonStub = sandbox.stub(fs, 'move');
+            const writeStub: sinon.SinonStub = sandbox.stub(fs, 'writeJson');
+
+            await environment.updateNode(newVersionNode1);
+
+            moveStub.should.not.have.been.called;
+            writeStub.should.have.been.calledWith(nodePath1, expectedNode1);
+            writeStub.should.have.been.calledWith(nodePath2, expectedNode2);
+        });
     });
 
     describe('#deleteNode', () => {

--- a/packages/blockchain-extension/configurations.ts
+++ b/packages/blockchain-extension/configurations.ts
@@ -32,7 +32,7 @@ export class SettingConfigurations {
     static readonly EXTENSION_DIRECTORY: string = 'ibm-blockchain-platform.ext.directory';
     static readonly EXTENSION_BYPASS_PREREQS: string = 'ibm-blockchain-platform.ext.bypassPreReqs';
     static readonly EXTENSION_LOCAL_FABRIC: string = 'ibm-blockchain-platform.ext.enableLocalFabric';
-    static readonly EXTENSION_REQUIRE_CLOUD_LOGIN: string = 'ibm-blockchain-platform.ext.requireCloudLogin';
+    static readonly EXTENSION_SAAS_CONFIG_UPDATES: string = 'ibm-blockchain-platform.ext.PollForConfigUpdatesWhenConnectedToIBM BlockchainPlatformOnIBM CloudEnvironments';
 
     // HOME CONFIGURATIONS
     static readonly HOME_SHOW_ON_STARTUP: string = 'ibm-blockchain-platform.home.showOnStartup';

--- a/packages/blockchain-extension/cucumber/helpers/environmentHelper.ts
+++ b/packages/blockchain-extension/cucumber/helpers/environmentHelper.ts
@@ -65,9 +65,9 @@ export class EnvironmentHelper {
                 // Connect to OpsTools and create environment without nodes
                 this.userInputUtilHelper.showQuickPickItemStub.withArgs('Select a method to add an environment').resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
                 if (opsType === 'SaaS') {
-                    this.userInputUtilHelper.showYesNoQuickPick.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+                    this.userInputUtilHelper.showYesNoQuickPick.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
                 } else if (opsType === 'software') {
-                    this.userInputUtilHelper.showYesNoQuickPick.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.NO);
+                    this.userInputUtilHelper.showYesNoQuickPick.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.NO);
                     this.userInputUtilHelper.inputBoxStub.withArgs('Enter the URL of the IBM Blockchain Platform Console you want to connect to').resolves(process.env.MAP_OPSTOOLS_URL);
                     this.userInputUtilHelper.inputBoxStub.withArgs('Enter the API key or the User ID of the IBM Blockchain Platform Console you want to connect to').resolves(process.env.MAP_OPSTOOLS_KEY);
                     this.userInputUtilHelper.inputBoxStub.withArgs('Enter the API secret or the password of the IBM Blockchain Platform Console you want to connect to').resolves(process.env.MAP_OPSTOOLS_SECRET);

--- a/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
@@ -100,7 +100,7 @@ export async function addEnvironment(): Promise<void> {
 
         } else if (createMethod === UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS) {
 
-            const isSaaS: string = await UserInputUtil.showQuickPickYesNo('Are you connecting to a service instance on IBM Cloud?');
+            const isSaaS: string = await UserInputUtil.showQuickPickYesNo('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?');
             if (!isSaaS) {
                 return;
             } else if (isSaaS === UserInputUtil.NO) {

--- a/packages/blockchain-extension/extension/commands/environmentConnectCommand.ts
+++ b/packages/blockchain-extension/extension/commands/environmentConnectCommand.ts
@@ -133,7 +133,7 @@ export async function fabricEnvironmentConnect(fabricEnvironmentRegistryEntry: F
             envType = 'Fabric Network created via JSON files';
         } else if (fabricEnvironmentRegistryEntry.environmentType === EnvironmentType.ANSIBLE_ENVIRONMENT) {
             envType = 'Network created using Ansible';
-        } else if (fabricEnvironmentRegistryEntry.environmentType === EnvironmentType.OPS_TOOLS_ENVIRONMENT) {
+        } else if (fabricEnvironmentRegistryEntry.environmentType === EnvironmentType.OPS_TOOLS_ENVIRONMENT || fabricEnvironmentRegistryEntry.environmentType === EnvironmentType.SAAS_OPS_TOOLS_ENVIRONMENT) {
             envType = 'Ops Tools network';
         } else {
             envType = 'Local network';

--- a/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
@@ -159,7 +159,7 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
                 if (environmentRegistryEntry.environmentType === EnvironmentType.SAAS_OPS_TOOLS_ENVIRONMENT) {
                     let askUserInput: boolean;
                     if ( fromConnectEnvironment ) {
-                        askUserInput = ExtensionUtil.getExtensionRequireCloudLoginSetting();
+                        askUserInput = ExtensionUtil.getExtensionSaasConfigUpdatesSetting();
                     } else {
                         askUserInput = true;
                     }

--- a/packages/blockchain-extension/extension/util/ExtensionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionUtil.ts
@@ -824,8 +824,8 @@ export class ExtensionUtil {
         return vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_LOCAL_FABRIC);
     }
 
-    public static getExtensionRequireCloudLoginSetting(): boolean {
-        return vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_REQUIRE_CLOUD_LOGIN);
+    public static getExtensionSaasConfigUpdatesSetting(): boolean {
+        return vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_SAAS_CONFIG_UPDATES);
     }
 
     private static getExtension(): vscode.Extension<any> {

--- a/packages/blockchain-extension/package.json
+++ b/packages/blockchain-extension/package.json
@@ -201,10 +201,10 @@
                     "default": true,
                     "description": "Allow this extension to use Docker and Docker Compose to run a simple pre-configured local Hyperledger Fabric network.\n\nIf you change this setting whilst the Prerequistes page is open, you may need to close it and re-open it for the changes to take effect."
                 },
-                "ibm-blockchain-platform.ext.requireCloudLogin": {
+                "ibm-blockchain-platform.ext.PollForConfigUpdatesWhenConnectedToIBM BlockchainPlatformOnIBM CloudEnvironments": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Always require IBM Cloud login when connecting to existing IBM Blockchain Platform on IBM Cloud"
+                    "description": "Disabling this option prevents repeated prompts when not logged in to IBM Cloud. You will still be asked to log in if you try to perform an action that requires you to be logged in (e.g. editing node filters)."
                 }
             }
         },

--- a/packages/blockchain-extension/test/commands/addEnvironmentCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/addEnvironmentCommand.test.ts
@@ -111,7 +111,7 @@ describe('AddEnvironmentCommand', () => {
             // Ops tools requirements
             axiosGetStub = mySandBox.stub(Axios, 'get');
             showQuickPickYesNoStub = mySandBox.stub(UserInputUtil, 'showQuickPickYesNo').callThrough();
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.NO);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.NO);
 
             url = 'https://my.OpsTool.url';
             userAuth1 = 'myOpsToolKey';
@@ -1021,7 +1021,7 @@ describe('AddEnvironmentCommand', () => {
 
         it('should handle when user cancels while choosing location of the OpsTool instance', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves();
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves();
 
             await vscode.commands.executeCommand(ExtensionCommands.ADD_ENVIRONMENT);
 
@@ -1039,10 +1039,10 @@ describe('AddEnvironmentCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Add environment');
         });
 
-        it('should suggest default name when adding environment from a SaaS OpsTool instance (SaaA)', async () => {
+        it('should suggest default name when adding environment from a SaaS OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().returnsArg(1);
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             axiosGetStub.onFirstCall().resolves(resourcesResponseMock);
             axiosGetStub.onSecondCall().resolves(consoleStatusMock);
 
@@ -1068,10 +1068,10 @@ describe('AddEnvironmentCommand', () => {
             sendTelemetryEventStub.should.have.been.calledOnceWithExactly('addEnvironmentCommand');
         });
 
-        it('should handle errors getting the access token when adding an OpsTool instance (SaaA)', async () => {
+        it('should handle errors getting the access token when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             const error: Error = new Error('some error');
             cloudAccountGetAccessTokenStub.rejects(error);
 
@@ -1092,9 +1092,9 @@ describe('AddEnvironmentCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Failed to add a new environment: ${error.message}`, `Failed to add a new environment: ${error.toString()}`);
         });
 
-        it('should handle user canceling while getting access token when adding an OpsTool instance (SaaA)', async () => {
+        it('should handle user canceling while getting access token when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             cloudAccountGetAccessTokenStub.resolves();
 
             await vscode.commands.executeCommand(ExtensionCommands.ADD_ENVIRONMENT);
@@ -1113,10 +1113,10 @@ describe('AddEnvironmentCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Add environment');
         });
 
-        it('should handle more than one page of resources when adding an OpsTool instance (SaaA)', async () => {
+        it('should handle more than one page of resources when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             axiosGetStub.onFirstCall().resolves({
                 data: {
                     next_url: '/some/resource/path',
@@ -1149,10 +1149,10 @@ describe('AddEnvironmentCommand', () => {
 
         });
 
-        it('should fail if there are no IBM Blockchain Platform resources for the selected account when adding an OpsTool instance (SaaA)', async () => {
+        it('should fail if there are no IBM Blockchain Platform resources for the selected account when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             const noBlockchainError: Error = new Error('There are no IBM Blockchain Platform service instances associated with the chosen account');
             axiosGetStub.onFirstCall().resolves({
                 data: {
@@ -1183,10 +1183,10 @@ describe('AddEnvironmentCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Failed to add a new environment: ${noBlockchainError.message}`, `Failed to add a new environment: ${noBlockchainError.toString()}`);
         });
 
-        it('should ask user to select resource if more than one IBM Blockchain platform exists when adding an OpsTool instance (SaaA)', async () => {
+        it('should ask user to select resource if more than one IBM Blockchain platform exists when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             axiosGetStub.onFirstCall().resolves({
                 data: {
                         next_url: null,
@@ -1237,10 +1237,10 @@ describe('AddEnvironmentCommand', () => {
             sendTelemetryEventStub.should.have.been.calledOnceWithExactly('addEnvironmentCommand');
         });
 
-        it('should handle user canceling while selecting an IBM Blockchain platform when adding an OpsTool instance (SaaA)', async () => {
+        it('should handle user canceling while selecting an IBM Blockchain platform when adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             axiosGetStub.onFirstCall().resolves({
                 data: {
                         next_url: null,
@@ -1274,10 +1274,10 @@ describe('AddEnvironmentCommand', () => {
             logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Add environment');
         });
 
-        it('should fail if OpsTools not deployed adding an OpsTool instance (SaaA)', async () => {
+        it('should fail if OpsTools not deployed adding an OpsTool instance (SaaS)', async () => {
             chooseMethodStub.resolves({data: UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS});
             chooseNameStub.onFirstCall().resolves('mySaaSOpsToolsEnvironment');
-            showQuickPickYesNoStub.withArgs('Are you connecting to a service instance on IBM Cloud?').resolves(UserInputUtil.YES);
+            showQuickPickYesNoStub.withArgs('Are you connecting to an IBM Blockchain Platform service instance on IBM Cloud?').resolves(UserInputUtil.YES);
             axiosGetStub.onFirstCall().resolves(resourcesResponseMock);
             axiosGetStub.onSecondCall().resolves({
                 status: 100,

--- a/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
+++ b/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
@@ -2505,10 +2505,10 @@ describe('ExtensionUtil Tests', () => {
 
     });
 
-    describe('getExtensionRequireCloudLoginSetting', () => {
+    describe('getExtensionSaasConfigUpdatesSetting', () => {
         it('should get required cloud login setting', async () => {
 
-            const result: any = ExtensionUtil.getExtensionRequireCloudLoginSetting();
+            const result: any = ExtensionUtil.getExtensionSaasConfigUpdatesSetting();
             result.should.deep.equal( true );
         });
     });


### PR DESCRIPTION
Fixes:

- [X] update the readme file
- [x] Wording of toggle setting
- [X] Wording of yes/no prompt for selecting service location
- [x] Associate identity with multi-node orderer only once
- [x] Hide multi-node orderer from tree
\# Wording of 'out of date' message: Not done as Ed was happy with the wording.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>