### PR TITLE
Add api_options and chaincode_options to a peer/orderer (resolves #2312)

### DIFF
--- a/packages/blockchain-common/src/fabricModel/FabricNode.ts
+++ b/packages/blockchain-common/src/fabricModel/FabricNode.ts
@@ -105,6 +105,7 @@ export class FabricNode {
     public display_name?: string;
     public type: FabricNodeType;
     public api_url: string;
+    public api_options?: object;
     public ca_name?: string;
     public pem?: string;
     public tls_cert?: string;
@@ -115,6 +116,7 @@ export class FabricNode {
     public msp_id?: string;
     public container_name?: string;
     public chaincode_url?: string;
+    public chaincode_options?: object;
     public enroll_secret?: string;
     public enroll_id?: string;
     public cluster_name?: string;

--- a/packages/blockchain-environment-v1/test/FabricEnvironmentConnection.test.ts
+++ b/packages/blockchain-environment-v1/test/FabricEnvironmentConnection.test.ts
@@ -203,6 +203,31 @@ describe('FabricEnvironmentConnection', () => {
             characteristics.url.should.equal('grpc://localhost:7051');
         });
 
+        it('should create peer clients for each peer node with API options', async () => {
+            const node: FabricNode = FabricNode.newPeer(
+                'org1peer',
+                'Org1 Peer',
+                `grpc://localhost:8080`,
+                `Org1`,
+                FabricRuntimeUtil.ADMIN_USER,
+                'Org1MSP'
+            );
+            node.api_options = {
+                'grpc.default_authority': 'org1peer.127-0-0-1.nip.io:8080',
+                'grpc.ssl_target_name_override': 'org1peer.127-0-0-1.nip.io:8080'
+            };
+            connection.disconnect();
+            await connection.connect([node]);
+            const peerNames: string[] = Array.from(connection['peers'].keys());
+            const peerValues: Client.Peer[] = Array.from(connection['peers'].values());
+            peerNames.should.deep.equal(['Org1 Peer']);
+            peerValues.should.have.lengthOf(1);
+            peerValues[0].should.be.an.instanceOf(Client.Peer);
+            const characteristics: any = peerValues[0]['getCharacteristics']();
+            characteristics.name.should.equal('org1peer.127-0-0-1.nip.io:8080');
+            characteristics.url.should.equal('grpc://localhost:8080');
+        });
+
         it('should create secure peer clients for each secure peer node', async () => {
             const peerNames: string[] = Array.from(connection['peers'].keys());
             const peerValues: Client.Peer[] = Array.from(connection['peers'].values());
@@ -212,7 +237,6 @@ describe('FabricEnvironmentConnection', () => {
             const characteristics: any = peerValues[3]['getCharacteristics']();
             characteristics.name.should.equal('localhost:8051');
             characteristics.url.should.equal('grpcs://localhost:8051');
-            characteristics.options['grpc.ssl_target_name_override'].should.equal('localhost');
         });
 
         it('should create secure peer clients for each secure peer node with an SSL target name override', async () => {
@@ -249,6 +273,32 @@ describe('FabricEnvironmentConnection', () => {
             characteristics.url.should.equal('grpc://localhost:7050');
         });
 
+        it('should create orderer clients for each orderer node with API options', async () => {
+            const node: FabricNode = FabricNode.newOrderer(
+                'orderer',
+                'Orderer',
+                `grpc://localhost:8080`,
+                'Org1',
+                FabricRuntimeUtil.ADMIN_USER,
+                'OrdererMSP',
+                'myCluster'
+            );
+            node.api_options = {
+                'grpc.default_authority': 'orderer.127-0-0-1.nip.io:8080',
+                'grpc.ssl_target_name_override': 'orderer.127-0-0-1.nip.io:8080'
+            };
+            connection.disconnect();
+            await connection.connect([node]);
+            const ordererNames: string[] = Array.from(connection['orderers'].keys());
+            const ordererValues: Client.Orderer[] = Array.from(connection['orderers'].values());
+            ordererNames.should.deep.equal(['Orderer']);
+            ordererValues.should.have.lengthOf(1);
+            ordererValues[0].should.be.an.instanceOf(Client.Orderer);
+            const characteristics: any = ordererValues[0]['getCharacteristics']();
+            characteristics.name.should.equal('orderer.127-0-0-1.nip.io:8080');
+            characteristics.url.should.equal('grpc://localhost:8080');
+        });
+
         it('should create secure orderer clients for each secure orderer node', async () => {
             const ordererNames: string[] = Array.from(connection['orderers'].keys());
             const ordererValues: Client.Orderer[] = Array.from(connection['orderers'].values());
@@ -258,7 +308,6 @@ describe('FabricEnvironmentConnection', () => {
             const characteristics: any = ordererValues[1]['getCharacteristics']();
             characteristics.name.should.equal('localhost:8050');
             characteristics.url.should.equal('grpcs://localhost:8050');
-            characteristics.options['grpc.ssl_target_name_override'].should.equal('localhost');
         });
 
         it('should create secure orderer clients for each secure orderer node with an SSL target name override', async () => {


### PR DESCRIPTION
This PR adds the `api_options` and `chaincode_options` node properties that are used by Fablet to pass various required gRPC options. We need to merge these into the options that we pass into the Fabric SDK. We also need to change the name of the node from the default that the Fabric SDK picks so that the instantiate process can find the right ordering service.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>