### PR TITLE
Added OpenSSL prereq tooltip (close #2298)

### DIFF
--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -255,7 +255,7 @@ export class DependencyManager {
             if (localFabricEnabled) {
                 dependencies.dockerForWindows = { name: 'Docker for Windows', id: 'dockerForWindows', complete: undefined, checkbox: true, required: true, text: 'Docker for Windows must be configured to use Linux containers (this is the default)' };
 
-                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively' };
+                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively', tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
                 dependencies.buildTools = { name: 'C++ Build Tools', required: true, version: undefined, url: 'https://github.com/felixrieseberg/windows-build-tools#windows-build-tools', requiredVersion: undefined, requiredLabel: undefined };
                 try {
                     const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);


### PR DESCRIPTION
Tooltip gets shown on the Prereq page - instructs Windows users to install OpenSSL in the correct location.
Signed-off-by: Jake Turner <jaketurner25@live.com>