### PR TITLE
Determine node label before node creation (resolves #2337)

### DIFF
--- a/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
+++ b/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
@@ -178,13 +178,18 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
                 arguments: [environmentRegistryEntry, node]
             };
 
+            let label: string = node.cluster_name || node.name;
+            if (!node.wallet || !node.identity) {
+                label += '   ⚠';
+            }
+
             if (node.type === FabricNodeType.PEER) {
-                const peerTreeItem: PeerTreeItem = new PeerTreeItem(this, node.name, node.name, environmentRegistryEntry, node, command);
+                const peerTreeItem: PeerTreeItem = new PeerTreeItem(this, label, node.name, environmentRegistryEntry, node, command);
                 tree.push(peerTreeItem);
             }
 
             if (node.type === FabricNodeType.CERTIFICATE_AUTHORITY) {
-                const certificateAuthorityTreeItem: CertificateAuthorityTreeItem = new CertificateAuthorityTreeItem(this, node.name, node.name, environmentRegistryEntry, node, command);
+                const certificateAuthorityTreeItem: CertificateAuthorityTreeItem = new CertificateAuthorityTreeItem(this, label, node.name, environmentRegistryEntry, node, command);
                 tree.push(certificateAuthorityTreeItem);
             }
 
@@ -192,10 +197,10 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
                 if (node.cluster_name) {
                     const foundTreeItem: BlockchainTreeItem = tree.find((treeItem: OrdererTreeItem) => treeItem.node && treeItem.node.type === FabricNodeType.ORDERER && node.cluster_name === treeItem.node.cluster_name);
                     if (!foundTreeItem) {
-                        tree.push(new OrdererTreeItem(this, node.cluster_name, node.cluster_name, environmentRegistryEntry, node, command));
+                        tree.push(new OrdererTreeItem(this, label, node.cluster_name, environmentRegistryEntry, node, command));
                     }
                 } else {
-                    tree.push(new OrdererTreeItem(this, node.name, node.name, environmentRegistryEntry, node, command));
+                    tree.push(new OrdererTreeItem(this, label, node.name, environmentRegistryEntry, node, command));
                 }
             }
         }

--- a/packages/blockchain-extension/extension/explorer/runtimeOps/connectedTree/NodeTreeItem.ts
+++ b/packages/blockchain-extension/extension/explorer/runtimeOps/connectedTree/NodeTreeItem.ts
@@ -21,29 +21,7 @@ import * as vscode from 'vscode';
 
 export abstract class NodeTreeItem extends BlockchainTreeItem {
 
-    private orginalLabel: string;
-
     constructor(provider: BlockchainExplorerProvider, label: string, public readonly tooltip: string, public readonly environmentRegistryEntry: FabricEnvironmentRegistryEntry, public readonly node: FabricNode, public readonly command?: vscode.Command) {
         super(provider, label, vscode.TreeItemCollapsibleState.None);
-
-        this.orginalLabel = label;
-
-        this.updateProperties();
-    }
-
-    protected updateProperties(): void {
-        let newLabel: string = this.orginalLabel;
-
-        if (!this.node.wallet || !this.node.identity) {
-            newLabel += '   ⚠';
-        }
-
-        this.setLabel(newLabel);
-        this.refresh();
-    }
-
-    private setLabel(label: string): void {
-        // label is readonly so make it less readonly
-        (this as any).label = label;
     }
 }

--- a/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
@@ -314,14 +314,15 @@ describe('environmentExplorer', () => {
                 getStateStub.returns(ConnectedState.SETUP);
 
                 const peerNode: FabricNode = FabricNode.newPeer('peer1', 'peer1.org1.example.com', 'http://peer.sample.org', undefined, undefined, undefined);
-                const ordererNode: FabricNode = FabricNode.newOrderer('orderer', 'orderer.example.com', 'http://orderer.sample.org', undefined, undefined, undefined, 'Ordering Service');
-                const ordererNode1: FabricNode = FabricNode.newOrderer('orderer1', 'orderer1.example.com', 'http://orderer.sample.org', undefined, undefined, undefined, 'Ordering Service');
-                const ordererNode2: FabricNode = FabricNode.newOrderer('orderer2', 'orderer2.example.com', 'http://orderer.sample.org', undefined, undefined, undefined, 'Another Ordering Service');
-                const ordererNode3: FabricNode = FabricNode.newOrderer('orderer3', 'orderer3.example.com', 'http://orderer.sample.org', undefined, undefined, undefined, 'Another Ordering Service');
+                const peerNode2: FabricNode = FabricNode.newPeer('peer2', 'peer2.org1.example.com', 'http://peer.sample.org', 'some wallet', 'some identity', undefined);
+                const ordererNode: FabricNode = FabricNode.newOrderer('orderer', 'orderer.example.com', 'http://orderer.sample.org', 'some wallet', undefined, undefined, 'Ordering Service');
+                const ordererNode1: FabricNode = FabricNode.newOrderer('orderer1', 'orderer1.example.com', 'http://orderer.sample.org', 'some wallet', undefined, undefined, 'Ordering Service');
+                const ordererNode2: FabricNode = FabricNode.newOrderer('orderer2', 'orderer2.example.com', 'http://orderer.sample.org', undefined, 'some identity', undefined, 'Another Ordering Service');
+                const ordererNode3: FabricNode = FabricNode.newOrderer('orderer3', 'orderer3.example.com', 'http://orderer.sample.org', undefined, 'some identity', undefined, 'Another Ordering Service');
 
                 const caNode: FabricNode = FabricNode.newCertificateAuthority('ca1', 'ca1.org1.example.com', 'http://ca.sample.org', undefined, undefined, undefined, undefined, undefined, undefined);
 
-                mySandBox.stub(FabricEnvironment.prototype, 'getNodes').resolves([peerNode, ordererNode, ordererNode1, ordererNode2, ordererNode3, caNode]);
+                mySandBox.stub(FabricEnvironment.prototype, 'getNodes').resolves([peerNode, peerNode2, ordererNode, ordererNode1, ordererNode2, ordererNode3, caNode]);
 
                 const environmentRegistry: FabricEnvironmentRegistryEntry = new FabricEnvironmentRegistryEntry();
                 environmentRegistry.name = 'myEnvironment';
@@ -335,25 +336,29 @@ describe('environmentExplorer', () => {
                 commandStub.should.have.been.calledWith('setContext', 'blockchain-environment-setup', true);
                 should.not.exist(blockchainRuntimeExplorerProvider['fabricEnvironmentToSetUp']);
 
-                children.length.should.equal(6);
+                children.length.should.equal(7);
                 children[0].label.should.equal(`Setting up: ${environmentRegistry.name}`);
                 children[1].label.should.equal(`(Click each node to perform setup)`);
                 children[2].label.should.equal('peer1.org1.example.com   ⚠');
                 children[2].command.command.should.equal(ExtensionCommands.ASSOCIATE_IDENTITY_NODE);
                 children[2].command.arguments.should.deep.equal([environmentRegistry, peerNode]);
                 children[2].tooltip.should.equal(peerNode.name);
-                children[3].label.should.equal('Ordering Service   ⚠');
+                children[3].label.should.equal('peer2.org1.example.com');
                 children[3].command.command.should.equal(ExtensionCommands.ASSOCIATE_IDENTITY_NODE);
-                children[3].command.arguments.should.deep.equal([environmentRegistry, ordererNode]);
-                children[3].tooltip.should.equal(ordererNode.cluster_name);
-                children[4].label.should.equal('Another Ordering Service   ⚠');
+                children[3].command.arguments.should.deep.equal([environmentRegistry, peerNode2]);
+                children[3].tooltip.should.equal(peerNode2.name);
+                children[4].label.should.equal('Ordering Service   ⚠');
                 children[4].command.command.should.equal(ExtensionCommands.ASSOCIATE_IDENTITY_NODE);
-                children[4].command.arguments.should.deep.equal([environmentRegistry, ordererNode2]);
-                children[4].tooltip.should.equal(ordererNode2.cluster_name);
-                children[5].label.should.equal('ca1.org1.example.com   ⚠');
+                children[4].command.arguments.should.deep.equal([environmentRegistry, ordererNode]);
+                children[4].tooltip.should.equal(ordererNode.cluster_name);
+                children[5].label.should.equal('Another Ordering Service   ⚠');
                 children[5].command.command.should.equal(ExtensionCommands.ASSOCIATE_IDENTITY_NODE);
-                children[5].command.arguments.should.deep.equal([environmentRegistry, caNode]);
-                children[5].tooltip.should.equal(caNode.name);
+                children[5].command.arguments.should.deep.equal([environmentRegistry, ordererNode2]);
+                children[5].tooltip.should.equal(ordererNode2.cluster_name);
+                children[6].label.should.equal('ca1.org1.example.com   ⚠');
+                children[6].command.command.should.equal(ExtensionCommands.ASSOCIATE_IDENTITY_NODE);
+                children[6].command.arguments.should.deep.equal([environmentRegistry, caNode]);
+                children[6].tooltip.should.equal(caNode.name);
             });
 
             it('should error if gRPC cant connect to Fabric', async () => {

--- a/packages/blockchain-extension/test/explorer/runtimeOps/NodeTreeItem.test.ts
+++ b/packages/blockchain-extension/test/explorer/runtimeOps/NodeTreeItem.test.ts
@@ -44,7 +44,7 @@ describe('NodeTreeItem', () => {
     beforeEach(async () => {
         await ExtensionUtil.activateExtension();
 
-        node = FabricNode.newPeer('peer1', 'peer1.org1.example.com', 'http://peer.sample.org', undefined, undefined, undefined);
+        node = FabricNode.newPeer('peer1', 'peer1.org1.example.com', 'http://peer.sample.org', 'admin', 'myWallet', 'Org1MSP');
 
         provider = ExtensionUtil.getBlockchainGatewayExplorerProvider();
     });
@@ -54,16 +54,7 @@ describe('NodeTreeItem', () => {
     });
 
     describe('#constructor', () => {
-        it('should have the right properties for a node without identity and wallet', async () => {
-            const treeItem: TestTreeItem = new TestTreeItem(provider, 'peer1.org1.example.com', 'peer1.org1.example.com', new FabricEnvironmentRegistryEntry(), node);
-
-            treeItem.label.should.equal('peer1.org1.example.com   ⚠');
-            treeItem.tooltip.should.equal('peer1.org1.example.com');
-        });
-
-        it('should have the right properties for a node with identity and wallet', async () => {
-            node.identity = 'admin';
-            node.wallet = 'myWallet';
+        it('should have the right properties for a node', async () => {
             const tooltip: string = `Name: ${node.name}\nMSPID: ${node.msp_id}\nAssociated Identity:\n${node.identity}`;
             const treeItem: TestTreeItem = new TestTreeItem(provider, 'peer1.org1.example.com', tooltip, new FabricEnvironmentRegistryEntry(), node);
 


### PR DESCRIPTION
Dynamically changing a tree nodes label using _my_ hacks introduced for the local runtime spinner doesn't work in Eclipse Che; it seems to cause the command associated with the tree node to be lost. Fortunately we don't use the local runtime spinner in Eclipse Che as you have to stand up your Fabric network via other means. 

The proper way to fix this is to generate node IDs or URIs ourselves (which looks like it will resolve the problem), but that's a substantial piece of re-engineering, and we only have this one bit of code to fix.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>