### PR TITLE
Use 2.1.2-snapshot version of Node SDK and old fabric-protos

### DIFF
--- a/packages/blockchain-environment-v1/package-lock.json
+++ b/packages/blockchain-environment-v1/package-lock.json
@@ -129,11 +129,102 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@grpc/grpc-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.3.tgz",
+			"integrity": "sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==",
+			"optional": true,
+			"requires": {
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"optional": true
+				}
+			}
+		},
+		"@grpc/proto-loader": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+			"integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+			"optional": true,
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"protobufjs": "^6.8.6"
+			}
+		},
 		"@istanbuljs/nyc-config-typescript": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
 			"integrity": "sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==",
 			"dev": true
+		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"optional": true
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"optional": true
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"optional": true
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"optional": true
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"optional": true,
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"optional": true
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"optional": true
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"optional": true
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"optional": true
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"optional": true
 		},
 		"@sinonjs/commons": {
 			"version": "1.7.1",
@@ -164,15 +255,6 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
-		},
-		"@types/bytebuffer": {
-			"version": "5.0.40",
-			"resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-			"integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
-			"requires": {
-				"@types/long": "*",
-				"@types/node": "*"
-			}
 		},
 		"@types/caseless": {
 			"version": "0.12.2",
@@ -224,7 +306,8 @@
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"optional": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -244,28 +327,15 @@
 			"integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
 		},
 		"@types/request": {
-			"version": "2.48.4",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-			"integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+			"version": "2.48.5",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
 			"optional": true,
 			"requires": {
 				"@types/caseless": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
 			}
 		},
 		"@types/rimraf": {
@@ -310,6 +380,7 @@
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"optional": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -437,19 +508,11 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"ascli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-			"integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-			"requires": {
-				"colour": "~0.7.1",
-				"optjs": "~3.2.2"
-			}
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"optional": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -457,7 +520,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"optional": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -473,17 +537,26 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"optional": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"optional": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"optional": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"optional": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -532,12 +605,14 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -549,14 +624,16 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -565,12 +642,14 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"optional": true
 		},
 		"browser-request": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+			"optional": true
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
@@ -590,14 +669,6 @@
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
-		"bytebuffer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-			"requires": {
-				"long": "~3"
-			}
-		},
 		"caching-transform": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -610,15 +681,23 @@
 				"write-file-atomic": "^2.4.2"
 			}
 		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"optional": true
+		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"optional": true
 		},
 		"chai": {
 			"version": "4.1.2",
@@ -687,6 +766,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
@@ -694,19 +774,21 @@
 			}
 		},
 		"cloudant-follow": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-			"integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+			"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
+			"optional": true,
 			"requires": {
 				"browser-request": "~0.3.0",
-				"debug": "^3.0.0",
-				"request": "^2.83.0"
+				"debug": "^4.0.1",
+				"request": "^2.88.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -736,17 +818,14 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-		},
-		"colour": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-			"integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"optional": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"optional": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -766,7 +845,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -830,12 +910,14 @@
 		"cycle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+			"optional": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -844,6 +926,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			},
@@ -851,7 +934,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -904,7 +988,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -916,15 +1001,17 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"optional": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -959,7 +1046,8 @@
 		"errs": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
-			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
+			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=",
+			"optional": true
 		},
 		"es-abstract": {
 			"version": "1.17.4",
@@ -1045,7 +1133,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
 		},
 		"extend-shallow": {
 			"version": "1.1.4",
@@ -1059,62 +1148,38 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"optional": true
 		},
 		"eyes": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+			"optional": true
 		},
 		"fabric-ca-client": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-			"integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-sttS3p2chFDy4VCCxHxLOPLOL9ilwrHtbveVuhVGITvHCL8ZIKMVoTdHtRB56+I1o89nIp9drxTUsgAkBM6aKg==",
 			"optional": true,
 			"requires": {
-				"fabric-common": "^2.1.0",
-				"jsrsasign": "^7.2.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"jsrsasign": "^8.0.15",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
 				"winston": "^2.4.0"
-			},
-			"dependencies": {
-				"fabric-common": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-					"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-					"optional": true,
-					"requires": {
-						"elliptic": "^6.2.3",
-						"fabric-protos": "^2.1.0",
-						"js-sha3": "^0.7.0",
-						"nano": "^6.4.4",
-						"nconf": "^0.10.0",
-						"pkcs11js": "^1.0.6",
-						"promise-settle": "^0.3.0",
-						"sjcl": "1.0.7",
-						"winston": "^2.4.0",
-						"yn": "^3.1.0"
-					}
-				},
-				"yn": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-					"optional": true
-				}
 			}
 		},
 		"fabric-common": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-			"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-OVhoSQQkROFe6ZFUOjxB8xqa9csQtORKp8o8g3ZuH2OmR1LSIjg2WQAAKj3YwKTZuGhSz/ltySo/HCu5zQyHXA==",
 			"optional": true,
 			"requires": {
-				"elliptic": "^6.2.3",
-				"fabric-protos": "^2.1.0",
+				"callsite": "^1.0.0",
+				"elliptic": "^6.5.2",
+				"fabric-protos": "2.1.2-snapshot.2",
 				"js-sha3": "^0.7.0",
-				"nano": "^6.4.4",
+				"jsrsasign": "^8.0.15",
 				"nconf": "^0.10.0",
 				"pkcs11js": "^1.0.6",
 				"promise-settle": "^0.3.0",
@@ -1132,140 +1197,72 @@
 			}
 		},
 		"fabric-network": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.0.tgz",
-			"integrity": "sha512-9VqUvYX2fROleTl1sKIx51EhLDfhDxDMHIgafRvicBFJKYAeQ6nyKWmk3gZIlGxmB2LjpIV+WzwR5Z2PiNI03w==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-gACrYS5ojBnv/J9mdeWk8zPv/Mj5axkww3XaxJWYyX6Q+NzWDeUmi5GmhB5kTQ0H1C8WfL2iY9//NZ15lqHSuA==",
 			"optional": true,
 			"requires": {
-				"fabric-ca-client": "^2.1.0",
-				"fabric-common": "^2.1.0",
-				"fs-extra": "^8.1.0",
+				"fabric-ca-client": "2.1.2-snapshot.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"fabric-protos": "2.1.2-snapshot.2",
+				"fs-extra": "^9.0.0",
 				"long": "^4.0.0",
-				"nano": "^8.1.0",
-				"winston": "^2.4.0"
+				"nano": "^8.2.2",
+				"winston": "^2.4.4"
 			},
 			"dependencies": {
-				"fabric-ca-client": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-					"integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
-					"optional": true,
-					"requires": {
-						"fabric-common": "^2.1.0",
-						"jsrsasign": "^7.2.2",
-						"url": "^0.11.0",
-						"util": "^0.10.3",
-						"winston": "^2.4.0"
-					}
-				},
-				"fabric-common": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-					"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-					"requires": {
-						"elliptic": "^6.2.3",
-						"fabric-protos": "^2.1.0",
-						"js-sha3": "^0.7.0",
-						"nano": "^6.4.4",
-						"nconf": "^0.10.0",
-						"pkcs11js": "^1.0.6",
-						"promise-settle": "^0.3.0",
-						"sjcl": "1.0.7",
-						"winston": "^2.4.0",
-						"yn": "^3.1.0"
-					},
-					"dependencies": {
-						"nano": {
-							"version": "6.4.4",
-							"resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-							"integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
-							"requires": {
-								"cloudant-follow": "~0.17.0",
-								"debug": "^2.2.0",
-								"errs": "^0.3.2",
-								"lodash.isempty": "^4.4.0",
-								"request": "^2.85.0"
-							}
-						}
-					}
-				},
 				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 					"optional": true,
 					"requires": {
+						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
 					}
 				},
-				"long": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-					"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-					"optional": true
-				},
-				"nano": {
-					"version": "8.2.2",
-					"resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
-					"integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
 					"optional": true,
 					"requires": {
-						"@types/request": "^2.48.4",
-						"cloudant-follow": "^0.18.2",
-						"debug": "^4.1.1",
-						"errs": "^0.3.2",
-						"request": "^2.88.0"
-					},
-					"dependencies": {
-						"cloudant-follow": {
-							"version": "0.18.2",
-							"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
-							"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
-							"optional": true,
-							"requires": {
-								"browser-request": "~0.3.0",
-								"debug": "^4.0.1",
-								"request": "^2.88.0"
-							}
-						},
-						"debug": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
 					}
 				},
-				"yn": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"optional": true
 				}
 			}
 		},
 		"fabric-protos": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-			"integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-qCfVyjMxWp885HREHyhacdlF4iclMguuzasSM0nO7MWBYHCnyaSbR7/JUNjuBdHg9zzLbVLdCY8RX13ZMUg+uw==",
+			"optional": true,
 			"requires": {
-				"grpc": "1.24.2",
-				"lodash.clone": "4.5.0",
-				"protobufjs": "^5.0.3"
+				"@grpc/grpc-js": "1.0.3",
+				"@grpc/proto-loader": "0.5.4",
+				"lodash.clone": "4.5.0"
 			}
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"optional": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"optional": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -1316,12 +1313,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"optional": true
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+			"optional": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -1341,7 +1340,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -1365,6 +1365,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -1373,6 +1374,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1399,424 +1401,6 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"grpc": {
-			"version": "1.24.2",
-			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
-			"integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
-			"requires": {
-				"@types/bytebuffer": "^5.0.40",
-				"lodash.camelcase": "^4.3.0",
-				"lodash.clone": "^4.5.0",
-				"nan": "^2.13.2",
-				"node-pre-gyp": "^0.14.0",
-				"protobufjs": "^5.0.3"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"bundled": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.3",
-					"bundled": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"needle": {
-					"version": "2.4.0",
-					"bundled": true,
-					"requires": {
-						"debug": "^3.2.6",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.14.0",
-					"bundled": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4.4.2"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"bundled": true
-				},
-				"npm-packlist": {
-					"version": "1.4.6",
-					"bundled": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"bundled": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"tar": {
-					"version": "4.4.13",
-					"bundled": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"bundled": true
-				}
-			}
-		},
 		"handlebars": {
 			"version": "4.7.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
@@ -1840,12 +1424,14 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"optional": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"optional": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -1885,6 +1471,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"optional": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -1909,6 +1496,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"optional": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -1931,6 +1519,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -1947,6 +1536,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1960,12 +1550,14 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"optional": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"optional": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -2026,7 +1618,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"optional": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -2049,7 +1642,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"optional": true
 		},
 		"istanbul": {
 			"version": "0.4.5",
@@ -2202,7 +1796,8 @@
 		"js-sha3": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
+			"optional": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -2223,7 +1818,8 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -2240,17 +1836,20 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"optional": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"optional": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"optional": true
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -2281,6 +1880,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -2289,9 +1889,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-7.2.2.tgz",
-			"integrity": "sha1-rlIwy1V0RRu5eanMaXQoxg9ZjSA=",
+			"version": "8.0.20",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.20.tgz",
+			"integrity": "sha512-JTXt9+nqdynIB8wFsS6e8ffHhIjilhywXwdaEVHSj9OVmwldG2H0EoCqkQ+KXkm2tVqREfH/HEmklY4k1/6Rcg==",
 			"optional": true
 		},
 		"just-extend": {
@@ -2310,6 +1910,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"optional": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -2384,12 +1985,14 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"optional": true
 		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"optional": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -2402,11 +2005,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"lodash.isempty": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -2424,9 +2022,10 @@
 			"dev": true
 		},
 		"long": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"optional": true
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -2499,32 +2098,37 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"optional": true
 		},
 		"mime-types": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"optional": true,
 			"requires": {
-				"mime-db": "1.43.0"
+				"mime-db": "1.44.0"
 			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"optional": true
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"optional": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2775,25 +2379,38 @@
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"optional": true
 		},
 		"nano": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-			"integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
+			"integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
 			"optional": true,
 			"requires": {
-				"cloudant-follow": "~0.17.0",
-				"debug": "^2.2.0",
+				"@types/request": "^2.48.4",
+				"cloudant-follow": "^0.18.2",
+				"debug": "^4.1.1",
 				"errs": "^0.3.2",
-				"lodash.isempty": "^4.4.0",
-				"request": "^2.85.0"
+				"request": "^2.88.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"nconf": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
 			"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+			"optional": true,
 			"requires": {
 				"async": "^1.4.0",
 				"ini": "^1.3.0",
@@ -2804,7 +2421,8 @@
 				"async": {
 					"version": "1.5.2",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+					"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+					"optional": true
 				}
 			}
 		},
@@ -3037,7 +2655,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"optional": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -3083,6 +2702,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3119,11 +2739,6 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
-		"optjs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-			"integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3134,6 +2749,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"optional": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -3195,7 +2811,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -3246,7 +2863,8 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"optional": true
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -3332,17 +2950,36 @@
 		"promise-settle": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promise-settle/-/promise-settle-0.3.0.tgz",
-			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY="
+			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY=",
+			"optional": true
 		},
 		"protobufjs": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-			"integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+			"integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+			"optional": true,
 			"requires": {
-				"ascli": "~1",
-				"bytebuffer": "~5",
-				"glob": "^7.0.5",
-				"yargs": "^3.10.0"
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
+				"@types/node": "^13.7.0",
+				"long": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "13.13.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+					"integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==",
+					"optional": true
+				}
 			}
 		},
 		"pseudomap": {
@@ -3354,7 +2991,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"optional": true
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -3364,7 +3002,8 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"optional": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -3474,6 +3113,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"optional": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -3495,6 +3135,19 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"optional": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"require-directory": {
@@ -3538,7 +3191,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"optional": true
 		},
 		"samsam": {
 			"version": "1.3.0",
@@ -3549,7 +3203,8 @@
 		"secure-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
+			"optional": true
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -3611,7 +3266,8 @@
 		"sjcl": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.7.tgz",
-			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U="
+			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U=",
+			"optional": true
 		},
 		"source-map": {
 			"version": "0.2.0",
@@ -3697,6 +3353,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"optional": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3712,7 +3369,8 @@
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"optional": true
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -3842,6 +3500,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"optional": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -3850,7 +3509,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -3941,6 +3601,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3948,7 +3609,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -4000,6 +3662,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"optional": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -4007,7 +3670,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -4018,23 +3682,6 @@
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			}
-		},
-		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"optional": true,
-			"requires": {
-				"inherits": "2.0.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"optional": true
-				}
 			}
 		},
 		"util-deprecate": {
@@ -4062,6 +3709,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -4095,12 +3743,14 @@
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+			"optional": true
 		},
 		"winston": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-			"integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+			"integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+			"optional": true,
 			"requires": {
 				"async": "~1.0.0",
 				"colors": "1.0.x",
@@ -4126,6 +3776,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -4134,7 +3785,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",
@@ -4162,7 +3814,8 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"optional": true
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -4174,6 +3827,7 @@
 			"version": "3.32.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+			"optional": true,
 			"requires": {
 				"camelcase": "^2.0.1",
 				"cliui": "^3.0.3",

--- a/packages/blockchain-environment-v1/package.json
+++ b/packages/blockchain-environment-v1/package.json
@@ -58,9 +58,9 @@
 		"url": "0.11.0"
 	},
 	"optionalDependencies": {
-		"fabric-ca-client": "2.1.0",
-		"fabric-common": "2.1.0",
-		"fabric-network": "2.1.0"
+		"fabric-ca-client": "2.1.2-snapshot.2",
+		"fabric-common": "2.1.2-snapshot.2",
+		"fabric-network": "2.1.2-snapshot.2"
 	},
 	"license-check-and-add-config": {
 		"folder": ".",

--- a/packages/blockchain-extension/package-lock.json
+++ b/packages/blockchain-extension/package-lock.json
@@ -9650,6 +9650,7 @@
 						"error": "^7.0.2",
 						"find-up": "^3.0.0",
 						"github-username": "^3.0.0",
+						"grouped-queue": "^1.1.0",
 						"istextorbinary": "^2.5.1",
 						"lodash": "^4.17.11",
 						"make-dir": "^3.0.0",
@@ -9663,7 +9664,8 @@
 						"semver": "^7.2.1",
 						"shelljs": "^0.8.3",
 						"text-table": "^0.2.0",
-						"through2": "^3.0.1"
+						"through2": "^3.0.1",
+						"yeoman-environment": "^2.9.5"
 					},
 					"dependencies": {
 						"rimraf": {

--- a/packages/blockchain-fabric-admin/package-lock.json
+++ b/packages/blockchain-fabric-admin/package-lock.json
@@ -5,31 +5,32 @@
     "requires": true,
     "dependencies": {
         "@babel/code-frame": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-            "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.3.tgz",
+            "integrity": "sha512-fDx9eNW0qz0WkUeqL6tXEXzVlPh6Y5aCDEZesl0xBGA8ndRukX91Uk44ZqnkECp01NAZUdCAl+aiQNGi0k88Eg==",
             "dev": true,
             "requires": {
-                "@babel/highlight": "^7.8.3"
+                "@babel/highlight": "^7.10.3"
             }
         },
         "@babel/core": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.8.7.tgz",
-            "integrity": "sha512-rBlqF3Yko9cynC5CCFy6+K/w2N+Sq/ff2BPy+Krp7rHlABIr5epbA7OxVeKoMHB39LZOp1UY5SuLjy6uWi35yA==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.3.tgz",
+            "integrity": "sha512-5YqWxYE3pyhIi84L84YcwjeEgS+fa7ZjK6IBVGTjDVfm64njkR2lfDhVR5OudLk8x2GK59YoSyVv+L/03k1q9w==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.8.3",
-                "@babel/generator": "^7.8.7",
-                "@babel/helpers": "^7.8.4",
-                "@babel/parser": "^7.8.7",
-                "@babel/template": "^7.8.6",
-                "@babel/traverse": "^7.8.6",
-                "@babel/types": "^7.8.7",
+                "@babel/code-frame": "^7.10.3",
+                "@babel/generator": "^7.10.3",
+                "@babel/helper-module-transforms": "^7.10.1",
+                "@babel/helpers": "^7.10.1",
+                "@babel/parser": "^7.10.3",
+                "@babel/template": "^7.10.3",
+                "@babel/traverse": "^7.10.3",
+                "@babel/types": "^7.10.3",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
-                "json5": "^2.1.0",
+                "json5": "^2.1.2",
                 "lodash": "^4.17.13",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
@@ -54,72 +55,142 @@
             }
         },
         "@babel/generator": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.8.8.tgz",
-            "integrity": "sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.3.tgz",
+            "integrity": "sha512-drt8MUHbEqRzNR0xnF8nMehbY11b1SDkRw03PSNH/3Rb2Z35oxkddVSi3rcaak0YJQ86PCuE7Qx1jSFhbLNBMA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.7",
+                "@babel/types": "^7.10.3",
                 "jsesc": "^2.5.1",
                 "lodash": "^4.17.13",
                 "source-map": "^0.5.0"
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-            "integrity": "sha512-BCxgX1BC2hD/oBlIFUgOCQDOPV8nSINxCwM3o93xP4P9Fq6aV5sgv2cOOITDMtCfQ+3PvHp3l689XZvAM9QyOA==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.3.tgz",
+            "integrity": "sha512-FvSj2aiOd8zbeqijjgqdMDSyxsGHaMt5Tr0XjQsGKHD3/1FP3wksjnLAWzxw7lvXiej8W1Jt47SKTZ6upQNiRw==",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.8.3",
-                "@babel/template": "^7.8.3",
-                "@babel/types": "^7.8.3"
+                "@babel/helper-get-function-arity": "^7.10.3",
+                "@babel/template": "^7.10.3",
+                "@babel/types": "^7.10.3"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-            "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.3.tgz",
+            "integrity": "sha512-iUD/gFsR+M6uiy69JA6fzM5seno8oE85IYZdbVVEuQaZlEzMO2MXblh+KSPJgsZAUx0EEbWXU0yJaW7C9CdAVg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.3"
+            }
+        },
+        "@babel/helper-member-expression-to-functions": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.3.tgz",
+            "integrity": "sha512-q7+37c4EPLSjNb2NmWOjNwj0+BOyYlssuQ58kHEWk1Z78K5i8vTUsteq78HMieRPQSl/NtpQyJfdjt3qZ5V2vw==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.3"
+            }
+        },
+        "@babel/helper-module-imports": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.3.tgz",
+            "integrity": "sha512-Jtqw5M9pahLSUWA+76nhK9OG8nwYXzhQzVIGFoNaHnXF/r4l7kz4Fl0UAW7B6mqC5myoJiBP5/YQlXQTMfHI9w==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.3"
+            }
+        },
+        "@babel/helper-module-transforms": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
+            "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-module-imports": "^7.10.1",
+                "@babel/helper-replace-supers": "^7.10.1",
+                "@babel/helper-simple-access": "^7.10.1",
+                "@babel/helper-split-export-declaration": "^7.10.1",
+                "@babel/template": "^7.10.1",
+                "@babel/types": "^7.10.1",
+                "lodash": "^4.17.13"
+            }
+        },
+        "@babel/helper-optimise-call-expression": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.3.tgz",
+            "integrity": "sha512-kT2R3VBH/cnSz+yChKpaKRJQJWxdGoc6SjioRId2wkeV3bK0wLLioFpJROrX0U4xr/NmxSSAWT/9Ih5snwIIzg==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "^7.10.3"
+            }
+        },
+        "@babel/helper-replace-supers": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
+            "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-member-expression-to-functions": "^7.10.1",
+                "@babel/helper-optimise-call-expression": "^7.10.1",
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
+            }
+        },
+        "@babel/helper-simple-access": {
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
+            "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.10.1",
+                "@babel/types": "^7.10.1"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-            "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+            "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.8.3"
+                "@babel/types": "^7.10.1"
             }
         },
+        "@babel/helper-validator-identifier": {
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.3.tgz",
+            "integrity": "sha512-bU8JvtlYpJSBPuj1VUmKpFGaDZuLxASky3LhaKj3bmpSTY6VWooSM8msk+Z0CZoErFye2tlABF6yDkT3FOPAXw==",
+            "dev": true
+        },
         "@babel/helpers": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.8.4.tgz",
-            "integrity": "sha512-VPbe7wcQ4chu4TDQjimHv/5tj73qz88o12EPkO2ValS2QiQS/1F2SsjyIGNnAD0vF/nZS6Cf9i+vW6HIlnaR8w==",
+            "version": "7.10.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
+            "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.8.3",
-                "@babel/traverse": "^7.8.4",
-                "@babel/types": "^7.8.3"
+                "@babel/template": "^7.10.1",
+                "@babel/traverse": "^7.10.1",
+                "@babel/types": "^7.10.1"
             }
         },
         "@babel/highlight": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-            "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.3.tgz",
+            "integrity": "sha512-Ih9B/u7AtgEnySE2L2F0Xm0GaM729XqqLfHkalTsbjXGyqmf/6M0Cu0WpvqueUlW+xk88BHw9Nkpj49naU+vWw==",
             "dev": true,
             "requires": {
+                "@babel/helper-validator-identifier": "^7.10.3",
                 "chalk": "^2.0.0",
-                "esutils": "^2.0.2",
                 "js-tokens": "^4.0.0"
             }
         },
         "@babel/parser": {
-            "version": "7.8.8",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.8.8.tgz",
-            "integrity": "sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.3.tgz",
+            "integrity": "sha512-oJtNJCMFdIMwXGmx+KxuaD7i3b8uS7TTFYW/FNG2BT8m+fmGHoiPYoH0Pe3gya07WuFmM5FCDIr1x0irkD/hyA==",
             "dev": true
         },
         "@babel/runtime-corejs3": {
@@ -133,28 +204,28 @@
             }
         },
         "@babel/template": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-            "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.3.tgz",
+            "integrity": "sha512-5BjI4gdtD+9fHZUsaxPHPNpwa+xRkDO7c7JbhYn2afvrkDu5SfAAbi9AIMXw2xEhO/BR35TqiW97IqNvCo/GqA==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.8.3",
-                "@babel/parser": "^7.8.6",
-                "@babel/types": "^7.8.6"
+                "@babel/code-frame": "^7.10.3",
+                "@babel/parser": "^7.10.3",
+                "@babel/types": "^7.10.3"
             }
         },
         "@babel/traverse": {
-            "version": "7.8.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.8.6.tgz",
-            "integrity": "sha512-2B8l0db/DPi8iinITKuo7cbPznLCEk0kCxDoB9/N6gGNg/gxOXiR/IcymAFPiBwk5w6TtQ27w4wpElgp9btR9A==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.3.tgz",
+            "integrity": "sha512-qO6623eBFhuPm0TmmrUFMT1FulCmsSeJuVGhiLodk2raUDFhhTECLd9E9jC4LBIWziqt4wgF6KuXE4d+Jz9yug==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.8.3",
-                "@babel/generator": "^7.8.6",
-                "@babel/helper-function-name": "^7.8.3",
-                "@babel/helper-split-export-declaration": "^7.8.3",
-                "@babel/parser": "^7.8.6",
-                "@babel/types": "^7.8.6",
+                "@babel/code-frame": "^7.10.3",
+                "@babel/generator": "^7.10.3",
+                "@babel/helper-function-name": "^7.10.3",
+                "@babel/helper-split-export-declaration": "^7.10.1",
+                "@babel/parser": "^7.10.3",
+                "@babel/types": "^7.10.3",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.13"
@@ -172,24 +243,42 @@
             }
         },
         "@babel/types": {
-            "version": "7.8.7",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.8.7.tgz",
-            "integrity": "sha512-k2TreEHxFA4CjGkL+GYjRyx35W0Mr7DP5+9q6WMkyKXB+904bYmG40syjMFV0oLlhhFCwWl0vA0DyzTDkwAiJw==",
+            "version": "7.10.3",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.3.tgz",
+            "integrity": "sha512-nZxaJhBXBQ8HVoIcGsf9qWep3Oh3jCENK54V4mRF7qaJabVsAYdbTtmSD8WmAp1R6ytPiu5apMwSXyxB1WlaBA==",
             "dev": true,
             "requires": {
-                "esutils": "^2.0.2",
+                "@babel/helper-validator-identifier": "^7.10.3",
                 "lodash": "^4.17.13",
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@grpc/grpc-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.3.tgz",
+            "integrity": "sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==",
+            "requires": {
+                "semver": "^6.2.0"
+            }
+        },
+        "@grpc/proto-loader": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+            "integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+            "requires": {
+                "lodash.camelcase": "^4.3.0",
+                "protobufjs": "^6.8.6"
+            }
+        },
         "@istanbuljs/load-nyc-config": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-            "integrity": "sha512-ZR0rq/f/E4f4XcgnDvtMWXCUJpi8eO0rssVhmztsZqLIEFA9UUP9zmpE0VxlM+kv/E1ul2I876Fwil2ayptDVg==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.3.1",
                 "find-up": "^4.1.0",
+                "get-package-type": "^0.1.0",
                 "js-yaml": "^3.13.1",
                 "resolve-from": "^5.0.0"
             },
@@ -199,6 +288,40 @@
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
                     "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
                     "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
                 }
             }
         },
@@ -207,6 +330,60 @@
             "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
             "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
             "dev": true
+        },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@sinonjs/commons": {
             "version": "1.7.1",
@@ -245,9 +422,9 @@
             "dev": true
         },
         "@types/bytebuffer": {
-            "version": "5.0.40",
-            "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-            "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+            "version": "5.0.41",
+            "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.41.tgz",
+            "integrity": "sha512-Mdrv4YcaHvpkx25ksqqFaezktx3yZRcd51GZY0rY/9avyaqZdiT/GiWRhfrJhMpgzXqTOSHgGvsumGxJFNiZZA==",
             "requires": {
                 "@types/long": "*",
                 "@types/node": "*"
@@ -286,9 +463,9 @@
             "dev": true
         },
         "@types/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==",
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.1.1.tgz",
+            "integrity": "sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -306,31 +483,19 @@
             "dev": true
         },
         "@types/node": {
-            "version": "13.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-            "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+            "version": "13.13.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+            "integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw=="
         },
         "@types/request": {
-            "version": "2.48.4",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-            "integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+            "version": "2.48.5",
+            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+            "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
             "requires": {
                 "@types/caseless": "*",
                 "@types/node": "*",
                 "@types/tough-cookie": "*",
                 "form-data": "^2.5.0"
-            },
-            "dependencies": {
-                "form-data": {
-                    "version": "2.5.1",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-                    "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.6",
-                        "mime-types": "^2.1.12"
-                    }
-                }
             }
         },
         "@types/sinon": {
@@ -340,9 +505,9 @@
             "dev": true
         },
         "@types/sinon-chai": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
-            "integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+            "integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
             "dev": true,
             "requires": {
                 "@types/chai": "*",
@@ -496,15 +661,20 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
+        "at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
+        },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -547,9 +717,9 @@
             "dev": true
         },
         "bn.js": {
-            "version": "4.11.8",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+            "version": "4.11.9",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+            "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -643,6 +813,11 @@
                 "write-file-atomic": "^3.0.0"
             }
         },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+        },
         "camelcase": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -692,6 +867,15 @@
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                     "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                     "dev": true
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -801,19 +985,19 @@
             }
         },
         "cloudant-follow": {
-            "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-            "integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+            "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
             "requires": {
                 "browser-request": "~0.3.0",
-                "debug": "^3.0.0",
-                "request": "^2.83.0"
+                "debug": "^4.0.1",
+                "request": "^2.88.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -904,14 +1088,25 @@
             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cross-spawn": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-            "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
             "dev": true,
             "requires": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
                 "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "crypt": {
@@ -1006,6 +1201,7 @@
             "version": "2.6.9",
             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "dev": true,
             "requires": {
                 "ms": "2.0.0"
             },
@@ -1013,7 +1209,8 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
@@ -1080,9 +1277,9 @@
             }
         },
         "elliptic": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-            "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
             "requires": {
                 "bn.js": "^4.4.0",
                 "brorand": "^1.0.1",
@@ -1094,9 +1291,9 @@
             }
         },
         "emoji-regex": {
-            "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
             "dev": true
         },
         "end-of-stream": {
@@ -1131,22 +1328,22 @@
             "integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
         },
         "es-abstract": {
-            "version": "1.17.5",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+            "version": "1.17.6",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+            "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
             "dev": true,
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1",
-                "is-callable": "^1.1.5",
-                "is-regex": "^1.0.5",
+                "is-callable": "^1.2.0",
+                "is-regex": "^1.1.0",
                 "object-inspect": "^1.7.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.0",
-                "string.prototype.trimleft": "^2.1.1",
-                "string.prototype.trimright": "^2.1.1"
+                "string.prototype.trimend": "^1.0.1",
+                "string.prototype.trimstart": "^1.0.1"
             }
         },
         "es-to-primitive": {
@@ -1210,12 +1407,6 @@
             "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
             "dev": true
         },
-        "esutils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-            "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-            "dev": true
-        },
         "ext": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -1249,55 +1440,26 @@
             "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
         },
         "fabric-ca-client": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-            "integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
+            "version": "2.1.2-snapshot.2",
+            "resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.2-snapshot.2.tgz",
+            "integrity": "sha512-sttS3p2chFDy4VCCxHxLOPLOL9ilwrHtbveVuhVGITvHCL8ZIKMVoTdHtRB56+I1o89nIp9drxTUsgAkBM6aKg==",
             "requires": {
-                "fabric-common": "^2.1.0",
-                "jsrsasign": "^7.2.2",
+                "fabric-common": "2.1.2-snapshot.2",
+                "jsrsasign": "^8.0.15",
                 "url": "^0.11.0",
-                "util": "^0.10.3",
                 "winston": "^2.4.0"
-            },
-            "dependencies": {
-                "fabric-common": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-                    "integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-                    "requires": {
-                        "elliptic": "^6.2.3",
-                        "fabric-protos": "^2.1.0",
-                        "js-sha3": "^0.7.0",
-                        "nano": "^6.4.4",
-                        "nconf": "^0.10.0",
-                        "pkcs11js": "^1.0.6",
-                        "promise-settle": "^0.3.0",
-                        "sjcl": "1.0.7",
-                        "winston": "^2.4.0",
-                        "yn": "^3.1.0"
-                    }
-                },
-                "fabric-protos": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-                    "integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
-                    "requires": {
-                        "grpc": "1.24.2",
-                        "lodash.clone": "4.5.0",
-                        "protobufjs": "^5.0.3"
-                    }
-                }
             }
         },
         "fabric-common": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-            "integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
+            "version": "2.1.2-snapshot.2",
+            "resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.2-snapshot.2.tgz",
+            "integrity": "sha512-OVhoSQQkROFe6ZFUOjxB8xqa9csQtORKp8o8g3ZuH2OmR1LSIjg2WQAAKj3YwKTZuGhSz/ltySo/HCu5zQyHXA==",
             "requires": {
-                "elliptic": "^6.2.3",
-                "fabric-protos": "^2.1.0",
+                "callsite": "^1.0.0",
+                "elliptic": "^6.5.2",
+                "fabric-protos": "2.1.2-snapshot.2",
                 "js-sha3": "^0.7.0",
-                "nano": "^6.4.4",
+                "jsrsasign": "^8.0.15",
                 "nconf": "^0.10.0",
                 "pkcs11js": "^1.0.6",
                 "promise-settle": "^0.3.0",
@@ -1307,114 +1469,65 @@
             },
             "dependencies": {
                 "fabric-protos": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-                    "integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
+                    "version": "2.1.2-snapshot.2",
+                    "resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.2-snapshot.2.tgz",
+                    "integrity": "sha512-qCfVyjMxWp885HREHyhacdlF4iclMguuzasSM0nO7MWBYHCnyaSbR7/JUNjuBdHg9zzLbVLdCY8RX13ZMUg+uw==",
                     "requires": {
-                        "grpc": "1.24.2",
-                        "lodash.clone": "4.5.0",
-                        "protobufjs": "^5.0.3"
+                        "@grpc/grpc-js": "1.0.3",
+                        "@grpc/proto-loader": "0.5.4",
+                        "lodash.clone": "4.5.0"
                     }
                 }
             }
         },
         "fabric-network": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.0.tgz",
-            "integrity": "sha512-9VqUvYX2fROleTl1sKIx51EhLDfhDxDMHIgafRvicBFJKYAeQ6nyKWmk3gZIlGxmB2LjpIV+WzwR5Z2PiNI03w==",
+            "version": "2.1.2-snapshot.2",
+            "resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.2-snapshot.2.tgz",
+            "integrity": "sha512-gACrYS5ojBnv/J9mdeWk8zPv/Mj5axkww3XaxJWYyX6Q+NzWDeUmi5GmhB5kTQ0H1C8WfL2iY9//NZ15lqHSuA==",
             "requires": {
-                "fabric-ca-client": "^2.1.0",
-                "fabric-common": "^2.1.0",
-                "fs-extra": "^8.1.0",
+                "fabric-ca-client": "2.1.2-snapshot.2",
+                "fabric-common": "2.1.2-snapshot.2",
+                "fabric-protos": "2.1.2-snapshot.2",
+                "fs-extra": "^9.0.0",
                 "long": "^4.0.0",
-                "nano": "^8.1.0",
-                "winston": "^2.4.0"
+                "nano": "^8.2.2",
+                "winston": "^2.4.4"
             },
             "dependencies": {
-                "fabric-ca-client": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-                    "integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
-                    "requires": {
-                        "fabric-common": "^2.1.0",
-                        "jsrsasign": "^7.2.2",
-                        "url": "^0.11.0",
-                        "util": "^0.10.3",
-                        "winston": "^2.4.0"
-                    }
-                },
-                "fabric-common": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-                    "integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-                    "requires": {
-                        "elliptic": "^6.2.3",
-                        "fabric-protos": "^2.1.0",
-                        "js-sha3": "^0.7.0",
-                        "nano": "^6.4.4",
-                        "nconf": "^0.10.0",
-                        "pkcs11js": "^1.0.6",
-                        "promise-settle": "^0.3.0",
-                        "sjcl": "1.0.7",
-                        "winston": "^2.4.0",
-                        "yn": "^3.1.0"
-                    },
-                    "dependencies": {
-                        "nano": {
-                            "version": "6.4.4",
-                            "resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-                            "integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
-                            "requires": {
-                                "cloudant-follow": "~0.17.0",
-                                "debug": "^2.2.0",
-                                "errs": "^0.3.2",
-                                "lodash.isempty": "^4.4.0",
-                                "request": "^2.85.0"
-                            }
-                        }
-                    }
-                },
                 "fabric-protos": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-                    "integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
+                    "version": "2.1.2-snapshot.2",
+                    "resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.2-snapshot.2.tgz",
+                    "integrity": "sha512-qCfVyjMxWp885HREHyhacdlF4iclMguuzasSM0nO7MWBYHCnyaSbR7/JUNjuBdHg9zzLbVLdCY8RX13ZMUg+uw==",
                     "requires": {
-                        "grpc": "1.24.2",
-                        "lodash.clone": "4.5.0",
-                        "protobufjs": "^5.0.3"
+                        "@grpc/grpc-js": "1.0.3",
+                        "@grpc/proto-loader": "0.5.4",
+                        "lodash.clone": "4.5.0"
                     }
                 },
-                "nano": {
-                    "version": "8.2.2",
-                    "resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
-                    "integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
+                "fs-extra": {
+                    "version": "9.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+                    "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
                     "requires": {
-                        "@types/request": "^2.48.4",
-                        "cloudant-follow": "^0.18.2",
-                        "debug": "^4.1.1",
-                        "errs": "^0.3.2",
-                        "request": "^2.88.0"
-                    },
-                    "dependencies": {
-                        "cloudant-follow": {
-                            "version": "0.18.2",
-                            "resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
-                            "integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
-                            "requires": {
-                                "browser-request": "~0.3.0",
-                                "debug": "^4.0.1",
-                                "request": "^2.88.0"
-                            }
-                        },
-                        "debug": {
-                            "version": "4.1.1",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                            "requires": {
-                                "ms": "^2.1.1"
-                            }
-                        }
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^1.0.0"
                     }
+                },
+                "jsonfile": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+                    "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^1.0.0"
+                    }
+                },
+                "universalify": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+                    "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
                 }
             }
         },
@@ -1426,12 +1539,25 @@
                 "grpc": "1.24.2",
                 "lodash.clone": "4.5.0",
                 "protobufjs": "^5.0.3"
+            },
+            "dependencies": {
+                "protobufjs": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+                    "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+                    "requires": {
+                        "ascli": "~1",
+                        "bytebuffer": "~5",
+                        "glob": "^7.0.5",
+                        "yargs": "^3.10.0"
+                    }
+                }
             }
         },
         "fast-deep-equal": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-            "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
         },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
@@ -1476,13 +1602,12 @@
             }
         },
         "find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+            "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
             "dev": true,
             "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
+                "locate-path": "^3.0.0"
             }
         },
         "flat": {
@@ -1518,9 +1643,9 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+            "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -1582,6 +1707,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "get-package-type": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
         },
         "getpass": {
@@ -1940,6 +2071,17 @@
                     "version": "2.0.1",
                     "bundled": true
                 },
+                "protobufjs": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
+                    "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+                    "requires": {
+                        "ascli": "~1",
+                        "bytebuffer": "~5",
+                        "glob": "^7.0.5",
+                        "yargs": "^3.10.0"
+                    }
+                },
                 "rc": {
                     "version": "1.2.8",
                     "bundled": true,
@@ -2134,9 +2276,9 @@
             }
         },
         "html-escaper": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
-            "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
             "dev": true
         },
         "http-signature": {
@@ -2215,9 +2357,9 @@
             "dev": true
         },
         "is-callable": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-            "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+            "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
             "dev": true
         },
         "is-date-object": {
@@ -2262,12 +2404,12 @@
             "dev": true
         },
         "is-regex": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-            "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+            "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
             "dev": true,
             "requires": {
-                "has": "^1.0.3"
+                "has-symbols": "^1.0.1"
             }
         },
         "is-stream": {
@@ -2334,15 +2476,12 @@
             }
         },
         "istanbul-lib-instrument": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
-            "integrity": "sha512-imIchxnodll7pvQBYOqUu88EufLCU56LMeFPZZM/fJZ1irYcYdqroaV+ACK1Ila8ls09iEYArp+nqyC6lW1Vfg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+            "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.7.5",
-                "@babel/parser": "^7.7.5",
-                "@babel/template": "^7.7.4",
-                "@babel/traverse": "^7.7.4",
                 "@istanbuljs/schema": "^0.1.2",
                 "istanbul-lib-coverage": "^3.0.0",
                 "semver": "^6.3.0"
@@ -2420,9 +2559,9 @@
             }
         },
         "istanbul-reports": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-            "integrity": "sha512-2osTcC8zcOSUkImzN2EWQta3Vdi4WjjKw99P2yWx5mLnigAM0Rd5uYFn1cf2i/Ois45GkNjaoTqc5CxgMSX80A==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+            "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
             "dev": true,
             "requires": {
                 "html-escaper": "^2.0.0",
@@ -2477,20 +2616,12 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "json5": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
-            "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+            "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
             "dev": true,
             "requires": {
                 "minimist": "^1.2.5"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.5",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-                    "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-                    "dev": true
-                }
             }
         },
         "jsonfile": {
@@ -2513,9 +2644,9 @@
             }
         },
         "jsrsasign": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-7.2.2.tgz",
-            "integrity": "sha1-rlIwy1V0RRu5eanMaXQoxg9ZjSA="
+            "version": "8.0.20",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.20.tgz",
+            "integrity": "sha512-JTXt9+nqdynIB8wFsS6e8ffHhIjilhywXwdaEVHSj9OVmwldG2H0EoCqkQ+KXkm2tVqREfH/HEmklY4k1/6Rcg=="
         },
         "just-extend": {
             "version": "4.1.0",
@@ -2582,12 +2713,13 @@
             }
         },
         "locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+            "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
             "dev": true,
             "requires": {
-                "p-locate": "^4.1.0"
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -2611,11 +2743,6 @@
             "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
             "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
             "dev": true
-        },
-        "lodash.isempty": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-            "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
         },
         "log-symbols": {
             "version": "3.0.0",
@@ -2644,9 +2771,9 @@
             "dev": true
         },
         "make-dir": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.2.tgz",
-            "integrity": "sha512-rYKABKutXa6vXTXhoV18cBE7PaewPXHe/Bdq4v+ZLMhxbWApkFFplT0LcbMW+6BbjnQXzZ/sAvSE/JdguApG5w==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+            "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
             "dev": true,
             "requires": {
                 "semver": "^6.0.0"
@@ -2670,16 +2797,16 @@
             }
         },
         "mime-db": {
-            "version": "1.43.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
         },
         "mime-types": {
-            "version": "2.1.26",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
             "requires": {
-                "mime-db": "1.43.0"
+                "mime-db": "1.44.0"
             }
         },
         "minimalistic-assert": {
@@ -2700,6 +2827,12 @@
                 "brace-expansion": "^1.1.7"
             }
         },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
+        },
         "mkdirp": {
             "version": "0.5.5",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
@@ -2718,9 +2851,9 @@
             }
         },
         "mocha": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-            "integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+            "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
             "dev": true,
             "requires": {
                 "ansi-colors": "3.2.3",
@@ -2755,12 +2888,6 @@
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
-                },
                 "cliui": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -2787,26 +2914,11 @@
                     "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
                     "dev": true
                 },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
-                },
                 "escape-string-regexp": {
                     "version": "1.0.5",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                     "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
                     "dev": true
-                },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
                 },
                 "glob": {
                     "version": "7.1.3",
@@ -2828,35 +2940,10 @@
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
                 "ms": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
                     "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -2877,24 +2964,6 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-                    "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
-                "which": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-                    "dev": true,
-                    "requires": {
-                        "isexe": "^2.0.0"
                     }
                 },
                 "wrap-ansi": {
@@ -2930,16 +2999,6 @@
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
                         "yargs-parser": "^13.1.2"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "13.1.2",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -3017,15 +3076,25 @@
             "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
         },
         "nano": {
-            "version": "6.4.4",
-            "resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-            "integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
+            "version": "8.2.2",
+            "resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
+            "integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
             "requires": {
-                "cloudant-follow": "~0.17.0",
-                "debug": "^2.2.0",
+                "@types/request": "^2.48.4",
+                "cloudant-follow": "^0.18.2",
+                "debug": "^4.1.1",
                 "errs": "^0.3.2",
-                "lodash.isempty": "^4.4.0",
-                "request": "^2.85.0"
+                "request": "^2.88.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "nconf": {
@@ -3117,9 +3186,9 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nyc": {
-            "version": "15.0.0",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.0.0.tgz",
-            "integrity": "sha512-qcLBlNCKMDVuKb7d1fpxjPR8sHeMVX0CHarXAVzrVWoFrigCkYR8xcrjfXSPi5HXM7EU78L6ywO7w1c5rZNCNg==",
+            "version": "15.1.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+            "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
             "dev": true,
             "requires": {
                 "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -3130,6 +3199,7 @@
                 "find-cache-dir": "^3.2.0",
                 "find-up": "^4.1.0",
                 "foreground-child": "^2.0.0",
+                "get-package-type": "^0.1.0",
                 "glob": "^7.1.6",
                 "istanbul-lib-coverage": "^3.0.0",
                 "istanbul-lib-hook": "^3.0.0",
@@ -3137,10 +3207,9 @@
                 "istanbul-lib-processinfo": "^2.0.2",
                 "istanbul-lib-report": "^3.0.0",
                 "istanbul-lib-source-maps": "^4.0.0",
-                "istanbul-reports": "^3.0.0",
-                "js-yaml": "^3.13.1",
+                "istanbul-reports": "^3.0.2",
                 "make-dir": "^3.0.0",
-                "node-preload": "^0.2.0",
+                "node-preload": "^0.2.1",
                 "p-map": "^3.0.0",
                 "process-on-spawn": "^1.0.0",
                 "resolve-from": "^5.0.0",
@@ -3148,7 +3217,6 @@
                 "signal-exit": "^3.0.2",
                 "spawn-wrap": "^2.0.0",
                 "test-exclude": "^6.0.0",
-                "uuid": "^3.3.3",
                 "yargs": "^15.0.2"
             },
             "dependencies": {
@@ -3161,6 +3229,12 @@
                         "@types/color-name": "^1.1.1",
                         "color-convert": "^2.0.1"
                     }
+                },
+                "camelcase": {
+                    "version": "5.3.1",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+                    "dev": true
                 },
                 "cliui": {
                     "version": "6.0.0",
@@ -3188,10 +3262,50 @@
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                     "dev": true
                 },
+                "emoji-regex": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+                    "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+                    "dev": true
+                },
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
                     "dev": true
                 },
                 "string-width": {
@@ -3240,6 +3354,16 @@
                         "y18n": "^4.0.0",
                         "yargs-parser": "^18.1.1"
                     }
+                },
+                "yargs-parser": {
+                    "version": "18.1.3",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+                    "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+                    "dev": true,
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
                 }
             }
         },
@@ -3255,9 +3379,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-            "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+            "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
             "dev": true
         },
         "object-keys": {
@@ -3310,21 +3434,21 @@
             }
         },
         "p-limit": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-            "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
         },
         "p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+            "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
             "dev": true,
             "requires": {
-                "p-limit": "^2.2.0"
+                "p-limit": "^2.0.0"
             }
         },
         "p-map": {
@@ -3373,9 +3497,9 @@
             }
         },
         "path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
             "dev": true
         },
         "path-is-absolute": {
@@ -3505,6 +3629,42 @@
             "dev": true,
             "requires": {
                 "find-up": "^4.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+                    "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^5.0.0",
+                        "path-exists": "^4.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+                    "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^4.1.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+                    "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^2.2.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+                    "dev": true
+                }
             }
         },
         "process-nextick-args": {
@@ -3533,14 +3693,23 @@
             "integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY="
         },
         "protobufjs": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-            "integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+            "version": "6.9.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+            "integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
             "requires": {
-                "ascli": "~1",
-                "bytebuffer": "~5",
-                "glob": "^7.0.5",
-                "yargs": "^3.10.0"
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": "^13.7.0",
+                "long": "^4.0.0"
             }
         },
         "psl": {
@@ -3549,9 +3718,9 @@
             "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
         },
         "punycode": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-            "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         },
         "qs": {
             "version": "6.5.2",
@@ -3639,6 +3808,18 @@
                 "tough-cookie": "~2.5.0",
                 "tunnel-agent": "^0.6.0",
                 "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "form-data": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+                    "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.6",
+                        "mime-types": "^2.1.12"
+                    }
+                }
             }
         },
         "require-directory": {
@@ -3701,8 +3882,7 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-            "dev": true
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         },
         "serialize-error": {
             "version": "4.1.0",
@@ -3735,9 +3915,9 @@
             "dev": true
         },
         "signal-exit": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
             "dev": true
         },
         "sinon": {
@@ -3790,9 +3970,9 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.16",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
-            "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
+            "version": "0.5.19",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -3819,6 +3999,17 @@
                 "rimraf": "^3.0.0",
                 "signal-exit": "^3.0.2",
                 "which": "^2.0.1"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "dev": true,
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
             }
         },
         "sprintf-js": {
@@ -3926,28 +4117,6 @@
                 "es-abstract": "^1.17.5"
             }
         },
-        "string.prototype.trimleft": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-            "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimstart": "^1.0.0"
-            }
-        },
-        "string.prototype.trimright": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-            "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5",
-                "string.prototype.trimend": "^1.0.0"
-            }
-        },
         "string.prototype.trimstart": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -4003,9 +4172,9 @@
             "dev": true
         },
         "supports-color": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+            "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
             "dev": true,
             "requires": {
                 "has-flag": "^3.0.0"
@@ -4097,18 +4266,25 @@
             "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                }
             }
         },
         "ts-node": {
-            "version": "8.6.2",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.2.tgz",
-            "integrity": "sha512-4mZEbofxGqLL2RImpe3zMJukvEvcO1XP8bj8ozBPySdCUXEcU5cIRwR0aM3R+VoZq7iXc8N86NC0FspGRqP4gg==",
+            "version": "8.10.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+            "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
             "dev": true,
             "requires": {
                 "arg": "^4.1.0",
                 "diff": "^4.0.1",
                 "make-error": "^1.1.1",
-                "source-map-support": "^0.5.6",
+                "source-map-support": "^0.5.17",
                 "yn": "3.1.1"
             }
         },
@@ -4122,15 +4298,15 @@
             }
         },
         "tslib": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-            "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+            "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
             "dev": true
         },
         "tslint": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.0.tgz",
-            "integrity": "sha512-fXjYd/61vU6da04E505OZQGb2VCN2Mq3doeWcOIryuG+eqdmFUXTYVwdhnbEu2k46LNLgUYt9bI5icQze/j0bQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.2.tgz",
+            "integrity": "sha512-UyNrLdK3E0fQG/xWNqAFAC5ugtFyPO4JJR1KyyfQAyzR8W0fTRrC91A8Wej4BntFzcvETdCSDa/4PnNYJQLYiA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
@@ -4141,7 +4317,7 @@
                 "glob": "^7.1.1",
                 "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
-                "mkdirp": "^0.5.1",
+                "mkdirp": "^0.5.3",
                 "resolve": "^1.3.2",
                 "semver": "^5.3.0",
                 "tslib": "^1.10.0",
@@ -4212,9 +4388,9 @@
             }
         },
         "typescript": {
-            "version": "3.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-            "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+            "version": "3.9.5",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+            "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
             "dev": true
         },
         "universalify": {
@@ -4234,6 +4410,13 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "requires": {
                 "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                }
             }
         },
         "url": {
@@ -4243,28 +4426,6 @@
             "requires": {
                 "punycode": "1.3.2",
                 "querystring": "0.2.0"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-                }
-            }
-        },
-        "util": {
-            "version": "0.10.4",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-            "requires": {
-                "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.3",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
-                }
             }
         },
         "util-arity": {
@@ -4294,9 +4455,9 @@
             }
         },
         "which": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
@@ -4323,9 +4484,9 @@
             "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
         },
         "winston": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-            "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+            "version": "2.4.5",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+            "integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
             "requires": {
                 "async": "~1.0.0",
                 "colors": "1.0.x",
@@ -4418,9 +4579,9 @@
             }
         },
         "yargs-parser": {
-            "version": "18.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-            "integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+            "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
             "dev": true,
             "requires": {
                 "camelcase": "^5.0.0",
@@ -4452,12 +4613,6 @@
                     "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
                     "dev": true
                 },
-                "camelcase": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                    "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                    "dev": true
-                },
                 "cliui": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -4469,50 +4624,10 @@
                         "wrap-ansi": "^5.1.0"
                     }
                 },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
-                },
-                "find-up": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
-                    "requires": {
-                        "locate-path": "^3.0.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
-                "locate-path": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
-                    "requires": {
-                        "p-locate": "^3.0.0",
-                        "path-exists": "^3.0.0"
-                    }
-                },
-                "p-locate": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
-                    "requires": {
-                        "p-limit": "^2.0.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
                     "dev": true
                 },
                 "string-width": {
@@ -4568,16 +4683,6 @@
                         "which-module": "^2.0.0",
                         "y18n": "^4.0.0",
                         "yargs-parser": "^13.1.2"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "13.1.2",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
                     }
                 }
             }

--- a/packages/blockchain-fabric-admin/package.json
+++ b/packages/blockchain-fabric-admin/package.json
@@ -23,14 +23,15 @@
         "generatePolcyParser": "pegjs --plugin ./node_modules/ts-pegjs --extra-options-file ./src/pegjs/config.json -o ./src/pegjs/policyParser.ts --cache ./src/pegjs/endorsementPolicy.pegjs"
     },
     "dependencies": {
-        "fabric-ca-client": "2.1.0",
-        "fabric-common": "2.1.0",
-        "fabric-network": "2.1.0",
+        "fabric-ca-client": "2.1.2-snapshot.2",
+        "fabric-common": "2.1.2-snapshot.2",
+        "fabric-network": "2.1.2-snapshot.2",
         "fabric-protos": "2.1.0",
         "fs-extra": "^8.1.0",
         "ignore-walk": "^3.0.0",
         "klaw": "^2.0.0",
         "long": "^4.0.0",
+        "protobufjs": "^6.9.0",
         "tar-stream": "1.6.1"
     },
     "devDependencies": {

--- a/packages/blockchain-fabric-admin/src/LifecyclePeer.ts
+++ b/packages/blockchain-fabric-admin/src/LifecyclePeer.ts
@@ -316,7 +316,7 @@ export class LifecyclePeer {
             const provider: IdentityProvider = this.wallet.getProviderRegistry().getProvider(identity.type);
             const user: User = await provider.getUserContext(identity, this.identity);
             const identityContext: IdentityContext = fabricClient.newIdentityContext(user);
-            endorsement.build(identityContext, buildRequest);
+            endorsement.build(identityContext, buildRequest as any);
 
             logger.debug('%s - sign the get all install smart contract request');
             endorsement.sign(identityContext);

--- a/packages/blockchain-gateway-v1/package-lock.json
+++ b/packages/blockchain-gateway-v1/package-lock.json
@@ -129,11 +129,102 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@grpc/grpc-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.3.tgz",
+			"integrity": "sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==",
+			"optional": true,
+			"requires": {
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"optional": true
+				}
+			}
+		},
+		"@grpc/proto-loader": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+			"integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+			"optional": true,
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"protobufjs": "^6.8.6"
+			}
+		},
 		"@istanbuljs/nyc-config-typescript": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
 			"integrity": "sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==",
 			"dev": true
+		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"optional": true
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"optional": true
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"optional": true
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"optional": true
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"optional": true,
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"optional": true
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"optional": true
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"optional": true
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"optional": true
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"optional": true
 		},
 		"@sinonjs/commons": {
 			"version": "1.6.0",
@@ -164,15 +255,6 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
-		},
-		"@types/bytebuffer": {
-			"version": "5.0.40",
-			"resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-			"integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
-			"requires": {
-				"@types/long": "*",
-				"@types/node": "*"
-			}
 		},
 		"@types/caseless": {
 			"version": "0.12.2",
@@ -224,7 +306,8 @@
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"optional": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -244,28 +327,15 @@
 			"integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
 		},
 		"@types/request": {
-			"version": "2.48.4",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-			"integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+			"version": "2.48.5",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
 			"optional": true,
 			"requires": {
 				"@types/caseless": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
 			}
 		},
 		"@types/rimraf": {
@@ -310,6 +380,7 @@
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"optional": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -437,19 +508,11 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"ascli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-			"integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-			"requires": {
-				"colour": "~0.7.1",
-				"optjs": "~3.2.2"
-			}
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"optional": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -457,7 +520,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"optional": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -473,17 +537,26 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"optional": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"optional": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"optional": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"optional": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -532,12 +605,14 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -549,14 +624,16 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -565,12 +642,14 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"optional": true
 		},
 		"browser-request": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+			"optional": true
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
@@ -590,14 +669,6 @@
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
-		"bytebuffer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-			"requires": {
-				"long": "~3"
-			}
-		},
 		"caching-transform": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -610,15 +681,23 @@
 				"write-file-atomic": "^2.4.2"
 			}
 		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"optional": true
+		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"optional": true
 		},
 		"chai": {
 			"version": "4.1.2",
@@ -687,6 +766,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
@@ -694,19 +774,21 @@
 			}
 		},
 		"cloudant-follow": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-			"integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+			"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
+			"optional": true,
 			"requires": {
 				"browser-request": "~0.3.0",
-				"debug": "^3.0.0",
-				"request": "^2.83.0"
+				"debug": "^4.0.1",
+				"request": "^2.88.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -736,17 +818,14 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-		},
-		"colour": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-			"integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"optional": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"optional": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -766,7 +845,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -830,12 +910,14 @@
 		"cycle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+			"optional": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -844,6 +926,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			},
@@ -851,7 +934,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -904,7 +988,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -916,15 +1001,17 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"optional": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -959,7 +1046,8 @@
 		"errs": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
-			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
+			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=",
+			"optional": true
 		},
 		"es-abstract": {
 			"version": "1.16.2",
@@ -1044,7 +1132,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
 		},
 		"extend-shallow": {
 			"version": "1.1.4",
@@ -1058,62 +1147,38 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"optional": true
 		},
 		"eyes": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+			"optional": true
 		},
 		"fabric-ca-client": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-			"integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-sttS3p2chFDy4VCCxHxLOPLOL9ilwrHtbveVuhVGITvHCL8ZIKMVoTdHtRB56+I1o89nIp9drxTUsgAkBM6aKg==",
 			"optional": true,
 			"requires": {
-				"fabric-common": "^2.1.0",
-				"jsrsasign": "^7.2.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"jsrsasign": "^8.0.15",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
 				"winston": "^2.4.0"
-			},
-			"dependencies": {
-				"fabric-common": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-					"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-					"optional": true,
-					"requires": {
-						"elliptic": "^6.2.3",
-						"fabric-protos": "^2.1.0",
-						"js-sha3": "^0.7.0",
-						"nano": "^6.4.4",
-						"nconf": "^0.10.0",
-						"pkcs11js": "^1.0.6",
-						"promise-settle": "^0.3.0",
-						"sjcl": "1.0.7",
-						"winston": "^2.4.0",
-						"yn": "^3.1.0"
-					}
-				},
-				"yn": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-					"optional": true
-				}
 			}
 		},
 		"fabric-common": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-			"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-OVhoSQQkROFe6ZFUOjxB8xqa9csQtORKp8o8g3ZuH2OmR1LSIjg2WQAAKj3YwKTZuGhSz/ltySo/HCu5zQyHXA==",
 			"optional": true,
 			"requires": {
-				"elliptic": "^6.2.3",
-				"fabric-protos": "^2.1.0",
+				"callsite": "^1.0.0",
+				"elliptic": "^6.5.2",
+				"fabric-protos": "2.1.2-snapshot.2",
 				"js-sha3": "^0.7.0",
-				"nano": "^6.4.4",
+				"jsrsasign": "^8.0.15",
 				"nconf": "^0.10.0",
 				"pkcs11js": "^1.0.6",
 				"promise-settle": "^0.3.0",
@@ -1131,140 +1196,72 @@
 			}
 		},
 		"fabric-network": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.0.tgz",
-			"integrity": "sha512-9VqUvYX2fROleTl1sKIx51EhLDfhDxDMHIgafRvicBFJKYAeQ6nyKWmk3gZIlGxmB2LjpIV+WzwR5Z2PiNI03w==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-gACrYS5ojBnv/J9mdeWk8zPv/Mj5axkww3XaxJWYyX6Q+NzWDeUmi5GmhB5kTQ0H1C8WfL2iY9//NZ15lqHSuA==",
 			"optional": true,
 			"requires": {
-				"fabric-ca-client": "^2.1.0",
-				"fabric-common": "^2.1.0",
-				"fs-extra": "^8.1.0",
+				"fabric-ca-client": "2.1.2-snapshot.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"fabric-protos": "2.1.2-snapshot.2",
+				"fs-extra": "^9.0.0",
 				"long": "^4.0.0",
-				"nano": "^8.1.0",
-				"winston": "^2.4.0"
+				"nano": "^8.2.2",
+				"winston": "^2.4.4"
 			},
 			"dependencies": {
-				"fabric-ca-client": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-					"integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
-					"optional": true,
-					"requires": {
-						"fabric-common": "^2.1.0",
-						"jsrsasign": "^7.2.2",
-						"url": "^0.11.0",
-						"util": "^0.10.3",
-						"winston": "^2.4.0"
-					}
-				},
-				"fabric-common": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-					"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
-					"requires": {
-						"elliptic": "^6.2.3",
-						"fabric-protos": "^2.1.0",
-						"js-sha3": "^0.7.0",
-						"nano": "^6.4.4",
-						"nconf": "^0.10.0",
-						"pkcs11js": "^1.0.6",
-						"promise-settle": "^0.3.0",
-						"sjcl": "1.0.7",
-						"winston": "^2.4.0",
-						"yn": "^3.1.0"
-					},
-					"dependencies": {
-						"nano": {
-							"version": "6.4.4",
-							"resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-							"integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
-							"requires": {
-								"cloudant-follow": "~0.17.0",
-								"debug": "^2.2.0",
-								"errs": "^0.3.2",
-								"lodash.isempty": "^4.4.0",
-								"request": "^2.85.0"
-							}
-						}
-					}
-				},
 				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 					"optional": true,
 					"requires": {
+						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
 					}
 				},
-				"long": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-					"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-					"optional": true
-				},
-				"nano": {
-					"version": "8.2.2",
-					"resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
-					"integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
 					"optional": true,
 					"requires": {
-						"@types/request": "^2.48.4",
-						"cloudant-follow": "^0.18.2",
-						"debug": "^4.1.1",
-						"errs": "^0.3.2",
-						"request": "^2.88.0"
-					},
-					"dependencies": {
-						"cloudant-follow": {
-							"version": "0.18.2",
-							"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
-							"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
-							"optional": true,
-							"requires": {
-								"browser-request": "~0.3.0",
-								"debug": "^4.0.1",
-								"request": "^2.88.0"
-							}
-						},
-						"debug": {
-							"version": "4.1.1",
-							"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-							"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-							"requires": {
-								"ms": "^2.1.1"
-							}
-						}
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
 					}
 				},
-				"yn": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"optional": true
 				}
 			}
 		},
 		"fabric-protos": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-			"integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-qCfVyjMxWp885HREHyhacdlF4iclMguuzasSM0nO7MWBYHCnyaSbR7/JUNjuBdHg9zzLbVLdCY8RX13ZMUg+uw==",
+			"optional": true,
 			"requires": {
-				"grpc": "1.24.2",
-				"lodash.clone": "4.5.0",
-				"protobufjs": "^5.0.3"
+				"@grpc/grpc-js": "1.0.3",
+				"@grpc/proto-loader": "0.5.4",
+				"lodash.clone": "4.5.0"
 			}
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"optional": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"optional": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -1315,12 +1312,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"optional": true
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+			"optional": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -1340,7 +1339,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -1364,6 +1364,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -1372,6 +1373,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1398,424 +1400,6 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"grpc": {
-			"version": "1.24.2",
-			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
-			"integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
-			"requires": {
-				"@types/bytebuffer": "^5.0.40",
-				"lodash.camelcase": "^4.3.0",
-				"lodash.clone": "^4.5.0",
-				"nan": "^2.13.2",
-				"node-pre-gyp": "^0.14.0",
-				"protobufjs": "^5.0.3"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"bundled": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.3",
-					"bundled": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"needle": {
-					"version": "2.4.0",
-					"bundled": true,
-					"requires": {
-						"debug": "^3.2.6",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.14.0",
-					"bundled": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4.4.2"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"bundled": true
-				},
-				"npm-packlist": {
-					"version": "1.4.6",
-					"bundled": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"bundled": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"tar": {
-					"version": "4.4.13",
-					"bundled": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"bundled": true
-				}
-			}
-		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -1839,12 +1423,14 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"optional": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"optional": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -1884,6 +1470,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"optional": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -1908,6 +1495,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"optional": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -1924,6 +1512,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -1940,6 +1529,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1953,12 +1543,14 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"optional": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"optional": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -2019,7 +1611,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"optional": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -2042,7 +1635,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"optional": true
 		},
 		"istanbul": {
 			"version": "0.4.5",
@@ -2195,7 +1789,8 @@
 		"js-sha3": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
+			"optional": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -2216,7 +1811,8 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -2233,17 +1829,20 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"optional": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"optional": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"optional": true
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -2274,6 +1873,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -2282,9 +1882,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-7.2.2.tgz",
-			"integrity": "sha1-rlIwy1V0RRu5eanMaXQoxg9ZjSA=",
+			"version": "8.0.20",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.20.tgz",
+			"integrity": "sha512-JTXt9+nqdynIB8wFsS6e8ffHhIjilhywXwdaEVHSj9OVmwldG2H0EoCqkQ+KXkm2tVqREfH/HEmklY4k1/6Rcg==",
 			"optional": true
 		},
 		"just-extend": {
@@ -2303,6 +1903,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"optional": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -2377,12 +1978,14 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"optional": true
 		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"optional": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -2395,11 +1998,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"lodash.isempty": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -2417,9 +2015,10 @@
 			"dev": true
 		},
 		"long": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"optional": true
 		},
 		"lru-cache": {
 			"version": "4.1.5",
@@ -2492,32 +2091,37 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"optional": true
 		},
 		"mime-types": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"optional": true,
 			"requires": {
-				"mime-db": "1.43.0"
+				"mime-db": "1.44.0"
 			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"optional": true
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"optional": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2768,25 +2372,38 @@
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"optional": true
 		},
 		"nano": {
-			"version": "6.4.4",
-			"resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-			"integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/nano/-/nano-8.2.2.tgz",
+			"integrity": "sha512-1/rAvpd1J0Os0SazgutWQBx2buAq3KwJpmdIylPDqOwy73iQeAhTSCq3uzbGzvcNNW16Vv/BLXkk+DYcdcH+aw==",
 			"optional": true,
 			"requires": {
-				"cloudant-follow": "~0.17.0",
-				"debug": "^2.2.0",
+				"@types/request": "^2.48.4",
+				"cloudant-follow": "^0.18.2",
+				"debug": "^4.1.1",
 				"errs": "^0.3.2",
-				"lodash.isempty": "^4.4.0",
-				"request": "^2.85.0"
+				"request": "^2.88.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				}
 			}
 		},
 		"nconf": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
 			"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+			"optional": true,
 			"requires": {
 				"async": "^1.4.0",
 				"ini": "^1.3.0",
@@ -3020,7 +2637,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"optional": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -3066,6 +2684,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3102,11 +2721,6 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
-		"optjs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-			"integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3117,6 +2731,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"optional": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -3178,7 +2793,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -3229,7 +2845,8 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"optional": true
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -3315,17 +2932,36 @@
 		"promise-settle": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promise-settle/-/promise-settle-0.3.0.tgz",
-			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY="
+			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY=",
+			"optional": true
 		},
 		"protobufjs": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-			"integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+			"integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+			"optional": true,
 			"requires": {
-				"ascli": "~1",
-				"bytebuffer": "~5",
-				"glob": "^7.0.5",
-				"yargs": "^3.10.0"
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
+				"@types/node": "^13.7.0",
+				"long": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "13.13.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+					"integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==",
+					"optional": true
+				}
 			}
 		},
 		"pseudomap": {
@@ -3337,7 +2973,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"optional": true
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -3347,7 +2984,8 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"optional": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -3457,6 +3095,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"optional": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -3478,6 +3117,19 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"optional": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"require-directory": {
@@ -3521,7 +3173,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"optional": true
 		},
 		"samsam": {
 			"version": "1.3.0",
@@ -3532,7 +3185,8 @@
 		"secure-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
+			"optional": true
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -3594,7 +3248,8 @@
 		"sjcl": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.7.tgz",
-			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U="
+			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U=",
+			"optional": true
 		},
 		"source-map": {
 			"version": "0.2.0",
@@ -3680,6 +3335,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"optional": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3695,7 +3351,8 @@
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"optional": true
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -3825,6 +3482,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"optional": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -3833,7 +3491,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -3924,6 +3583,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3931,7 +3591,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -3983,6 +3644,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"optional": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -3990,7 +3652,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -4001,23 +3664,6 @@
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			}
-		},
-		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"optional": true,
-			"requires": {
-				"inherits": "2.0.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"optional": true
-				}
 			}
 		},
 		"util-deprecate": {
@@ -4045,6 +3691,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -4078,12 +3725,14 @@
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+			"optional": true
 		},
 		"winston": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-			"integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+			"integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+			"optional": true,
 			"requires": {
 				"async": "~1.0.0",
 				"colors": "1.0.x",
@@ -4096,7 +3745,8 @@
 				"async": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+					"optional": true
 				}
 			}
 		},
@@ -4116,6 +3766,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -4124,7 +3775,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",
@@ -4152,7 +3804,8 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"optional": true
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -4164,6 +3817,7 @@
 			"version": "3.32.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+			"optional": true,
 			"requires": {
 				"camelcase": "^2.0.1",
 				"cliui": "^3.0.3",

--- a/packages/blockchain-gateway-v1/package.json
+++ b/packages/blockchain-gateway-v1/package.json
@@ -58,9 +58,9 @@
 		"url": "0.11.0"
 	},
 	"optionalDependencies": {
-		"fabric-ca-client": "2.1.0",
-		"fabric-common": "2.1.0",
-		"fabric-network": "2.1.0"
+		"fabric-ca-client": "2.1.2-snapshot.2",
+		"fabric-common": "2.1.2-snapshot.2",
+		"fabric-network": "2.1.2-snapshot.2"
 	},
 	"license-check-and-add-config": {
 		"folder": ".",

--- a/packages/blockchain-gateway-v1/src/FabricConnection.ts
+++ b/packages/blockchain-gateway-v1/src/FabricConnection.ts
@@ -18,7 +18,7 @@ import { URL } from 'url';
 import { ConsoleOutputAdapter, FabricSmartContractDefinition, OutputAdapter } from 'ibm-blockchain-platform-common';
 import { FabricWallet } from 'ibm-blockchain-platform-wallet';
 import { Lifecycle, LifecyclePeer, LifecycleChannel, DefinedSmartContract } from 'ibm-blockchain-platform-fabric-admin';
-import { Endorser, Channel } from 'fabric-network/node_modules/fabric-common';
+import { Endorser, Channel } from 'fabric-common';
 
 export abstract class FabricConnection {
 
@@ -58,7 +58,7 @@ export abstract class FabricConnection {
     }
 
     public async getAllChannelsForPeer(peerName: string): Promise<Array<string>> {
-        const peer: LifecyclePeer = this.lifecycle.getPeer(peerName, this.gateway.getOptions().wallet, this.gateway.getOptions().identity);
+        const peer: LifecyclePeer = this.lifecycle.getPeer(peerName, this.gateway.getOptions().wallet, this.gateway.getOptions().identity as any);
         try {
             const channelNames: string[] = await peer.getAllChannelNames();
             return channelNames.sort();
@@ -85,7 +85,7 @@ export abstract class FabricConnection {
 
     // TODO: this needs to be changed to getAllCommitttedSmartContracts
     public async getInstantiatedChaincode(channelName: string): Promise<Array<FabricSmartContractDefinition>> {
-        const lifecycleChannel: LifecycleChannel = this.lifecycle.getChannel(channelName, this.gateway.getOptions().wallet, this.gateway.getOptions().identity);
+        const lifecycleChannel: LifecycleChannel = this.lifecycle.getChannel(channelName, this.gateway.getOptions().wallet, this.gateway.getOptions().identity as any);
 
         const channelMap: Map<string, string[]> = await this.createChannelMap();
 

--- a/packages/blockchain-gateway-v1/src/FabricGatewayConnection.ts
+++ b/packages/blockchain-gateway-v1/src/FabricGatewayConnection.ts
@@ -16,7 +16,7 @@ import { FabricConnection } from './FabricConnection';
 import { FabricWallet } from 'ibm-blockchain-platform-wallet';
 import { IFabricGatewayConnection, OutputAdapter, LogType, ConnectionProfileUtil } from 'ibm-blockchain-platform-common';
 import { Network, Contract, Transaction, ContractListener } from 'fabric-network';
-import { Endorser } from 'fabric-network/node_modules/fabric-common';
+import { Endorser } from 'fabric-common';
 
 export class FabricGatewayConnection extends FabricConnection implements IFabricGatewayConnection {
 

--- a/packages/blockchain-gateway-v1/test/FabricConnection.test.ts
+++ b/packages/blockchain-gateway-v1/test/FabricConnection.test.ts
@@ -22,7 +22,7 @@ import { Gateway, Wallet } from 'fabric-network';
 import { OutputAdapter, LogType } from 'ibm-blockchain-platform-common';
 import { FabricWallet } from 'ibm-blockchain-platform-wallet';
 import * as path from 'path';
-import { Client, Channel } from 'fabric-network/node_modules/fabric-common';
+import { Client, Channel } from 'fabric-common';
 import { LifecyclePeer, LifecycleChannel } from 'ibm-blockchain-platform-fabric-admin';
 
 chai.should();
@@ -61,7 +61,7 @@ describe('FabricConnection', () => {
         }
 
         async connect(wallet: FabricWallet, identityName: string, requestTimeout: number): Promise<void> {
-            this['gateway'] = fabricGatewayStub;
+            this['gateway'] = fabricGatewayStub as any;
 
             await this.connectInner(this.connectionProfile, wallet.getWallet(), identityName, requestTimeout);
         }
@@ -156,7 +156,7 @@ describe('FabricConnection', () => {
         fabricGatewayStub.getNetwork.returns(fabricNetworkStub);
         fabricGatewayStub.disconnect.returns(null);
 
-        fabricConnection['gateway'] = fabricGatewayStub;
+        fabricConnection['gateway'] = fabricGatewayStub as any;
         fabricConnection['outputAdapter'] = TestOutputAdapter.instance();
 
         await fabricConnection.connect(fabricWallet, mockIdentityName, 120);

--- a/packages/blockchain-gateway-v1/test/FabricGatewayConnection.test.ts
+++ b/packages/blockchain-gateway-v1/test/FabricGatewayConnection.test.ts
@@ -22,7 +22,7 @@ import * as sinonChai from 'sinon-chai';
 import { Gateway } from 'fabric-network';
 import { LogType, ConsoleOutputAdapter, FabricRuntimeUtil } from 'ibm-blockchain-platform-common';
 import { FabricWallet } from 'ibm-blockchain-platform-wallet';
-import { Endorser, Client } from 'fabric-network/node_modules/fabric-common';
+import { Endorser, Client } from 'fabric-common';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -118,7 +118,7 @@ describe('FabricGatewayConnection', () => {
         fabricGatewayStub.disconnect.returns(null);
 
         fabricClientConnection = new FabricGatewayConnection('connectionpath');
-        fabricClientConnection['gateway'] = fabricGatewayStub;
+        fabricClientConnection['gateway'] = fabricGatewayStub as any;
     });
 
     afterEach(() => {
@@ -131,7 +131,7 @@ describe('FabricGatewayConnection', () => {
             const connectionProfilePath: string = path.join(rootPath, 'test/data/connectionProfiles/connection.json');
 
             fabricClientConnection = new FabricGatewayConnection(connectionProfilePath);
-            fabricClientConnection['gateway'] = fabricGatewayStub;
+            fabricClientConnection['gateway'] = fabricGatewayStub as any;
 
             wallet = await FabricWallet.newFabricWallet(path.join(rootPath, 'test/data/walletDir/wallet'));
         });
@@ -148,7 +148,7 @@ describe('FabricGatewayConnection', () => {
 
             wallet = await FabricWallet.newFabricWallet(path.join(rootPath, 'test/data/wallet'));
             fabricClientConnectionYaml = new FabricGatewayConnection(connectionProfilePath);
-            fabricClientConnectionYaml['gateway'] = fabricGatewayStub;
+            fabricClientConnectionYaml['gateway'] = fabricGatewayStub as any;
 
             await fabricClientConnectionYaml.connect(wallet, FabricRuntimeUtil.ADMIN_USER, timeout);
             fabricGatewayStub.connect.should.have.been.called;
@@ -161,7 +161,7 @@ describe('FabricGatewayConnection', () => {
 
             wallet = await FabricWallet.newFabricWallet(path.join(rootPath, 'test/data/wallet'));
             otherFabricClientConnectionYml = new FabricGatewayConnection(connectionProfilePath);
-            otherFabricClientConnectionYml['gateway'] = fabricGatewayStub;
+            otherFabricClientConnectionYml['gateway'] = fabricGatewayStub as any;
 
             await otherFabricClientConnectionYml.connect(wallet, FabricRuntimeUtil.ADMIN_USER, timeout);
             fabricGatewayStub.connect.should.have.been.called;
@@ -174,7 +174,7 @@ describe('FabricGatewayConnection', () => {
             wallet = await FabricWallet.newFabricWallet(path.join(rootPath, 'test/data/wallet'));
 
             fabricClientConnection = new FabricGatewayConnection(connectionProfilePath);
-            fabricClientConnection['gateway'] = fabricGatewayStub;
+            fabricClientConnection['gateway'] = fabricGatewayStub as any;
 
             await fabricClientConnection.connect(wallet, FabricRuntimeUtil.ADMIN_USER, timeout);
 
@@ -190,7 +190,7 @@ describe('FabricGatewayConnection', () => {
             };
             wallet = await FabricWallet.newFabricWallet(connectionData.walletPath);
             fabricClientConnection = new FabricGatewayConnection(connectionData.connectionProfilePath);
-            fabricClientConnection['gateway'] = fabricGatewayStub;
+            fabricClientConnection['gateway'] = fabricGatewayStub as any;
 
             await fabricClientConnection.connect(wallet, FabricRuntimeUtil.ADMIN_USER, timeout);
 
@@ -204,7 +204,7 @@ describe('FabricGatewayConnection', () => {
 
             wallet = await FabricWallet.newFabricWallet(path.join(rootPath, 'test/data/wallet'));
             fabricClientConnectionWrong = new FabricGatewayConnection(connectionProfilePath);
-            fabricClientConnectionWrong['gateway'] = fabricGatewayStub;
+            fabricClientConnectionWrong['gateway'] = fabricGatewayStub as any;
 
             await fabricClientConnectionWrong.connect(wallet, FabricRuntimeUtil.ADMIN_USER, timeout).should.have.been.rejectedWith('Connection profile must be in JSON or yaml format');
             fabricGatewayStub.connect.should.not.have.been.called;

--- a/packages/blockchain-wallet/package-lock.json
+++ b/packages/blockchain-wallet/package-lock.json
@@ -129,11 +129,102 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
+		"@grpc/grpc-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.3.tgz",
+			"integrity": "sha512-JKV3f5Bv2TZxK6eJSB9EarsZrnLxrvcFNwI9goq0YRXa3S6NNoCSnI3cG3lkXVIJ03Wng1WXe76kc2JQtRe7AQ==",
+			"optional": true,
+			"requires": {
+				"semver": "^6.2.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"optional": true
+				}
+			}
+		},
+		"@grpc/proto-loader": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.4.tgz",
+			"integrity": "sha512-HTM4QpI9B2XFkPz7pjwMyMgZchJ93TVkL3kWPW8GDMDKYxsMnmf4w2TNMJK7+KNiYHS5cJrCEAFlF+AwtXWVPA==",
+			"optional": true,
+			"requires": {
+				"lodash.camelcase": "^4.3.0",
+				"protobufjs": "^6.8.6"
+			}
+		},
 		"@istanbuljs/nyc-config-typescript": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/@istanbuljs/nyc-config-typescript/-/nyc-config-typescript-0.1.3.tgz",
 			"integrity": "sha512-EzRFg92bRSD1W/zeuNkeGwph0nkWf+pP2l/lYW4/5hav7RjKKBN5kV1Ix7Tvi0CMu3pC4Wi/U7rNisiJMR3ORg==",
 			"dev": true
+		},
+		"@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+			"optional": true
+		},
+		"@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"optional": true
+		},
+		"@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"optional": true
+		},
+		"@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+			"optional": true
+		},
+		"@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+			"optional": true,
+			"requires": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+			"optional": true
+		},
+		"@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+			"optional": true
+		},
+		"@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+			"optional": true
+		},
+		"@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+			"optional": true
+		},
+		"@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+			"optional": true
 		},
 		"@sinonjs/commons": {
 			"version": "1.6.0",
@@ -164,15 +255,6 @@
 			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
 			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
 			"dev": true
-		},
-		"@types/bytebuffer": {
-			"version": "5.0.40",
-			"resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
-			"integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
-			"requires": {
-				"@types/long": "*",
-				"@types/node": "*"
-			}
 		},
 		"@types/caseless": {
 			"version": "0.12.2",
@@ -224,7 +306,8 @@
 		"@types/long": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
-			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+			"integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+			"optional": true
 		},
 		"@types/minimatch": {
 			"version": "3.0.3",
@@ -244,28 +327,15 @@
 			"integrity": "sha512-Ja7d4s0qyGFxjGeDq5S7Si25OFibSAHUi6i17UWnwNnpitADN7hah9q0Tl25gxuV5R1u2Bx+np6w4LHXfHyj/g=="
 		},
 		"@types/request": {
-			"version": "2.48.4",
-			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.4.tgz",
-			"integrity": "sha512-W1t1MTKYR8PxICH+A4HgEIPuAC3sbljoEVfyZbeFJJDbr30guDspJri2XOaM2E+Un7ZjrihaDi7cf6fPa2tbgw==",
+			"version": "2.48.5",
+			"resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
+			"integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
 			"optional": true,
 			"requires": {
 				"@types/caseless": "*",
 				"@types/node": "*",
 				"@types/tough-cookie": "*",
 				"form-data": "^2.5.0"
-			},
-			"dependencies": {
-				"form-data": {
-					"version": "2.5.1",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-					"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-					"optional": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.6",
-						"mime-types": "^2.1.12"
-					}
-				}
 			}
 		},
 		"@types/rimraf": {
@@ -310,6 +380,7 @@
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"optional": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -437,19 +508,11 @@
 			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
 			"dev": true
 		},
-		"ascli": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
-			"integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-			"requires": {
-				"colour": "~0.7.1",
-				"optjs": "~3.2.2"
-			}
-		},
 		"asn1": {
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"optional": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -457,7 +520,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"optional": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -473,17 +537,26 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"optional": true
+		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"optional": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"optional": true
 		},
 		"aws4": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
+			"integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+			"optional": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -532,12 +605,14 @@
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"optional": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -549,14 +624,16 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+			"optional": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"requires": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -565,12 +642,14 @@
 		"brorand": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+			"optional": true
 		},
 		"browser-request": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/browser-request/-/browser-request-0.3.3.tgz",
-			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc="
+			"integrity": "sha1-ns5bWsqJopkyJC4Yv5M975h2zBc=",
+			"optional": true
 		},
 		"browser-stdout": {
 			"version": "1.3.1",
@@ -590,21 +669,6 @@
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
 			"dev": true
 		},
-		"bytebuffer": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
-			"integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-			"requires": {
-				"long": "~3"
-			},
-			"dependencies": {
-				"long": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-					"integrity": "sha1-2CG3E4yhy1gcFymQ7xTbIAtcR0s="
-				}
-			}
-		},
 		"caching-transform": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -617,15 +681,23 @@
 				"write-file-atomic": "^2.4.2"
 			}
 		},
+		"callsite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+			"optional": true
+		},
 		"camelcase": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+			"integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+			"optional": true
 		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"optional": true
 		},
 		"chai": {
 			"version": "4.1.2",
@@ -694,6 +766,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1",
@@ -701,19 +774,21 @@
 			}
 		},
 		"cloudant-follow": {
-			"version": "0.17.0",
-			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.17.0.tgz",
-			"integrity": "sha512-JQ1xvKAHh8rsnSVBjATLCjz/vQw1sWBGadxr2H69yFMwD7hShUGDwwEefdypaxroUJ/w6t1cSwilp/hRUxEW8w==",
+			"version": "0.18.2",
+			"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
+			"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
+			"optional": true,
 			"requires": {
 				"browser-request": "~0.3.0",
-				"debug": "^3.0.0",
-				"request": "^2.83.0"
+				"debug": "^4.0.1",
+				"request": "^2.88.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "3.2.6",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -743,17 +818,14 @@
 		"colors": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-		},
-		"colour": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/colour/-/colour-0.7.1.tgz",
-			"integrity": "sha1-nLFpkX7F0SwHNtPoaFdG3xyt93g="
+			"integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+			"optional": true
 		},
 		"combined-stream": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"optional": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -773,7 +845,8 @@
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+			"dev": true
 		},
 		"convert-source-map": {
 			"version": "1.7.0",
@@ -837,12 +910,14 @@
 		"cycle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+			"integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
+			"optional": true
 		},
 		"dashdash": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -851,6 +926,7 @@
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
 			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"dev": true,
 			"requires": {
 				"ms": "2.0.0"
 			},
@@ -858,7 +934,8 @@
 				"ms": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"dev": true
 				}
 			}
 		},
@@ -911,7 +988,8 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"optional": true
 		},
 		"diff": {
 			"version": "3.5.0",
@@ -923,15 +1001,17 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"optional": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
 			}
 		},
 		"elliptic": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"optional": true,
 			"requires": {
 				"bn.js": "^4.4.0",
 				"brorand": "^1.0.1",
@@ -966,7 +1046,8 @@
 		"errs": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/errs/-/errs-0.3.2.tgz",
-			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk="
+			"integrity": "sha1-eYCZstvTfKK8dJ5TinwTB9C1BJk=",
+			"optional": true
 		},
 		"es-abstract": {
 			"version": "1.16.2",
@@ -1051,7 +1132,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"optional": true
 		},
 		"extend-shallow": {
 			"version": "1.1.4",
@@ -1065,35 +1147,38 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"optional": true
 		},
 		"eyes": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+			"integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
+			"optional": true
 		},
 		"fabric-ca-client": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.0.tgz",
-			"integrity": "sha512-f8s8e/tOwsWDHwMhvnPPdnL4bgwkpG8LED5frEaP+rWHUoqUNAUOpvs/kLdnBcezix84UNA3f+UbccF9KL6dAA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-ca-client/-/fabric-ca-client-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-sttS3p2chFDy4VCCxHxLOPLOL9ilwrHtbveVuhVGITvHCL8ZIKMVoTdHtRB56+I1o89nIp9drxTUsgAkBM6aKg==",
 			"optional": true,
 			"requires": {
-				"fabric-common": "^2.1.0",
-				"jsrsasign": "^7.2.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"jsrsasign": "^8.0.15",
 				"url": "^0.11.0",
-				"util": "^0.10.3",
 				"winston": "^2.4.0"
 			}
 		},
 		"fabric-common": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.0.tgz",
-			"integrity": "sha512-t980mEGBlbVTq2y6Zi3ZtVN5RnUy5xNoRWhPTpifAsI1m0KYBSh8jPcxtybMrLds12J/PAE7qI4TrgbZMqapKg==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-common/-/fabric-common-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-OVhoSQQkROFe6ZFUOjxB8xqa9csQtORKp8o8g3ZuH2OmR1LSIjg2WQAAKj3YwKTZuGhSz/ltySo/HCu5zQyHXA==",
+			"optional": true,
 			"requires": {
-				"elliptic": "^6.2.3",
-				"fabric-protos": "^2.1.0",
+				"callsite": "^1.0.0",
+				"elliptic": "^6.5.2",
+				"fabric-protos": "2.1.2-snapshot.2",
 				"js-sha3": "^0.7.0",
-				"nano": "^6.4.4",
+				"jsrsasign": "^8.0.15",
 				"nconf": "^0.10.0",
 				"pkcs11js": "^1.0.6",
 				"promise-settle": "^0.3.0",
@@ -1102,71 +1187,81 @@
 				"yn": "^3.1.0"
 			},
 			"dependencies": {
-				"nano": {
-					"version": "6.4.4",
-					"resolved": "https://registry.npmjs.org/nano/-/nano-6.4.4.tgz",
-					"integrity": "sha512-7sldMrZI1ZH8QE29PnzohxLfR67WNVzMKLa7EMl3x9Hr+0G+YpOUCq50qZ9G66APrjcb0Of2BTOZLNBCutZGag==",
-					"requires": {
-						"cloudant-follow": "~0.17.0",
-						"debug": "^2.2.0",
-						"errs": "^0.3.2",
-						"lodash.isempty": "^4.4.0",
-						"request": "^2.85.0"
-					}
-				},
 				"yn": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
+					"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+					"optional": true
 				}
 			}
 		},
 		"fabric-network": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.0.tgz",
-			"integrity": "sha512-9VqUvYX2fROleTl1sKIx51EhLDfhDxDMHIgafRvicBFJKYAeQ6nyKWmk3gZIlGxmB2LjpIV+WzwR5Z2PiNI03w==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-network/-/fabric-network-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-gACrYS5ojBnv/J9mdeWk8zPv/Mj5axkww3XaxJWYyX6Q+NzWDeUmi5GmhB5kTQ0H1C8WfL2iY9//NZ15lqHSuA==",
 			"optional": true,
 			"requires": {
-				"fabric-ca-client": "^2.1.0",
-				"fabric-common": "^2.1.0",
-				"fs-extra": "^8.1.0",
+				"fabric-ca-client": "2.1.2-snapshot.2",
+				"fabric-common": "2.1.2-snapshot.2",
+				"fabric-protos": "2.1.2-snapshot.2",
+				"fs-extra": "^9.0.0",
 				"long": "^4.0.0",
-				"nano": "^8.1.0",
-				"winston": "^2.4.0"
+				"nano": "^8.2.2",
+				"winston": "^2.4.4"
 			},
 			"dependencies": {
 				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"version": "9.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+					"integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
 					"optional": true,
 					"requires": {
+						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
 					}
+				},
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"optional": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"optional": true
 				}
 			}
 		},
 		"fabric-protos": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.0.tgz",
-			"integrity": "sha512-99+5ouNLUGz6sA5wQJyhpCYUGlfk8JHWSPUtjutnTRyb40TnbfebmG6k7lBCI6Kjyd7l9AHlD5yZuF7oCqAgkA==",
+			"version": "2.1.2-snapshot.2",
+			"resolved": "https://registry.npmjs.org/fabric-protos/-/fabric-protos-2.1.2-snapshot.2.tgz",
+			"integrity": "sha512-qCfVyjMxWp885HREHyhacdlF4iclMguuzasSM0nO7MWBYHCnyaSbR7/JUNjuBdHg9zzLbVLdCY8RX13ZMUg+uw==",
+			"optional": true,
 			"requires": {
-				"grpc": "1.24.2",
-				"lodash.clone": "4.5.0",
-				"protobufjs": "^5.0.3"
+				"@grpc/grpc-js": "1.0.3",
+				"@grpc/proto-loader": "0.5.4",
+				"lodash.clone": "4.5.0"
 			}
 		},
 		"fast-deep-equal": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"optional": true
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"optional": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
@@ -1217,12 +1312,14 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"optional": true
 		},
 		"form-data": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+			"integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+			"optional": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
@@ -1242,7 +1339,8 @@
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+			"dev": true
 		},
 		"function-bind": {
 			"version": "1.1.1",
@@ -1266,6 +1364,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -1274,6 +1373,7 @@
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
 			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+			"dev": true,
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1300,424 +1400,6 @@
 			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
 			"dev": true
 		},
-		"grpc": {
-			"version": "1.24.2",
-			"resolved": "https://registry.npmjs.org/grpc/-/grpc-1.24.2.tgz",
-			"integrity": "sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==",
-			"requires": {
-				"@types/bytebuffer": "^5.0.40",
-				"lodash.camelcase": "^4.3.0",
-				"lodash.clone": "^4.5.0",
-				"nan": "^2.13.2",
-				"node-pre-gyp": "^0.14.0",
-				"protobufjs": "^5.0.3"
-			},
-			"dependencies": {
-				"abbrev": {
-					"version": "1.1.1",
-					"bundled": true
-				},
-				"ansi-regex": {
-					"version": "2.1.1",
-					"bundled": true
-				},
-				"aproba": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"are-we-there-yet": {
-					"version": "1.1.5",
-					"bundled": true,
-					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
-					}
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"chownr": {
-					"version": "1.1.3",
-					"bundled": true
-				},
-				"code-point-at": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true
-				},
-				"console-control-strings": {
-					"version": "1.1.0",
-					"bundled": true
-				},
-				"core-util-is": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"debug": {
-					"version": "3.2.6",
-					"bundled": true,
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"deep-extend": {
-					"version": "0.6.0",
-					"bundled": true
-				},
-				"delegates": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"detect-libc": {
-					"version": "1.0.3",
-					"bundled": true
-				},
-				"fs-minipass": {
-					"version": "1.2.7",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.6.0"
-					}
-				},
-				"fs.realpath": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"gauge": {
-					"version": "2.7.4",
-					"bundled": true,
-					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
-					}
-				},
-				"glob": {
-					"version": "7.1.4",
-					"bundled": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"has-unicode": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"iconv-lite": {
-					"version": "0.4.24",
-					"bundled": true,
-					"requires": {
-						"safer-buffer": ">= 2.1.2 < 3"
-					}
-				},
-				"ignore-walk": {
-					"version": "3.0.3",
-					"bundled": true,
-					"requires": {
-						"minimatch": "^3.0.4"
-					}
-				},
-				"inflight": {
-					"version": "1.0.6",
-					"bundled": true,
-					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
-					}
-				},
-				"inherits": {
-					"version": "2.0.4",
-					"bundled": true
-				},
-				"ini": {
-					"version": "1.3.5",
-					"bundled": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "1.0.0",
-					"bundled": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"bundled": true
-				},
-				"minimatch": {
-					"version": "3.0.4",
-					"bundled": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				},
-				"minimist": {
-					"version": "1.2.0",
-					"bundled": true
-				},
-				"minipass": {
-					"version": "2.9.0",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "1.3.3",
-					"bundled": true,
-					"requires": {
-						"minipass": "^2.9.0"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
-							"bundled": true
-						}
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"needle": {
-					"version": "2.4.0",
-					"bundled": true,
-					"requires": {
-						"debug": "^3.2.6",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
-					}
-				},
-				"node-pre-gyp": {
-					"version": "0.14.0",
-					"bundled": true,
-					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.1",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.2.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4.4.2"
-					}
-				},
-				"nopt": {
-					"version": "4.0.1",
-					"bundled": true,
-					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
-					}
-				},
-				"npm-bundled": {
-					"version": "1.0.6",
-					"bundled": true
-				},
-				"npm-packlist": {
-					"version": "1.4.6",
-					"bundled": true,
-					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
-					}
-				},
-				"npmlog": {
-					"version": "4.1.2",
-					"bundled": true,
-					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
-					}
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"object-assign": {
-					"version": "4.1.1",
-					"bundled": true
-				},
-				"once": {
-					"version": "1.4.0",
-					"bundled": true,
-					"requires": {
-						"wrappy": "1"
-					}
-				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"osenv": {
-					"version": "0.1.5",
-					"bundled": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
-					}
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true
-				},
-				"process-nextick-args": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"rc": {
-					"version": "1.2.8",
-					"bundled": true,
-					"requires": {
-						"deep-extend": "^0.6.0",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
-					}
-				},
-				"readable-stream": {
-					"version": "2.3.6",
-					"bundled": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
-					}
-				},
-				"rimraf": {
-					"version": "2.7.1",
-					"bundled": true,
-					"requires": {
-						"glob": "^7.1.3"
-					}
-				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true
-				},
-				"safer-buffer": {
-					"version": "2.1.2",
-					"bundled": true
-				},
-				"sax": {
-					"version": "1.2.4",
-					"bundled": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"bundled": true
-				},
-				"set-blocking": {
-					"version": "2.0.0",
-					"bundled": true
-				},
-				"signal-exit": {
-					"version": "3.0.2",
-					"bundled": true
-				},
-				"string-width": {
-					"version": "1.0.2",
-					"bundled": true,
-					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
-					}
-				},
-				"string_decoder": {
-					"version": "1.1.1",
-					"bundled": true,
-					"requires": {
-						"safe-buffer": "~5.1.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "3.0.1",
-					"bundled": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
-				},
-				"strip-json-comments": {
-					"version": "2.0.1",
-					"bundled": true
-				},
-				"tar": {
-					"version": "4.4.13",
-					"bundled": true,
-					"requires": {
-						"chownr": "^1.1.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.8.6",
-						"minizlib": "^1.2.1",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.3"
-					}
-				},
-				"util-deprecate": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"wide-align": {
-					"version": "1.1.3",
-					"bundled": true,
-					"requires": {
-						"string-width": "^1.0.2 || 2"
-					}
-				},
-				"wrappy": {
-					"version": "1.0.2",
-					"bundled": true
-				},
-				"yallist": {
-					"version": "3.1.1",
-					"bundled": true
-				}
-			}
-		},
 		"handlebars": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -1741,12 +1423,14 @@
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"optional": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"optional": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -1786,6 +1470,7 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
 			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"optional": true,
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
@@ -1810,6 +1495,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
 			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"optional": true,
 			"requires": {
 				"hash.js": "^1.0.3",
 				"minimalistic-assert": "^1.0.0",
@@ -1826,6 +1512,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -1842,6 +1529,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+			"dev": true,
 			"requires": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -1855,12 +1543,14 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"optional": true
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+			"optional": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -1921,7 +1611,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"optional": true
 		},
 		"is-utf8": {
 			"version": "0.2.1",
@@ -1944,7 +1635,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"optional": true
 		},
 		"istanbul": {
 			"version": "0.4.5",
@@ -2097,7 +1789,8 @@
 		"js-sha3": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.7.0.tgz",
-			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA=="
+			"integrity": "sha512-Wpks3yBDm0UcL5qlVhwW9Jr9n9i4FfeWBFOOXP5puDS/SiudJGhw7DPyBqn3487qD4F0lsC0q3zxink37f7zeA==",
+			"optional": true
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -2118,7 +1811,8 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"optional": true
 		},
 		"jsesc": {
 			"version": "2.5.2",
@@ -2135,17 +1829,20 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"optional": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"optional": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"optional": true
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -2176,6 +1873,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -2184,9 +1882,9 @@
 			}
 		},
 		"jsrsasign": {
-			"version": "7.2.2",
-			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-7.2.2.tgz",
-			"integrity": "sha1-rlIwy1V0RRu5eanMaXQoxg9ZjSA=",
+			"version": "8.0.20",
+			"resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.20.tgz",
+			"integrity": "sha512-JTXt9+nqdynIB8wFsS6e8ffHhIjilhywXwdaEVHSj9OVmwldG2H0EoCqkQ+KXkm2tVqREfH/HEmklY4k1/6Rcg==",
 			"optional": true
 		},
 		"just-extend": {
@@ -2205,6 +1903,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+			"optional": true,
 			"requires": {
 				"invert-kv": "^1.0.0"
 			}
@@ -2279,12 +1978,14 @@
 		"lodash.camelcase": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
+			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+			"optional": true
 		},
 		"lodash.clone": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
-			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
+			"integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=",
+			"optional": true
 		},
 		"lodash.flattendeep": {
 			"version": "4.4.0",
@@ -2297,11 +1998,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"lodash.isempty": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-			"integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
 		},
 		"log-symbols": {
 			"version": "2.2.0",
@@ -2395,32 +2091,37 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+			"integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+			"optional": true
 		},
 		"mime-types": {
-			"version": "2.1.26",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"version": "2.1.27",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+			"integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+			"optional": true,
 			"requires": {
-				"mime-db": "1.43.0"
+				"mime-db": "1.44.0"
 			}
 		},
 		"minimalistic-assert": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+			"optional": true
 		},
 		"minimalistic-crypto-utils": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+			"optional": true
 		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+			"dev": true,
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
@@ -2671,7 +2372,8 @@
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"optional": true
 		},
 		"nano": {
 			"version": "8.2.2",
@@ -2686,21 +2388,11 @@
 				"request": "^2.88.0"
 			},
 			"dependencies": {
-				"cloudant-follow": {
-					"version": "0.18.2",
-					"resolved": "https://registry.npmjs.org/cloudant-follow/-/cloudant-follow-0.18.2.tgz",
-					"integrity": "sha512-qu/AmKxDqJds+UmT77+0NbM7Yab2K3w0qSeJRzsq5dRWJTEJdWeb+XpG4OpKuTE9RKOa/Awn2gR3TTnvNr3TeA==",
-					"optional": true,
-					"requires": {
-						"browser-request": "~0.3.0",
-						"debug": "^4.0.1",
-						"request": "^2.88.0"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"optional": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -2711,6 +2403,7 @@
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/nconf/-/nconf-0.10.0.tgz",
 			"integrity": "sha512-fKiXMQrpP7CYWJQzKkPPx9hPgmq+YLDyxcG9N8RpiE9FoCkCbzD0NyW0YhE3xn3Aupe7nnDeIx4PFzYehpHT9Q==",
+			"optional": true,
 			"requires": {
 				"async": "^1.4.0",
 				"ini": "^1.3.0",
@@ -2944,7 +2637,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"optional": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -2990,6 +2684,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -3026,11 +2721,6 @@
 				"word-wrap": "~1.2.3"
 			}
 		},
-		"optjs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/optjs/-/optjs-3.2.2.tgz",
-			"integrity": "sha1-aabOicRCpEQDFBrS+bNwvVu29O4="
-		},
 		"os-homedir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -3041,6 +2731,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+			"optional": true,
 			"requires": {
 				"lcid": "^1.0.0"
 			}
@@ -3102,7 +2793,8 @@
 		"path-is-absolute": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+			"dev": true
 		},
 		"path-parse": {
 			"version": "1.0.6",
@@ -3153,7 +2845,8 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"optional": true
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -3239,17 +2932,36 @@
 		"promise-settle": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/promise-settle/-/promise-settle-0.3.0.tgz",
-			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY="
+			"integrity": "sha1-tO/VcqHrdM95T4KM00naQKCOTpY=",
+			"optional": true
 		},
 		"protobufjs": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.3.tgz",
-			"integrity": "sha512-55Kcx1MhPZX0zTbVosMQEO5R6/rikNXd9b6RQK4KSPcrSIIwoXTtebIczUrXlwaSrbz4x8XUVThGPob1n8I4QA==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.9.0.tgz",
+			"integrity": "sha512-LlGVfEWDXoI/STstRDdZZKb/qusoAWUnmLg9R8OLSO473mBLWHowx8clbX5/+mKDEI+v7GzjoK9tRPZMMcoTrg==",
+			"optional": true,
 			"requires": {
-				"ascli": "~1",
-				"bytebuffer": "~5",
-				"glob": "^7.0.5",
-				"yargs": "^3.10.0"
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/long": "^4.0.1",
+				"@types/node": "^13.7.0",
+				"long": "^4.0.0"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "13.13.12",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.12.tgz",
+					"integrity": "sha512-zWz/8NEPxoXNT9YyF2osqyA9WjssZukYpgI4UYZpOjcyqwIUqWGkcCionaEb9Ki+FULyPyvNFpg/329Kd2/pbw==",
+					"optional": true
+				}
 			}
 		},
 		"pseudomap": {
@@ -3261,7 +2973,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"optional": true
 		},
 		"punycode": {
 			"version": "1.3.2",
@@ -3271,7 +2984,8 @@
 		"qs": {
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+			"optional": true
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -3381,6 +3095,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"optional": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -3402,6 +3117,19 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+					"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+					"optional": true,
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.6",
+						"mime-types": "^2.1.12"
+					}
+				}
 			}
 		},
 		"require-directory": {
@@ -3445,7 +3173,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"optional": true
 		},
 		"samsam": {
 			"version": "1.3.0",
@@ -3456,7 +3185,8 @@
 		"secure-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
-			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
+			"integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o=",
+			"optional": true
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -3518,7 +3248,8 @@
 		"sjcl": {
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/sjcl/-/sjcl-1.0.7.tgz",
-			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U="
+			"integrity": "sha1-MrNlpQ3Ju6JriLo8nfjqNCF9n0U=",
+			"optional": true
 		},
 		"source-map": {
 			"version": "0.2.0",
@@ -3604,6 +3335,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"optional": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -3619,7 +3351,8 @@
 		"stack-trace": {
 			"version": "0.0.10",
 			"resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+			"integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
+			"optional": true
 		},
 		"string-width": {
 			"version": "1.0.2",
@@ -3749,6 +3482,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"optional": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -3757,7 +3491,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -3848,6 +3583,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"optional": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -3855,7 +3591,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"optional": true
 		},
 		"type-check": {
 			"version": "0.3.2",
@@ -3907,6 +3644,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"optional": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			},
@@ -3914,7 +3652,8 @@
 				"punycode": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"optional": true
 				}
 			}
 		},
@@ -3925,23 +3664,6 @@
 			"requires": {
 				"punycode": "1.3.2",
 				"querystring": "0.2.0"
-			}
-		},
-		"util": {
-			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-			"optional": true,
-			"requires": {
-				"inherits": "2.0.3"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.3",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"optional": true
-				}
 			}
 		},
 		"util-deprecate": {
@@ -3969,6 +3691,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"optional": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -4002,12 +3725,14 @@
 		"window-size": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+			"integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+			"optional": true
 		},
 		"winston": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
-			"integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
+			"version": "2.4.5",
+			"resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
+			"integrity": "sha512-TWoamHt5yYvsMarGlGEQE59SbJHqGsZV8/lwC+iCcGeAe0vUaOh+Lv6SYM17ouzC/a/LB1/hz/7sxFBtlu1l4A==",
+			"optional": true,
 			"requires": {
 				"async": "~1.0.0",
 				"colors": "1.0.x",
@@ -4020,7 +3745,8 @@
 				"async": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+					"integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
+					"optional": true
 				}
 			}
 		},
@@ -4040,6 +3766,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+			"optional": true,
 			"requires": {
 				"string-width": "^1.0.1",
 				"strip-ansi": "^3.0.1"
@@ -4048,7 +3775,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write-file-atomic": {
 			"version": "2.4.3",
@@ -4076,7 +3804,8 @@
 		"y18n": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+			"integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+			"optional": true
 		},
 		"yallist": {
 			"version": "2.1.2",
@@ -4088,6 +3817,7 @@
 			"version": "3.32.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+			"optional": true,
 			"requires": {
 				"camelcase": "^2.0.1",
 				"cliui": "^3.0.3",

--- a/packages/blockchain-wallet/package.json
+++ b/packages/blockchain-wallet/package.json
@@ -56,7 +56,7 @@
 		"url": "0.11.0"
 	},
 	"optionalDependencies": {
-		"fabric-network": "2.1.0"
+		"fabric-network": "2.1.2-snapshot.2"
 	},
 	"license-check-and-add-config": {
 		"folder": ".",


### PR DESCRIPTION
Alternative to PR #2477 that uses a published Node SDK snapshot that includes a required fix. The lifecycle admin package depends on a v2.1.0 of fabric-protos prior to the change to grpc-js, and a protobufjs dependency to resolve what looks to be a missing dependency in the later fabric-protos package used by fabric-common.