### PR TITLE
v1 - Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The following dependencies are required on all operating systems:
 - [VS Code version 1.38.0 or greater](https://code.visualstudio.com)
 > VS Code version can be found by running: `code --version`
 
-- [Node v8.x or v10.x and npm v6.x or greater](https://nodejs.org/en/download/)
+- [Node v10 (v10.15.3 or greater) or v12 (v12.15.0 or greater) and npm v6.x or greater](https://nodejs.org/en/download/)
 > Node version can be found by running: `node --version`
 >
 > npm version can be found by running: `npm --version`
@@ -497,9 +497,8 @@ You will need the following:
 
 - Docker for Windows is configured to use Linux containers (this is the default)
 - You will need to install the C++ Build Tools for Windows from [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools#windows-build-tools)
-- You will need to install OpenSSL v1.0.2 if using Node 8, or v1.1.1 if using Node 10 from [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
+- You will need to install OpenSSL v1.0.2 [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
   - Install the normal version, not the version marked as "light"
-  - Install the Win32 version into `C:\OpenSSL-Win32` on 32-bit systems
   - Install the Win64 version into `C:\OpenSSL-Win64` on 64-bit systems
 
 For more information see the [1 Org Local Fabric](#1-org-local-fabric) section.

--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -15,12 +15,12 @@
 
 export class Dependencies {
 
-    static readonly NODEJS_REQUIRED: string = '8.x || 10.x';
+    static readonly NODEJS_REQUIRED: string =  '>=10.15.3 < 11.0.0|| >=12.15.0 < 13.0.0';
     static readonly NPM_REQUIRED: string = '>=6.0.0';
     static readonly DOCKER_REQUIRED: string = '>=17.6.2';
     static readonly DOCKER_COMPOSE_REQUIRED: string = '>=1.14.0';
 
-    static readonly OPENSSL_REQUIRED: string = '1.0.2 || 1.1.1';
+    static readonly OPENSSL_REQUIRED: string = '1.0.2';
 
     static readonly GO_REQUIRED: string = '>=1.12.0';
     static readonly JAVA_REQUIRED: string = '1.8.x';

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -258,7 +258,7 @@ export class DependencyManager {
             if (localFabricEnabled) {
                 dependencies.dockerForWindows = { name: 'Docker for Windows', id: 'dockerForWindows', complete: undefined, checkbox: true, required: true, text: 'Docker for Windows must be configured to use Linux containers (this is the default)' };
 
-                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively', tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
+                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'only', tooltip: 'Install the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
                 dependencies.buildTools = { name: 'C++ Build Tools', required: true, version: undefined, url: 'https://github.com/felixrieseberg/windows-build-tools#windows-build-tools', requiredVersion: undefined, requiredLabel: undefined };
                 try {
                     const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);

--- a/packages/blockchain-extension/extension/webview/PreReqView.ts
+++ b/packages/blockchain-extension/extension/webview/PreReqView.ts
@@ -24,6 +24,7 @@ import { SettingConfigurations } from '../../configurations';
 import { GlobalState, ExtensionData } from '../util/GlobalState';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from 'ibm-blockchain-platform-common';
+import { Dependencies } from '../dependencies/Dependencies';
 
 export class PreReqView extends View {
 
@@ -191,6 +192,12 @@ export class PreReqView extends View {
 
         for (const _dependency of Object.keys(dependencies)) {
 
+            // Make node version requirements more readable
+            if (dependencies[_dependency].name === 'Node.js') {
+                const required: string = Dependencies.NODEJS_REQUIRED.replace(/<.*\|\|/, '||').replace(/<.*/, '');
+                dependencies[_dependency].requiredVersion  = required;
+            }
+            
             const isInstalled: boolean = dependencyManager.isValidDependency(dependencies[_dependency]);
             if (isInstalled) {
                 installedDependencies[_dependency] = dependencies[_dependency];

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -537,22 +537,65 @@ describe('DependencyManager Tests', () => {
 
         });
 
-        it(`should return false if Node version isn't between 8 and 11`, async () => {
-            const dependencies: any = {
+        it(`should return false if wrong Node version`, async () => {
+            // should be >=10.15.3 < 11.0.0|| >=12.15.0 < 13.0.0
+            const dependencyManager: DependencyManager = DependencyManager.instance();
+            getPreReqVersionsStub.resolves({
                 node: {
                     name: 'Node.js',
-                    version: '12',
+                    version: '8.12.0',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 }
-            };
+            });
 
-            getPreReqVersionsStub.resolves(dependencies);
+            const resultNode8: boolean = await dependencyManager.hasPreReqsInstalled();
+            resultNode8.should.equal(false);
 
-            const dependencyManager: DependencyManager = DependencyManager.instance();
-            const result: boolean = await dependencyManager.hasPreReqsInstalled();
+            getPreReqVersionsStub.resolves({
+                node: {
+                    name: 'Node.js',
+                    version: '10.15.2',
+                    requiredVersion: Dependencies.NODEJS_REQUIRED
+                }
+            });
 
-            result.should.equal(false);
-            getPreReqVersionsStub.should.have.been.calledOnce;
+            const resultNode10low: boolean = await dependencyManager.hasPreReqsInstalled();
+            resultNode10low.should.equal(false);
+
+            getPreReqVersionsStub.resolves({
+                node: {
+                    name: 'Node.js',
+                    version: '11.1.1',
+                    requiredVersion: Dependencies.NODEJS_REQUIRED
+                }
+            });
+
+            const resultNode11: boolean = await dependencyManager.hasPreReqsInstalled();
+            resultNode11.should.equal(false);
+
+            getPreReqVersionsStub.resolves({
+                node: {
+                    name: 'Node.js',
+                    version: '12.14.0',
+                    requiredVersion: Dependencies.NODEJS_REQUIRED
+                }
+            });
+
+            const resultNode12low: boolean = await dependencyManager.hasPreReqsInstalled();
+            resultNode12low.should.equal(false);
+
+            getPreReqVersionsStub.resolves({
+                node: {
+                    name: 'Node.js',
+                    version: '13.0.0',
+                    requiredVersion: Dependencies.NODEJS_REQUIRED
+                }
+            });
+
+            const resultNode13: boolean = await dependencyManager.hasPreReqsInstalled();
+            resultNode13.should.equal(false);
+
+            getPreReqVersionsStub.getCalls().length.should.equal(5);
 
         });
 
@@ -560,7 +603,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -583,7 +626,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -607,7 +650,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -635,7 +678,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -664,7 +707,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -697,7 +740,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -731,7 +774,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -771,7 +814,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -812,7 +855,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -844,7 +887,7 @@ describe('DependencyManager Tests', () => {
             const dependencies: any = {
                 node: {
                     name: 'Node.js',
-                    version: '8.12.0',
+                    version: '10.15.3',
                     requiredVersion: Dependencies.NODEJS_REQUIRED
                 },
                 npm: {
@@ -883,7 +926,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -927,7 +970,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -950,7 +993,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.6',
+                        version: '1.1.1',
                         requiredVersion: Dependencies.OPENSSL_REQUIRED
                     }
                 };
@@ -971,7 +1014,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1020,7 +1063,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1073,7 +1116,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1128,7 +1171,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1156,7 +1199,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1200,7 +1243,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1247,7 +1290,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1291,7 +1334,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1336,7 +1379,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1385,7 +1428,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1439,7 +1482,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1493,7 +1536,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1551,7 +1594,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1613,7 +1656,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1679,7 +1722,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1749,7 +1792,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: Dependencies.NODEJS_REQUIRED
                     },
                     npm: {

--- a/packages/blockchain-extension/test/webview/PreReqView.test.ts
+++ b/packages/blockchain-extension/test/webview/PreReqView.test.ts
@@ -41,6 +41,7 @@ describe('PreReqView', () => {
     let createWebviewPanelStub: sinon.SinonStub;
     let reporterStub: sinon.SinonStub;
     let executeCommandStub: sinon.SinonStub;
+    const nodeJsRequirement: string = Dependencies.NODEJS_REQUIRED.replace(/<.*\|\|/, '||').replace(/<.*/, '');
 
     before(async () => {
         await TestUtil.setupTests(mySandBox);
@@ -98,7 +99,7 @@ describe('PreReqView', () => {
 
         it('should show message that all prerequisites have been installed', async () => {
             const dependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },
@@ -126,7 +127,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"8.12.0","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NODEJS_REQUIRED}","requiredLabel":"only"}`);
+            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"10.15.3","url":"https://nodejs.org/en/download/releases","requiredVersion":"${nodeJsRequirement}","requiredLabel":"only"}`);
             html.should.contain(`"npm":{"name":"npm","required":true,"version":"6.4.1","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NPM_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"docker":{"name":"Docker","required":true,"version":"17.7.0","url":"https://www.docker.com/get-started","requiredVersion":"${Dependencies.DOCKER_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"dockerCompose":{"name":"Docker Compose","required":true,"version":"1.15.0","url":"https://docs.docker.com/compose/install/","requiredVersion":"${Dependencies.DOCKER_COMPOSE_REQUIRED}","requiredLabel":""}`);
@@ -192,7 +193,7 @@ describe('PreReqView', () => {
             const preReqView: PreReqView = new PreReqView(context);
 
             const dependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },
@@ -213,7 +214,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"8.12.0","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NODEJS_REQUIRED}","requiredLabel":"only"}`);
+            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"10.15.3","url":"https://nodejs.org/en/download/releases","requiredVersion":"${nodeJsRequirement}","requiredLabel":"only"}`);
             html.should.contain(`"npm":{"name":"npm","required":true,"version":"6.4.1","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NPM_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"docker":{"name":"Docker","required":true,"version":"17.7.0","url":"https://www.docker.com/get-started","requiredVersion":"${Dependencies.DOCKER_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"dockerCompose":{"name":"Docker Compose","required":true,"version":"1.15.0","url":"https://docs.docker.com/compose/install/","requiredVersion":"${Dependencies.DOCKER_COMPOSE_REQUIRED}","requiredLabel":""}`);
@@ -243,7 +244,7 @@ describe('PreReqView', () => {
             const preReqView: PreReqView = new PreReqView(context);
 
             const dependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },
@@ -265,7 +266,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"8.12.0","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NODEJS_REQUIRED}","requiredLabel":"only"}`);
+            html.should.contain(`"node":{"name":"Node.js","required":true,"version":"10.15.3","url":"https://nodejs.org/en/download/releases","requiredVersion":"${nodeJsRequirement}","requiredLabel":"only"}`);
             html.should.contain(`"npm":{"name":"npm","required":true,"version":"6.4.1","url":"https://nodejs.org/en/download/releases","requiredVersion":"${Dependencies.NPM_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"docker":{"name":"Docker","required":true,"version":"17.7.0","url":"https://www.docker.com/get-started","requiredVersion":"${Dependencies.DOCKER_REQUIRED}","requiredLabel":""}`);
             html.should.contain(`"dockerCompose":{"name":"Docker Compose","required":true,"version":"1.15.0","url":"https://docs.docker.com/compose/install/","requiredVersion":"${Dependencies.DOCKER_COMPOSE_REQUIRED}","requiredLabel":""}`);
@@ -601,7 +602,7 @@ describe('PreReqView', () => {
         it(`should handle 'check' message where Docker for Windows has been confirmed`, async () => {
 
             const mockDependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },
@@ -691,7 +692,7 @@ describe('PreReqView', () => {
         it(`should handle 'check' message where System Requirements has been confirmed`, async () => {
 
             const mockDependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },
@@ -857,7 +858,7 @@ describe('PreReqView', () => {
         it(`should handle 'skip' message where all dependencies are installed`, async () => {
 
             const mockDependencies: any = {
-                node: {name: 'Node.js', required: true, version: '8.12.0', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
+                node: {name: 'Node.js', required: true, version: '10.15.3', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only' },
                 npm: {name: 'npm', required: true, version: '6.4.1', url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '' },
                 docker: {name: 'Docker', required: true, version: '17.7.0', url: 'https://www.docker.com/get-started', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '' },
                 dockerCompose: {name: 'Docker Compose', required: true, version: '1.15.0', url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '' },


### PR DESCRIPTION
Changed node dependencies from versions 8 and 10 to 10 and 12 according to node sdk engine requirements.
Changed openSSL requirement to be version v1.0.2 regardless of node version, and removed windows 32bit information from the readme and prereqs links.

closes #2641 
closes #2633 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>