### PR TITLE
Include IBM Cloud Account extension in Che package (resolves #2374)

### DIFF
--- a/che/build.sh
+++ b/che/build.sh
@@ -62,4 +62,5 @@ spec:
   extensions:
   - https://github.com/IBM-Blockchain/blockchain-vscode-extension/releases/download/v${VERSION}/ibm-blockchain-platform-che-${VERSION}.vsix
   - https://open-vsx.org/api/vscode/markdown-language-features/1.39.1/file/vscode.markdown-language-features-1.39.1.vsix
+  - https://github.com/IBM/vscode-ibmcloud-account/releases/download/v1.0.2/ibmcloud-account-1.0.2.vsix
 EOF


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>