### PR TITLE
Add peer targeting to transaction view

### DIFF
--- a/packages/blockchain-extension/extension/commands/openTransactionViewCommand.ts
+++ b/packages/blockchain-extension/extension/commands/openTransactionViewCommand.ts
@@ -27,7 +27,7 @@ export async function openTransactionView(treeItem?: InstantiatedTreeItem): Prom
     outputAdapter.log(LogType.INFO, undefined, `Open Transaction View`);
     let smartContractLabel: string;
     let contract: { name: string, contractInstance: {}, transactions: Array<{}>, info: {} };
-    let data: { name: string, version: string, channel: string, label: string, transactions: Array<{}>, namespace: string };
+    let data: { name: string, version: string, channel: string, label: string, transactions: Array<{}>, namespace: string, peerNames: string[] };
 
     let connection: IFabricGatewayConnection = FabricGatewayConnectionManager.instance().getConnection();
 
@@ -69,6 +69,10 @@ export async function openTransactionView(treeItem?: InstantiatedTreeItem): Prom
 
     for (const [thisChannelName] of channelMap) {
         const chaincodes: Array<FabricSmartContractDefinition> = await connection.getInstantiatedChaincode(thisChannelName); // returns array of objects
+        const channelPeerInfo: {name: string, mspID: string}[] = await connection.getChannelPeersInfo(thisChannelName);
+        const peerNames: string[] = channelPeerInfo.map((peer: {name: string, mspID: string}) => {
+            return peer.name;
+        });
         for (const chaincode of chaincodes) {
             metadataObj = await connection.getMetadata(chaincode.name, thisChannelName);
             const contractsObject: any = metadataObj.contracts;
@@ -82,7 +86,8 @@ export async function openTransactionView(treeItem?: InstantiatedTreeItem): Prom
                             channel: thisChannelName,
                             label: chaincode.name + '@' + chaincode.version,
                             transactions: contract.transactions,
-                            namespace: contract.name
+                            namespace: contract.name,
+                            peerNames
                         };
                         selectedSmartContract = data;
                         return;

--- a/packages/blockchain-extension/extension/commands/submitTransaction.ts
+++ b/packages/blockchain-extension/extension/commands/submitTransaction.ts
@@ -262,7 +262,7 @@ export async function submitTransaction(evaluate: boolean, treeItem?: Instantiat
 
     if (transactionObject) {
         peerTargetNames = transactionObject.peerTargetNames;
-        peerTargetMessage = '';
+        peerTargetMessage = peerTargetNames.length ? ` to peers ${peerTargetNames}` : '';
     } else {
         if (channelPeerInfo.length === 0) {
             outputAdapter.log(LogType.ERROR, `No channel peers available to target`);

--- a/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
@@ -93,6 +93,14 @@ describe('OpenTransactionViewCommand', () => {
             fabricClientConnectionMock.getAllPeerNames.returns(['peerOne']);
             fabricClientConnectionMock.getAllChannelsForPeer.withArgs('peerOne').resolves(['myChannel']);
 
+            fabricClientConnectionMock.getChannelPeersInfo.resolves([{
+                name: 'peerOne',
+                mspID: 'org1msp'
+            }, {
+                name: 'peerTwo',
+                mspID: 'org1msp'
+            }]);
+
             fabricClientConnectionMock.getInstantiatedChaincode.resolves([{ name: 'mySmartContract', version: '0.0.1' }]);
 
             fabricClientConnectionMock.getMetadata.resolves(

--- a/packages/blockchain-extension/test/commands/submitTransaction.test.ts
+++ b/packages/blockchain-extension/test/commands/submitTransaction.test.ts
@@ -948,6 +948,44 @@ describe('SubmitTransactionCommand', () => {
             dockerLogsOutputSpy.should.not.have.been.called;
         });
 
+        it('should submit a transaction with custom peer targeting through the transaction view', async () => {
+            const transactionObject: any = {
+                smartContract: 'myContract',
+                transactionName: 'transaction1',
+                channelName: 'myChannel',
+                args: `["arg1", "arg2", "arg3"]`,
+                namespace: 'my-contract',
+                transientData: '',
+                peerTargetNames: ['peer1', 'peer2']
+            };
+
+            await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION, undefined, undefined, undefined, transactionObject);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWith('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract');
+            dockerLogsOutputSpy.should.not.have.been.called;
+            logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with args arg1,arg2,arg3 on channel myChannel to peers peer1,peer2`);
+            logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction');
+            reporterStub.should.have.been.calledWith('submit transaction');
+        });
+
+        it('should evaluate a transaction with custom peer targeting through the transaction view', async () => {
+            const transactionObject: any = {
+                smartContract: 'myContract',
+                transactionName: 'transaction1',
+                channelName: 'myChannel',
+                args: `["arg1", "arg2", "arg3"]`,
+                namespace: 'my-contract',
+                transientData: '',
+                peerTargetNames: ['peer1', 'peer2']
+            };
+
+            await vscode.commands.executeCommand(ExtensionCommands.EVALUATE_TRANSACTION, undefined, undefined, undefined, transactionObject);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWith('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract');
+            dockerLogsOutputSpy.should.not.have.been.called;
+            logSpy.should.have.been.calledWith(LogType.INFO, undefined, `evaluating transaction transaction1 with args arg1,arg2,arg3 on channel myChannel to peers peer1,peer2`);
+            logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully evaluated transaction');
+            reporterStub.should.have.been.calledWith('evaluate transaction');
+        });
+
         it('should let a user submit a file in their associated transaction data directory', async () => {
             const gatewayWithTestData: FabricGatewayRegistryEntry = new FabricGatewayRegistryEntry();
             gatewayWithTestData.name = 'myConnection';

--- a/packages/blockchain-ui/cypress/integration/transaction_page.spec.ts
+++ b/packages/blockchain-ui/cypress/integration/transaction_page.spec.ts
@@ -36,7 +36,8 @@ describe('Transaction page', () => {
         channel: 'mychannel',
         label: 'greenContract@0.0.1',
         transactions: [transactionOne, transactionTwo],
-        namespace: 'GreenContract'
+        namespace: 'GreenContract',
+        peerNames: ['peer1', 'peer2']
     };
 
     const mockMessage: {path: string, transactionData: {gatewayName: string, smartContract: ISmartContract} } = {
@@ -61,8 +62,10 @@ describe('Transaction page', () => {
     });
 
     it('generates appropriate arguments when a transaction is selected', () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
         cy.get('#arguments-text-area')
             .invoke('val')
             .then((text: JQuery<HTMLElement>): void => {
@@ -71,8 +74,10 @@ describe('Transaction page', () => {
     });
 
     it('replaces generated arguments when a new transaction is selected', () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
         cy.get('#arguments-text-area')
             .invoke('val')
             .then((text: JQuery<HTMLElement>): void => {
@@ -81,6 +86,7 @@ describe('Transaction page', () => {
 
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionTwo').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionTwo');
         cy.get('#arguments-text-area')
             .invoke('val')
             .then((text: JQuery<HTMLElement>): void => {
@@ -89,8 +95,11 @@ describe('Transaction page', () => {
     });
 
     it(`can submit a transaction with the user's input`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
+
         cy.get('#arguments-text-area').type('{leftarrow}{leftarrow}{leftarrow}penguin');
 
         cy.get('#submit-button').click();
@@ -103,8 +112,11 @@ describe('Transaction page', () => {
     });
 
     it(`can submit a transaction with transient data`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
+
         cy.get('#arguments-text-area').type('{leftarrow}{leftarrow}{leftarrow}penguin');
         cy.get('#transient-data-input').type('{"some": "data"}', {parseSpecialCharSequences: false});
 
@@ -117,9 +129,32 @@ describe('Transaction page', () => {
         cy.get('.output-body').contains(mockOutput.transactionOutput);
     });
 
+    it(`can submit a transaction with custom peer`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
+        cy.get('#transaction-select').click(); // Expand dropdown
+        cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
+
+        cy.get('#peer-select').contains('Select peers');
+        cy.get('#peer-select').click(); // Expand dropdown
+        cy.get('#peer-select').contains('peer1').click(); // Click on option
+        cy.get('#peer-select').contains('peer1');
+
+        cy.get('#submit-button').click();
+
+        cy.window().then((window: Window) => {
+            window.postMessage(mockOutput, '*');
+        });
+
+        cy.get('.output-body').contains(mockOutput.transactionOutput);
+    });
+
     it(`can evaluate a transaction with the user's input`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionTwo').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionTwo');
+
         cy.get('#arguments-text-area').type('{leftarrow}{leftarrow}{leftarrow}big');
 
         cy.get('#evaluate-button').click();
@@ -132,10 +167,33 @@ describe('Transaction page', () => {
     });
 
     it(`can evaluate a transaction with transient data`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
         cy.get('#transaction-select').click(); // Expand dropdown
         cy.get('#transaction-select').contains('transactionTwo').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionTwo');
+
         cy.get('#arguments-text-area').type('{leftarrow}{leftarrow}{leftarrow}big');
         cy.get('#transient-data-input').type('{"some": "data"}', {parseSpecialCharSequences: false});
+
+        cy.get('#evaluate-button').click();
+
+        cy.window().then((window: Window) => {
+            window.postMessage(mockOutput, '*');
+        });
+
+        cy.get('.output-body').contains(mockOutput.transactionOutput);
+    });
+
+    it(`can submit a transaction with custom peer`, () => {
+        cy.get('#transaction-select').contains('Select the transaction name');
+        cy.get('#transaction-select').click(); // Expand dropdown
+        cy.get('#transaction-select').contains('transactionOne').click(); // Click on option
+        cy.get('#transaction-select').contains('transactionOne');
+
+        cy.get('#peer-select').contains('Select peers');
+        cy.get('#peer-select').click(); // Expand dropdown
+        cy.get('#peer-select').contains('peer1').click(); // Click on option
+        cy.get('#peer-select').contains('peer1');
 
         cy.get('#evaluate-button').click();
 

--- a/packages/blockchain-ui/enzyme/tests/App.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/App.test.tsx
@@ -123,7 +123,8 @@ describe('App', () => {
                 channel: 'myChannel',
                 label: 'mySmartContract@0.0.1',
                 transactions: [],
-                namespace: 'My Smart Contract'
+                namespace: 'My Smart Contract',
+                peerNames: ['peer1', 'peer2']
             }
         };
 

--- a/packages/blockchain-ui/enzyme/tests/TransactionForm.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionForm.test.tsx
@@ -46,7 +46,8 @@ describe('TransactionForm component', () => {
         channel: 'mychannel',
         label: 'greenContract@0.0.1',
         transactions: [transactionOne, transactionTwo],
-        namespace: 'GreenContract'
+        namespace: 'GreenContract',
+        peerNames: ['peer1', 'peer2']
     };
 
     beforeEach(async () => {
@@ -106,6 +107,19 @@ describe('TransactionForm component', () => {
         component.state().transientData.should.equal('some transient data');
     });
 
+    it('should update state when a peer is selected', async () => {
+        const onChangeEvent: { selectedItems: { id: string; label: string}[] } = {
+            selectedItems: [{
+                id: 'peer1',
+                label: 'peer1'
+            }]
+        };
+        const component: any = mount(<TransactionForm smartContract={greenContract}/>);
+        component.state().selectedPeerNames.should.deep.equal(greenContract.peerNames);
+        component.find('MultiSelect').at(0).prop('onChange')(onChangeEvent);
+        component.state().selectedPeerNames.should.deep.equal(['peer1']);
+    });
+
     it('should attempt to submit a transaction when the submit button is clicked ', async () => {
         const component: any = mount(<TransactionForm smartContract={greenContract}/>);
         component.setState({
@@ -120,7 +134,7 @@ describe('TransactionForm component', () => {
                 channelName: 'mychannel',
                 evaluate: false,
                 namespace: 'GreenContract',
-                peerTargetNames: [],
+                peerTargetNames: greenContract.peerNames,
                 smartContract: 'greenContract',
                 transactionName: 'transactionOne',
                 transientData: ''
@@ -142,7 +156,7 @@ describe('TransactionForm component', () => {
                 channelName: 'mychannel',
                 evaluate: true,
                 namespace: 'GreenContract',
-                peerTargetNames: [],
+                peerTargetNames: greenContract.peerNames,
                 smartContract: 'greenContract',
                 transactionName: 'transactionOne',
                 transientData: ''
@@ -165,7 +179,7 @@ describe('TransactionForm component', () => {
                 channelName: 'mychannel',
                 evaluate: false,
                 namespace: 'GreenContract',
-                peerTargetNames: [],
+                peerTargetNames: greenContract.peerNames,
                 smartContract: 'greenContract',
                 transactionName: 'transactionOne',
                 transientData: '{"some": "data"}'
@@ -188,7 +202,55 @@ describe('TransactionForm component', () => {
                 channelName: 'mychannel',
                 evaluate: true,
                 namespace: 'GreenContract',
-                peerTargetNames: [],
+                peerTargetNames: greenContract.peerNames,
+                smartContract: 'greenContract',
+                transactionName: 'transactionOne',
+                transientData: '{"some": "data"}'
+            }
+        });
+    });
+
+    it('should attempt to submit a transaction with custom peers when the submit button is clicked ', async () => {
+        const component: any = mount(<TransactionForm smartContract={greenContract}/>);
+        component.setState({
+            activeTransaction: transactionOne,
+            transactionArguments: '[\nname: "Green"\n]',
+            transientData: '{"some": "data"}',
+            selectedPeerNames: ['peer1']
+        });
+        component.find('#submit-button').at(1).simulate('click');
+        postToVSCodeStub.should.have.been.calledOnceWithExactly({
+            command: ExtensionCommands.SUBMIT_TRANSACTION,
+            data: {
+                args: '["Green"]',
+                channelName: 'mychannel',
+                evaluate: false,
+                namespace: 'GreenContract',
+                peerTargetNames: ['peer1'],
+                smartContract: 'greenContract',
+                transactionName: 'transactionOne',
+                transientData: '{"some": "data"}'
+            }
+        });
+    });
+
+    it('should attempt to evaluate a transaction with transient data when the evaluate button is clicked', async () => {
+        const component: any = mount(<TransactionForm smartContract={greenContract}/>);
+        component.setState({
+            activeTransaction: transactionOne,
+            transactionArguments: '[\nname: "Green"\n]',
+            transientData: '{"some": "data"}',
+            selectedPeerNames: ['peer1']
+        });
+        component.find('#evaluate-button').at(1).simulate('click');
+        postToVSCodeStub.should.have.been.calledOnceWithExactly({
+            command: ExtensionCommands.EVALUATE_TRANSACTION,
+            data: {
+                args: '["Green"]',
+                channelName: 'mychannel',
+                evaluate: true,
+                namespace: 'GreenContract',
+                peerTargetNames: ['peer1'],
                 smartContract: 'greenContract',
                 transactionName: 'transactionOne',
                 transientData: '{"some": "data"}'

--- a/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
@@ -43,7 +43,8 @@ describe('TransactionPage component', () => {
         channel: 'mychannel',
         label: 'greenContract@0.0.1',
         transactions: [transactionOne, transactionTwo],
-        namespace: 'GreenContract'
+        namespace: 'GreenContract',
+        peerNames: ['peer1', 'peer2']
     };
 
     const state: {gatewayName: string, smartContract: ISmartContract} = {

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionForm.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionForm.test.tsx.snap
@@ -135,48 +135,88 @@ exports[`TransactionForm component should render the expected snapshot 1`] = `
       Peer targeting
     </legend>
     <div
-      className="bx--form-item"
+      className="bx--multi-select__wrapper bx--list-box__wrapper"
     >
-      <div
-        className="bx--select select-width hide-label"
+      <span
+        className="bx--label"
+        id="multiselect-label-1"
       >
-        <label
-          className="bx--label"
-          htmlFor="peers-select"
-        >
-          Peers
-        </label>
+        Target specific peer (optional)
+      </span>
+      <div
+        className="bx--multi-select bx--multi-select--selected bx--list-box"
+        id="peer-select"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+      >
         <div
-          className="bx--select-input__wrapper"
-          data-invalid={null}
+          aria-controls={null}
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-labelledby="multiselect-label-1 multiselect-field-label-1"
+          aria-owns={null}
+          className="bx--list-box__field"
+          data-toggle={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex="0"
+          type="button"
         >
-          <select
-            className="bx--select-input"
-            id="peers-select"
+          <div
+            aria-label="Clear Selection"
+            className="bx--list-box__selection bx--tag--filter bx--list-box__selection--multi"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Clear all selected items"
           >
-            <option
-              className="bx--select-option"
-              disabled={false}
-              hidden={false}
-              value="select-a-peer"
+            2
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
             >
-              Select a peer
-            </option>
-          </select>
-          <svg
-            aria-hidden={true}
-            className="bx--select__arrow"
-            focusable="false"
-            height={16}
-            preserveAspectRatio="xMidYMid meet"
-            viewBox="0 0 16 16"
-            width={16}
-            xmlns="http://www.w3.org/2000/svg"
+              <polygon
+                points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"
+              />
+            </svg>
+          </div>
+          <span
+            className="bx--list-box__label"
+            id="multiselect-field-label-1"
           >
-            <polygon
-              points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
-            />
-          </svg>
+            Select peers
+          </span>
+          <div
+            className="bx--list-box__menu-icon"
+          >
+            <svg
+              aria-label="Open menu"
+              focusable="false"
+              height={16}
+              name="chevron--down"
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+              />
+              <title>
+                Open menu
+              </title>
+            </svg>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionPage.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionPage.test.tsx.snap
@@ -168,48 +168,88 @@ exports[`TransactionPage component should render the expected snapshot 1`] = `
                 Peer targeting
               </legend>
               <div
-                className="bx--form-item"
+                className="bx--multi-select__wrapper bx--list-box__wrapper"
               >
-                <div
-                  className="bx--select select-width hide-label"
+                <span
+                  className="bx--label"
+                  id="multiselect-label-1"
                 >
-                  <label
-                    className="bx--label"
-                    htmlFor="peers-select"
-                  >
-                    Peers
-                  </label>
+                  Target specific peer (optional)
+                </span>
+                <div
+                  className="bx--multi-select bx--multi-select--selected bx--list-box"
+                  id="peer-select"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                >
                   <div
-                    className="bx--select-input__wrapper"
-                    data-invalid={null}
+                    aria-controls={null}
+                    aria-disabled={false}
+                    aria-expanded={false}
+                    aria-haspopup={true}
+                    aria-labelledby="multiselect-label-1 multiselect-field-label-1"
+                    aria-owns={null}
+                    className="bx--list-box__field"
+                    data-toggle={true}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onKeyDown={[Function]}
+                    role="button"
+                    tabIndex="0"
+                    type="button"
                   >
-                    <select
-                      className="bx--select-input"
-                      id="peers-select"
+                    <div
+                      aria-label="Clear Selection"
+                      className="bx--list-box__selection bx--tag--filter bx--list-box__selection--multi"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      tabIndex={0}
+                      title="Clear all selected items"
                     >
-                      <option
-                        className="bx--select-option"
-                        disabled={false}
-                        hidden={false}
-                        value="select-a-peer"
+                      2
+                      <svg
+                        aria-hidden={true}
+                        focusable="false"
+                        height={16}
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 32 32"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
                       >
-                        Select a peer
-                      </option>
-                    </select>
-                    <svg
-                      aria-hidden={true}
-                      className="bx--select__arrow"
-                      focusable="false"
-                      height={16}
-                      preserveAspectRatio="xMidYMid meet"
-                      viewBox="0 0 16 16"
-                      width={16}
-                      xmlns="http://www.w3.org/2000/svg"
+                        <polygon
+                          points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"
+                        />
+                      </svg>
+                    </div>
+                    <span
+                      className="bx--list-box__label"
+                      id="multiselect-field-label-1"
                     >
-                      <polygon
-                        points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
-                      />
-                    </svg>
+                      Select peers
+                    </span>
+                    <div
+                      className="bx--list-box__menu-icon"
+                    >
+                      <svg
+                        aria-label="Open menu"
+                        focusable="false"
+                        height={16}
+                        name="chevron--down"
+                        preserveAspectRatio="xMidYMid meet"
+                        role="img"
+                        viewBox="0 0 16 16"
+                        width={16}
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <polygon
+                          points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+                        />
+                        <title>
+                          Open menu
+                        </title>
+                      </svg>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/packages/blockchain-ui/src/App.tsx
+++ b/packages/blockchain-ui/src/App.tsx
@@ -27,7 +27,7 @@ class App extends Component<{}, AppState> {
             extensionVersion: '',
             tutorialData: [],
             deployData: { channelName: '', environmentName: '', packageEntries: [], workspaceNames: [], selectedPackage: undefined, committedDefinitions: [], environmentPeers: [], discoveredPeers: [], orgMap: {}, orgApprovals: {} },
-            transactionData: {gatewayName: '', smartContract: {name: '', version: '', channel: '', label: '', transactions: [], namespace: ''} },
+            transactionData: {gatewayName: '', smartContract: {name: '', version: '', channel: '', label: '', transactions: [], namespace: '', peerNames: []} },
             transactionOutput: ''
         };
     }

--- a/packages/blockchain-ui/src/interfaces/ISmartContract.ts
+++ b/packages/blockchain-ui/src/interfaces/ISmartContract.ts
@@ -7,6 +7,7 @@ interface ISmartContract {
     label: string;
     transactions: Array<ITransaction>;
     namespace: string;
+    peerNames: string[];
 }
 
 export default ISmartContract;


### PR DESCRIPTION
To access the transaction view from the command palette, go into the package.json and remove these lines:

```
{
     "command": "transactionPage.open",
     "when": "false"
},
```

Closes #1678 and contributes to #1155

Signed-off-by: Erin Hughes Erin.Hughes@ibm.com