### PR TITLE
Add survey message on first contract submit

### DIFF
--- a/packages/blockchain-extension/extension/commands/UserInputUtil.ts
+++ b/packages/blockchain-extension/extension/commands/UserInputUtil.ts
@@ -1233,6 +1233,13 @@ export class UserInputUtil {
         return newNodes.concat(hiddenNodes, pickedNodes);
     }
 
+    public static async showExternalLinkButton(message: string, callToAction: string, url: string): Promise<void> {
+        const selectedText: string = await vscode.window.showInformationMessage(message, callToAction);
+        if (selectedText === callToAction) {
+            vscode.env.openExternal(vscode.Uri.parse(url));
+        }
+    }
+
     private static async checkForUnsavedFiles(): Promise<void> {
         const unsavedFiles: vscode.TextDocument = vscode.workspace.textDocuments.find((document: vscode.TextDocument) => {
             return document.isDirty;

--- a/packages/blockchain-extension/extension/commands/submitTransaction.ts
+++ b/packages/blockchain-extension/extension/commands/submitTransaction.ts
@@ -25,6 +25,7 @@ import { VSCodeBlockchainDockerOutputAdapter } from '../logging/VSCodeBlockchain
 import { InstantiatedTreeItem } from '../explorer/model/InstantiatedTreeItem';
 import { IFabricGatewayConnection, LogType, FabricGatewayRegistryEntry, FabricEnvironmentRegistryEntry, FabricEnvironmentRegistry, EnvironmentType } from 'ibm-blockchain-platform-common';
 import { FabricDebugConfigurationProvider } from '../debug/FabricDebugConfigurationProvider';
+import { GlobalState, ExtensionData } from '../util/GlobalState';
 
 interface ITransactionData {
     transactionName: string;
@@ -331,6 +332,22 @@ export async function submitTransaction(evaluate: boolean, treeItem?: Instantiat
             outputAdapter.log(LogType.SUCCESS, `Successfully ${actioned} transaction`, message);
 
             outputAdapter.show(); // Bring the 'Blockchain' output channel into focus.
+
+            const extensionData: ExtensionData = GlobalState.get();
+
+            // On the user's first transaction submit, show a link to a survey
+            if (!evaluate && !extensionData.shownFirstSubmissionSurveyURL) {
+                // Show review box when we know that it has been successful
+                const surveyMessage: string = 'Congratulations on submitting your first transaction! We appreciate your feedback to help improve the extension';
+                const surveyCallToAction: string = 'Open survey';
+                const surveyURL: string = 'https://www.surveygizmo.com/s3/5561397/VSCodeExt-Popup-Link';
+                await GlobalState.update({ ...extensionData, shownFirstSubmissionSurveyURL: true });
+
+                // Don't use async/await here so that the parent function can return
+                // tslint:disable-next-line: no-floating-promises
+                UserInputUtil.showExternalLinkButton(surveyMessage, surveyCallToAction, surveyURL);
+
+            }
 
             if (transactionObject) {
                 return message;

--- a/packages/blockchain-extension/extension/extension.ts
+++ b/packages/blockchain-extension/extension/extension.ts
@@ -56,7 +56,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         preReqPageShown: originalExtensionData.preReqPageShown,
         dockerForWindows: originalExtensionData.dockerForWindows,
         createOneOrgLocalFabric: originalExtensionData.createOneOrgLocalFabric,
-        deletedOneOrgLocalFabric: originalExtensionData.deletedOneOrgLocalFabric
+        deletedOneOrgLocalFabric: originalExtensionData.deletedOneOrgLocalFabric,
+        shownFirstSubmissionSurveyURL: originalExtensionData.shownFirstSubmissionSurveyURL,
     };
 
     let extDir: string = SettingConfigurations.getExtensionDir();

--- a/packages/blockchain-extension/extension/util/GlobalState.ts
+++ b/packages/blockchain-extension/extension/util/GlobalState.ts
@@ -27,6 +27,7 @@ export class ExtensionData {
     public dockerForWindows: boolean;
     public createOneOrgLocalFabric: boolean;
     public deletedOneOrgLocalFabric: boolean;
+    public shownFirstSubmissionSurveyURL: boolean;
 }
 
 export const EXTENSION_DATA_KEY: string = 'ibm-blockchain-platform-extension-data';
@@ -39,7 +40,8 @@ export const DEFAULT_EXTENSION_DATA: ExtensionData = {
     preReqPageShown: false, // The very first time the extension is installed, the prereq page should be shown,
     dockerForWindows: false, // Has the user agreed to configure Windows containers to use Linux (default)
     createOneOrgLocalFabric: true, // Should we create the '1 Org Local Fabric' environment?
-    deletedOneOrgLocalFabric: false // Has the user deleted the '1 Org Local Fabric' environment?
+    deletedOneOrgLocalFabric: false, // Has the user deleted the '1 Org Local Fabric' environment?
+    shownFirstSubmissionSurveyURL: false // Show the survey URL the first time the user submits a transaction
 };
 
 // tslint:disable-next-line: max-classes-per-file

--- a/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
+++ b/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
@@ -3151,4 +3151,30 @@ describe('UserInputUtil', () => {
             result.should.deep.equal(expectedSortedNodes);
         });
     });
+
+    describe('showExternalLinkButton', () => {
+        const msg: string = 'msg';
+        const callToAction: string = 'callToAction';
+        const url: string = 'url';
+
+        it('should open the URL as the selected text is the callToAction', async () => {
+            const showInformationMessage: sinon.SinonStub = mySandBox.stub(vscode.window, 'showInformationMessage').resolves(callToAction);
+            const openSurvey: sinon.SinonStub = mySandBox.stub(vscode.env, 'openExternal');
+
+            await UserInputUtil.showExternalLinkButton(msg, callToAction, url);
+
+            showInformationMessage.should.have.been.calledWith(msg, callToAction);
+            openSurvey.should.have.been.calledWith(vscode.Uri.parse(url));
+        });
+
+        it('should do nothing as the selected text is not the callToAction', async () => {
+            const showInformationMessage: sinon.SinonStub = mySandBox.stub(vscode.window, 'showInformationMessage').resolves(msg);
+            const openSurvey: sinon.SinonStub = mySandBox.stub(vscode.env, 'openExternal');
+
+            await UserInputUtil.showExternalLinkButton(msg, callToAction, url);
+
+            showInformationMessage.should.have.been.calledWith(msg, callToAction);
+            openSurvey.should.have.not.been.called;
+        });
+    });
 });


### PR DESCRIPTION
Final part of #2210 

### Summary
Added an information message when the user makes their first ever contract submission which links to a survey: https://www.surveygizmo.com/s3/5561397/VSCodeExt-Popup-Link.

![image](https://user-images.githubusercontent.com/17385115/93992016-f23fcf80-fd84-11ea-8f20-1fbdd4259e33.png)

### Testing
* Added unit tests to ensure the survey only appears on the users **first submit** (not evaluate).
* Manually tested that the information message appears with a blue button and links to the survey.