### PR TITLE
Changed script so it checks if sourcebranch starts with refs/tags/v1*

### DIFF
--- a/azure-templates/build-pdf.yml
+++ b/azure-templates/build-pdf.yml
@@ -32,7 +32,7 @@ jobs:
             git commit -asm "PDFs automatically generated"
             git status
 
-            if [[ $(Build.SourceBranchName) == v1* ]]; then
+            if [[ $(Build.SourceBranch) == refs/tags/v1* ]]; then
               export branch_name=master
             else
               export branch_name=v2


### PR DESCRIPTION
Updated the script to see if changing the if statement fixes the problem of the script trying to push to the v2 branch through code used elsewhere.

`startsWith(variables['Build.SourceBranch'], 'refs/tags/v1'`

Signed-off-by: Akshat Shah <akshatshah@akshats-mbp.hursley.uk.ibm.com>