### PR TITLE
Fall back to file system when keytar not available (resolves #2310)

### DIFF
--- a/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/addEnvironmentCommand.ts
@@ -22,7 +22,6 @@ import { Reporter } from '../util/Reporter';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { FabricEnvironmentRegistry, FabricEnvironmentRegistryEntry, LogType, EnvironmentType, FabricEnvironment, FabricNode, FabricRuntimeUtil, FileSystemUtil, FileConfigurations } from 'ibm-blockchain-platform-common';
 import { ExtensionCommands } from '../../ExtensionCommands';
-import { ModuleUtil } from '../util/ModuleUtil';
 import { EnvironmentFactory } from '../fabric/environments/EnvironmentFactory';
 import { LocalEnvironmentManager } from '../fabric/environments/LocalEnvironmentManager';
 import { SettingConfigurations } from '../../configurations';
@@ -31,6 +30,8 @@ import { GlobalState, ExtensionData } from '../util/GlobalState';
 import { URL } from 'url';
 import { ExtensionsInteractionUtil } from '../util/ExtensionsInteractionUtil';
 import { FeatureFlagManager } from '../util/FeatureFlags';
+import { SecureStore } from '../util/SecureStore';
+import { SecureStoreFactory } from '../util/SecureStoreFactory';
 
 export async function addEnvironment(): Promise<void> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -288,10 +289,7 @@ export async function addEnvironment(): Promise<void> {
     }
 
     async function getOpsToolsAccessInfo(): Promise<string> {
-        const keytar: any = ModuleUtil.getCoreNodeModule('keytar');
-        if (!keytar) {
-            throw new Error('Error importing the keytar module');
-        }
+        const secureStore: SecureStore = await SecureStoreFactory.getSecureStore();
 
         const HEALTH_CHECK: string = '/ak/api/v1/health';
         const GET_ALL_COMPONENTS: string = '/ak/api/v1/components';
@@ -350,7 +348,7 @@ export async function addEnvironment(): Promise<void> {
         }
         // Securely store API key and secret
         try {
-            await keytar.setPassword('blockchain-vscode-ext', url, `${userAuth1}:${userAuth2}:${requestOptions.httpsAgent.options.rejectUnauthorized}`);
+            await secureStore.setPassword('blockchain-vscode-ext', url, `${userAuth1}:${userAuth2}:${requestOptions.httpsAgent.options.rejectUnauthorized}`);
         } catch (errorStorePass) {
             throw new Error(`Unable to store the required credentials: ${errorStorePass.message}`);
         }

--- a/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
+++ b/packages/blockchain-extension/extension/commands/importNodesToEnvironmentCommand.ts
@@ -23,9 +23,10 @@ import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricEnvironmentManager } from '../fabric/environments/FabricEnvironmentManager';
 import { EnvironmentFactory } from '../fabric/environments/EnvironmentFactory';
 import Axios from 'axios';
-import { ModuleUtil } from '../util/ModuleUtil';
 import { ExtensionsInteractionUtil } from '../util/ExtensionsInteractionUtil';
 import { ExtensionUtil } from '../util/ExtensionUtil';
+import { SecureStore } from '../util/SecureStore';
+import { SecureStoreFactory } from '../util/SecureStoreFactory';
 
 export async function importNodesToEnvironment(environmentRegistryEntry: FabricEnvironmentRegistryEntry, fromAddEnvironment: boolean = false, createMethod?: string, informOfChanges: boolean = false, showSuccess: boolean = true, fromConnectEnvironment: boolean = false): Promise<boolean> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
@@ -173,12 +174,9 @@ export async function importNodesToEnvironment(environmentRegistryEntry: FabricE
                     }
                     requestOptions = { headers: { Authorization: `Bearer ${accessToken}` } };
                 } else {
-                    const keytar: any = ModuleUtil.getCoreNodeModule('keytar');
-                    if (!keytar) {
-                        throw new Error('Error importing the keytar module');
-                    }
+                    const secureStore: SecureStore = await SecureStoreFactory.getSecureStore();
 
-                    const credentials: string = await keytar.getPassword('blockchain-vscode-ext', environmentRegistryEntry.url);
+                    const credentials: string = await secureStore.getPassword('blockchain-vscode-ext', environmentRegistryEntry.url);
                     const credentialsArray: string[] = credentials.split(':'); // 'API key or User ID' : 'API secret or password' : rejectUnauthorized
                     if (credentialsArray.length !== 3) {
                         throw new Error(`Unable to retrieve the stored credentials`);

--- a/packages/blockchain-extension/extension/util/FileSystemSecureStore.ts
+++ b/packages/blockchain-extension/extension/util/FileSystemSecureStore.ts
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { SecureStore, SecureStoreCredentials } from './SecureStore';
+import * as fs from 'fs-extra';
+
+interface Service {
+    [account: string]: string;
+}
+
+interface Store {
+    [service: string]: Service;
+}
+
+export class FileSystemSecureStore implements SecureStore {
+
+    constructor(private path: string) {
+
+    }
+
+    async getPassword(service: string, account: string): Promise<string | null> {
+        const store: Store = await this.load();
+        if (!store[service]) {
+            return null;
+        }
+        const password: string = store[service][account];
+        if (!password) {
+            return null;
+        }
+        return password;
+    }
+
+    async setPassword(service: string, account: string, password: string): Promise<void> {
+        const store: Store = await this.load();
+        if (!store[service]) {
+            store[service] = {};
+        }
+        store[service][account] = password;
+        await this.save(store);
+    }
+
+    async deletePassword(service: string, account: string): Promise<boolean> {
+        const store: Store = await this.load();
+        if (!store[service] || !store[service][account]) {
+            return false;
+        }
+        delete store[service][account];
+        await this.save(store);
+        return true;
+    }
+
+    async findCredentials(service: string): Promise<SecureStoreCredentials> {
+        const store: Store = await this.load();
+        if (!store[service]) {
+            return [];
+        }
+        const result = [];
+        for (const [account, password] of Object.entries(store[service])) {
+            result.push({ account, password });
+        }
+        return result;
+    }
+
+    async findPassword(_service: string): Promise<string | null> {
+        throw new Error('Operation not supported');
+    }
+
+    private async load(): Promise<Store> {
+        try {
+            const data: string = await fs.readFile(this.path, 'utf8');
+            return JSON.parse(Buffer.from(data, 'base64').toString('utf8'));
+        } catch (error) {
+            // Ignore any errors - file doesn't exist, can't be accessed, corrupted, etc
+            return {};
+        }
+    }
+
+    private async save(store: Store): Promise<void> {
+        const data: string = Buffer.from(JSON.stringify(store), 'utf8').toString('base64');
+        return fs.writeJson(this.path, data, { encoding: 'utf8', mode: 0o600 });
+    }
+
+}

--- a/packages/blockchain-extension/extension/util/KeytarSecureStore.ts
+++ b/packages/blockchain-extension/extension/util/KeytarSecureStore.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { SecureStore, SecureStoreCredentials } from './SecureStore';
+
+export class KeytarSecureStore implements SecureStore {
+
+    constructor(private keytar: any) {
+
+    }
+
+    async getPassword(service: string, account: string): Promise<string | null> {
+        return this.keytar.getPassword(service, account);
+    }
+
+    async setPassword(service: string, account: string, password: string): Promise<void> {
+        return this.keytar.setPassword(service, account, password);
+    }
+
+    async deletePassword(service: string, account: string): Promise<boolean> {
+        return this.keytar.deletePassword(service, account);
+    }
+
+    async findCredentials(service: string): Promise<SecureStoreCredentials> {
+        return this.keytar.findCredentials(service);
+    }
+
+    async findPassword(_service: string): Promise<string | null> {
+        throw new Error('Operation not supported');
+    }
+
+}

--- a/packages/blockchain-extension/extension/util/SecureStore.ts
+++ b/packages/blockchain-extension/extension/util/SecureStore.ts
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+export interface SecureStoreCredential {
+    account: string;
+    password: string;
+}
+
+export type SecureStoreCredentials = Array<SecureStoreCredential>;
+
+export interface SecureStore {
+    getPassword(service: string, account: string): Promise<string | null>;
+    setPassword(service: string, account: string, password: string): Promise<void>;
+    deletePassword(service: string, account: string): Promise<boolean>;
+    findCredentials(service: string): Promise<SecureStoreCredentials>;
+    findPassword(service: string): Promise<string | null>;
+}
+

--- a/packages/blockchain-extension/extension/util/SecureStoreFactory.ts
+++ b/packages/blockchain-extension/extension/util/SecureStoreFactory.ts
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { SecureStore } from './SecureStore';
+import { ModuleUtil } from './ModuleUtil';
+import { KeytarSecureStore } from './KeytarSecureStore';
+import { SettingConfigurations } from '../../configurations';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { FileSystemSecureStore } from './FileSystemSecureStore';
+
+export class SecureStoreFactory {
+
+    static async getSecureStore(): Promise<SecureStore> {
+        const keytar: any = ModuleUtil.getCoreNodeModule('keytar');
+        if (keytar) {
+            return new KeytarSecureStore(keytar);
+        }
+        const extensionDirectory: string = vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_DIRECTORY);
+        const storePath: string = path.join(extensionDirectory, 'ibm-blockchain-platform.store');
+        return new FileSystemSecureStore(storePath);
+    }
+
+}

--- a/packages/blockchain-extension/test/commands/importNodesToEnvironmentCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/importNodesToEnvironmentCommand.test.ts
@@ -25,12 +25,37 @@ import { VSCodeBlockchainOutputAdapter } from '../../extension/logging/VSCodeBlo
 import { ExtensionCommands } from '../../ExtensionCommands';
 import { FabricEnvironmentRegistryEntry, LogType, FabricEnvironment, FabricNode, FabricEnvironmentRegistry, EnvironmentType } from 'ibm-blockchain-platform-common';
 import { FabricEnvironmentManager } from '../../extension/fabric/environments/FabricEnvironmentManager';
-import { ModuleUtil } from '../../extension/util/ModuleUtil';
 import { ExtensionsInteractionUtil } from '../../extension/util/ExtensionsInteractionUtil';
+import { SecureStore, SecureStoreCredentials } from '../../extension/util/SecureStore';
+import { SecureStoreFactory } from '../../extension/util/SecureStoreFactory';
 
 // tslint:disable no-unused-expression
 chai.use(sinonChai);
 const should: Chai.Should = chai.should();
+
+class TestSecureStore implements SecureStore {
+
+    async getPassword(_service: string, _account: string): Promise<string | null> {
+        return null;
+    }
+
+    async setPassword(_service: string, _account: string, _password: string): Promise<void> {
+        return;
+    }
+
+    async deletePassword(_service: string, _account: string): Promise<boolean> {
+        return false;
+    }
+
+    async findCredentials(_service: string): Promise<SecureStoreCredentials> {
+        return [];
+    }
+
+    async findPassword(_service: string): Promise<string | null> {
+        return null;
+    }
+
+}
 
 describe('ImportNodesToEnvironmentCommand', () => {
     const mySandBox: sinon.SinonSandbox = sinon.createSandbox();
@@ -48,7 +73,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
     let axiosGetStub: sinon.SinonStub;
     let showNodesQuickPickBoxStub: sinon.SinonStub;
     let getPasswordStub: sinon.SinonStub;
-    let getCoreNodeModuleStub: sinon.SinonStub;
     let fsPathExistsStub: sinon.SinonStub;
     let localFabricNodes: any;
     let opsToolNodes: any;
@@ -165,10 +189,10 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             axiosGetStub.onFirstCall().resolves({data: opsToolNodes});
             showNodesQuickPickBoxStub.resolves(opsToolNodes.map((_node: any) => ({ label: _node.display_name, data: _node })));
-            getPasswordStub = mySandBox.stub().resolves(`${userAuth1}:${userAuth2}:${rejectUnauthorized}`);
-            getCoreNodeModuleStub = mySandBox.stub(ModuleUtil, 'getCoreNodeModule').returns({
-                getPassword: getPasswordStub
-            });
+            const mockSecureStore: sinon.SinonStubbedInstance<TestSecureStore> = sinon.createStubInstance(TestSecureStore);
+            getPasswordStub = mockSecureStore.getPassword;
+            getPasswordStub.resolves(`${userAuth1}:${userAuth2}:${rejectUnauthorized}`);
+            mySandBox.stub(SecureStoreFactory, 'getSecureStore').resolves(mockSecureStore);
 
             // Ops tools SaaS
             SaaSurl = 'my/OpsTool/IBM/url';
@@ -256,7 +280,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -298,7 +321,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -313,7 +335,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, undefined, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -332,7 +353,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, undefined, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -349,7 +369,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, false);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -366,7 +385,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, false);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -376,28 +394,12 @@ describe('ImportNodesToEnvironmentCommand', () => {
             logSpy.getCall(1).should.have.been.calledWith(LogType.SUCCESS, 'Successfully filtered nodes');
         });
 
-        it('should handle when the keytar module cannot be imported at all when creating a new OpsTool instance (Software Support)', async () => {
-            getCoreNodeModuleStub.returns(undefined);
-            const error: Error = new Error('Error importing the keytar module');
-
-            await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS).should.be.rejectedWith('Error importing the keytar module');
-
-            getCoreNodeModuleStub.should.have.been.calledOnce;
-            ensureDirStub.should.have.not.been.called;
-            updateNodeStub.should.not.have.been.called;
-            getNodesStub.should.have.been.calledOnce;
-            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'Edit node filters');
-            logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Failed to acquire nodes from ${opsToolRegistryEntry.url}, with error ${error.message}`, `Failed to acquire nodes from ${opsToolRegistryEntry.url}, with error ${error.toString()}`);
-            logSpy.getCall(2).should.have.been.calledWith(LogType.ERROR, `Error filtering nodes: ${error.message}`);
-        });
-
         it('should handle when the user id + password/api key + secret cannot be retrieved when creating new OpsTool instance (Software Support)', async () => {
             const error: Error = new Error('newError');
-            getPasswordStub.throws(error);
+            getPasswordStub.rejects(error);
 
             await vscode.commands.executeCommand(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS).should.be.rejectedWith(error.message);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.not.been.called;
             updateNodeStub.should.not.have.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -411,7 +413,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.IMPORT_NODES_TO_ENVIRONMENT, opsToolRegistryEntry, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.not.been.called;
             updateNodeStub.should.not.have.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -459,7 +460,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -733,7 +733,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.not.been.called;
             updateNodeStub.should.not.have.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -748,7 +747,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS).should.eventually.be.rejectedWith(error.message);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.not.been.called;
             updateNodeStub.should.not.have.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -843,7 +841,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.called;
             getNodesStub.should.have.been.calledTwice;
@@ -908,7 +905,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             }));
             savedNodesHidden.should.deep.equal(expectedNodesHidden);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.called;
             getNodesStub.should.have.been.calledTwice;
@@ -1111,7 +1107,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.DELETE_NODE);
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.called;
             getNodesStub.should.have.been.calledTwice;
@@ -1131,7 +1126,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.not.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -1171,7 +1165,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.DELETE_NODE);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.DELETE_ENVIRONMENT);
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.not.been.called;
             getNodesStub.should.have.been.calledOnce;
@@ -1191,7 +1184,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, opsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.not.been.called;
             getNodesStub.should.have.been.calledTwice;
@@ -1231,7 +1223,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.DELETE_NODE);
             executeCommandStub.should.have.not.been.calledWith(ExtensionCommands.DELETE_ENVIRONMENT);
-            getCoreNodeModuleStub.should.have.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.not.been.called;
             getNodesStub.should.have.been.calledTwice;
@@ -1249,7 +1240,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, SaaSOpsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
             cloudAccountGetAccessTokenStub.should.have.been.called;
-            getCoreNodeModuleStub.should.have.not.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -1266,7 +1256,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, undefined, false, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
             cloudAccountGetAccessTokenStub.should.have.been.called;
-            getCoreNodeModuleStub.should.have.not.been.calledOnce;
             ensureDirStub.should.have.been.calledOnce;
             updateNodeStub.should.have.been.calledTwice;
             getNodesStub.should.have.been.calledTwice;
@@ -1281,7 +1270,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, SaaSOpsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS);
 
             cloudAccountGetAccessTokenStub.should.have.been.called;
-            getCoreNodeModuleStub.should.have.not.been.calledOnce;
             ensureDirStub.should.have.not.been.calledOnce;
             updateNodeStub.should.have.not.been.calledTwice;
             getNodesStub.should.have.been.calledOnce;
@@ -1296,7 +1284,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, SaaSOpsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS).should.eventually.be.rejectedWith(tokenError);
 
             cloudAccountGetAccessTokenStub.should.have.been.called;
-            getCoreNodeModuleStub.should.have.not.been.calledOnce;
             ensureDirStub.should.have.not.been.calledOnce;
             updateNodeStub.should.have.not.been.calledTwice;
             getNodesStub.should.have.been.calledOnce;
@@ -1316,7 +1303,6 @@ describe('ImportNodesToEnvironmentCommand', () => {
             await vscode.commands.executeCommand(ExtensionCommands.EDIT_NODE_FILTERS, SaaSOpsToolRegistryEntry, true, UserInputUtil.ADD_ENVIRONMENT_FROM_OPS_TOOLS, informOfChanges, showSuccess, fromConnectEnvironment).should.eventually.be.rejectedWith(thrownError.message);
 
             cloudAccountGetAccessTokenStub.should.have.been.called;
-            getCoreNodeModuleStub.should.have.not.been.calledOnce;
             ensureDirStub.should.have.not.been.calledOnce;
             updateNodeStub.should.have.not.been.calledTwice;
             getNodesStub.should.have.been.calledOnce;

--- a/packages/blockchain-extension/test/util/FileSystemSecureStore.test.ts
+++ b/packages/blockchain-extension/test/util/FileSystemSecureStore.test.ts
@@ -1,0 +1,162 @@
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { FileSystemSecureStore } from '../../extension/util/FileSystemSecureStore';
+import * as chai from 'chai';
+import * as fs from 'fs-extra';
+import * as tmp from 'tmp';
+import * as chaiAsPromised from 'chai-as-promised';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('FileSystemSecureStore', () => {
+
+    let path: string;
+    let store: FileSystemSecureStore;
+
+    beforeEach(() => {
+        path = tmp.tmpNameSync();
+        store = new FileSystemSecureStore(path);
+    });
+
+    afterEach(async () => {
+        await fs.remove(path);
+    });
+
+    async function writeStore(contents: any): Promise<void> {
+        const data: string = Buffer.from(JSON.stringify(contents), 'utf8').toString('base64');
+        await fs.writeFile(path, data, { encoding: 'utf8', mode: 0o600 });
+    }
+
+    async function readStore(): Promise<any> {
+        const data: string = await fs.readFile(path, 'utf8');
+        return JSON.parse(Buffer.from(data, 'base64').toString('utf8'));
+    }
+
+    describe('#getPassword', () => {
+
+        it('should get the password', async () => {
+            await writeStore({
+                mysvc: {
+                    myacct: 'topsecret'
+                }
+            });
+            await store.getPassword('mysvc', 'myacct').should.eventually.equal('topsecret');
+        });
+
+        it('should return null if the account does not exist', async () => {
+            await writeStore({
+                mysvc: {}
+            });
+            await store.getPassword('mysvc', 'myacct').should.eventually.be.null;
+        });
+
+        it('should return null if the service does not exist', async () => {
+            await writeStore({});
+            await store.getPassword('mysvc', 'myacct').should.eventually.be.null;
+        });
+
+    });
+
+    describe('#setPassword', () => {
+
+        it('should set the password if the account does not exist', async () => {
+            await store.setPassword('mysvc', 'myacct', 'topsecret').should.eventually.be.fulfilled;
+            await readStore().should.eventually.deep.equal({
+                mysvc: {
+                    myacct: 'topsecret'
+                }
+            });
+        });
+
+        it('should set the password if the account already exists', async () => {
+            await writeStore({
+                mysvc: {
+                    myacct: 'suchpass'
+                }
+            });
+            await store.setPassword('mysvc', 'myacct', 'topsecret').should.eventually.be.fulfilled;
+            await readStore().should.eventually.deep.equal({
+                mysvc: {
+                    myacct: 'topsecret'
+                }
+            });
+        });
+
+    });
+
+    describe('#deletePassword', () => {
+
+        it('should delete the password', async () => {
+            await writeStore({
+                mysvc: {
+                    myacct: 'topsecret'
+                }
+            });
+            await store.deletePassword('mysvc', 'myacct').should.eventually.be.true;
+            await readStore().should.eventually.deep.equal({
+                mysvc: {}
+            });
+        });
+
+        it('should not delete the password if the account does not exist', async () => {
+            await writeStore({
+                mysvc: {}
+            });
+            await store.deletePassword('mysvc', 'myacct').should.eventually.be.false;
+            await readStore().should.eventually.deep.equal({
+                mysvc: {}
+            });
+        });
+
+        it('should delete the password if the service does not exist', async () => {
+            await writeStore({});
+            await store.deletePassword('mysvc', 'myacct').should.eventually.be.false;
+            await readStore().should.eventually.deep.equal({});
+        });
+
+    });
+
+    describe('#findCredentials', () => {
+
+        it('should return all of credentials', async () => {
+            await writeStore({
+                mysvc: {
+                    myacct: 'topsecret'
+                }
+            });
+            await store.findCredentials('mysvc').should.eventually.deep.equal([{
+                account: 'myacct',
+                password: 'topsecret'
+            }]);
+        });
+
+        it('should return an empty array if the service does not exist', async () => {
+            await writeStore({});
+            await store.findCredentials('mysvc').should.eventually.deep.equal([]);
+        });
+
+    });
+
+    describe('#findPassword', () => {
+
+        it('should throw an error as it is not supported', async () => {
+            await store.findPassword('mysvc').should.eventually.be.rejectedWith(/Operation not supported/);
+        });
+
+    });
+
+});

--- a/packages/blockchain-extension/test/util/KeytarSecureStore.test.ts
+++ b/packages/blockchain-extension/test/util/KeytarSecureStore.test.ts
@@ -1,0 +1,99 @@
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { KeytarSecureStore } from '../../extension/util/KeytarSecureStore';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+
+chai.should();
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe('KeytarSecureStore', () => {
+
+    let store: KeytarSecureStore;
+    let mockKeytar: any;
+    let getPasswordStub: sinon.SinonStub;
+    let setPasswordStub: sinon.SinonStub;
+    let deletePasswordStub: sinon.SinonStub;
+    let findCredentialsStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        getPasswordStub = sinon.stub();
+        setPasswordStub = sinon.stub();
+        deletePasswordStub = sinon.stub();
+        findCredentialsStub = sinon.stub();
+        mockKeytar = {
+            getPassword: getPasswordStub,
+            setPassword: setPasswordStub,
+            deletePassword: deletePasswordStub,
+            findCredentials: findCredentialsStub
+        };
+        store = new KeytarSecureStore(mockKeytar);
+    });
+
+    describe('#getPassword', () => {
+
+        it('should get the password', async () => {
+            getPasswordStub.withArgs('mysvc', 'myacct').resolves('topsecret');
+            await store.getPassword('mysvc', 'myacct').should.eventually.equal('topsecret');
+        });
+
+    });
+
+    describe('#setPassword', () => {
+
+        it('should set the password', async () => {
+            await store.setPassword('mysvc', 'myacct', 'topsecret').should.eventually.be.fulfilled;
+            setPasswordStub.should.have.been.calledOnceWithExactly('mysvc', 'myacct', 'topsecret');
+        });
+
+    });
+
+    describe('#deletePassword', () => {
+
+        it('should delete the password', async () => {
+            await store.deletePassword('mysvc', 'myacct').should.eventually.be.fulfilled;
+            deletePasswordStub.should.have.been.calledOnceWithExactly('mysvc', 'myacct');
+        });
+
+    });
+
+    describe('#findCredentials', () => {
+
+        it('should delete the password', async () => {
+            findCredentialsStub.withArgs('mysvc').resolves([{
+                account: 'myacct',
+                password: 'topsecret'
+            }]);
+            await store.findCredentials('mysvc').should.eventually.deep.equal([{
+                account: 'myacct',
+                password: 'topsecret'
+            }]);
+        });
+
+    });
+
+    describe('#findPassword', () => {
+
+        it('should throw an error as it is not supported', async () => {
+            await store.findPassword('mysvc').should.eventually.be.rejectedWith(/Operation not supported/);
+        });
+
+    });
+
+});

--- a/packages/blockchain-extension/test/util/SecureStoreFactory.test.ts
+++ b/packages/blockchain-extension/test/util/SecureStoreFactory.test.ts
@@ -1,0 +1,63 @@
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { SecureStore } from '../../extension/util/SecureStore';
+import { SecureStoreFactory } from '../../extension/util/SecureStoreFactory';
+import { KeytarSecureStore } from '../../extension/util/KeytarSecureStore';
+import { ModuleUtil } from '../../extension/util/ModuleUtil';
+import { FileSystemSecureStore } from '../../extension/util/FileSystemSecureStore';
+import * as chai from 'chai';
+import * as chaiAsPromised from 'chai-as-promised';
+import * as path from 'path';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { SettingConfigurations } from '../../configurations';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('SecureStoreFactory', () => {
+
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('#getSecureStore', () => {
+
+        it('should return a keytar secure store if keytar is available', async () => {
+            sandbox.stub(ModuleUtil, 'getCoreNodeModule').withArgs('keytar').returns({ fake: 'keytar' });
+            const secureStore: SecureStore = await SecureStoreFactory.getSecureStore();
+            secureStore.should.be.an.instanceOf(KeytarSecureStore);
+            secureStore['keytar'].should.deep.equal({ fake: 'keytar' });
+        });
+
+        it('should return a file system secure store if keytar is not available', async () => {
+            sandbox.stub(ModuleUtil, 'getCoreNodeModule').withArgs('keytar').returns(undefined);
+            const secureStore: SecureStore = await SecureStoreFactory.getSecureStore();
+            secureStore.should.be.an.instanceOf(FileSystemSecureStore);
+            const extensionDirectory: string = vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_DIRECTORY);
+            const storePath: string = path.join(extensionDirectory, 'ibm-blockchain-platform.store');
+            secureStore['path'].should.equal(storePath);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Keytar is not available in Eclipse Che/Theia. VSCode ships a copy of Keytar which we use, but Eclipse Che/Theia does not. 

We could include it in the Che package, but:
- It doesn't work because it relies on various parts of the "GUI" (D-Bus etc) that aren't available in headless environments.
- Keytar doesn't support multiple native binaries like gRPC does, which means we'd have to compile it in the target environment, which is not possible in Che.

So... we need to introduce a fallback option which is file system based. Eclipse Che is responsible for securing access to users files within a developer workspace, so it should be OK. 

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>