### PR TITLE
Improve performance of prerequisites page 

### DIFF
--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -13,7 +13,7 @@
 */
 'use strict';
 
-export class Dependencies {
+export class DependencyVersions {
 
     static readonly DOCKER_REQUIRED: string = '>=17.6.2';
     static readonly DOCKER_COMPOSE_REQUIRED: string = '>=1.14.0';
@@ -23,5 +23,169 @@ export class Dependencies {
     static readonly OPENSSL_REQUIRED: string = '1.0.2 || 1.1.1';
     static readonly GO_REQUIRED: string = '>=1.12.0';
     static readonly JAVA_REQUIRED: string = '1.8.x';
-
 }
+
+interface Dependency {
+    name: string;
+    required: boolean;
+}
+
+export interface DependencyWithVersion extends Dependency {
+    version: string;
+    url: string;
+    requiredVersion: string;
+    requiredLabel: string;
+    tooltip: string;
+}
+
+export interface DependencyWithComplete extends Dependency {
+    complete: boolean;
+    id: string;
+    checkbox: boolean;
+    text: string;
+    // System properties uses a version for amount of memory
+    version?: any;
+}
+
+export interface RequiredDependencies {
+    docker?: DependencyWithVersion;
+    dockerCompose?: DependencyWithVersion;
+    systemRequirements?: DependencyWithComplete;
+    openssl?: DependencyWithVersion;
+    dockerForWindows?: DependencyWithComplete;
+}
+
+export interface OptionalDependencies {
+    node: DependencyWithVersion;
+    npm: DependencyWithVersion;
+    go: DependencyWithVersion;
+    goExtension: DependencyWithVersion;
+    java: DependencyWithVersion;
+    javaLanguageExtension: DependencyWithVersion;
+    javaDebuggerExtension: DependencyWithVersion;
+    javaTestRunnerExtension: DependencyWithVersion;
+}
+
+export interface Dependencies extends RequiredDependencies, OptionalDependencies {}
+
+export const defaultDependencies: { required: RequiredDependencies, optional: OptionalDependencies } = {
+    required: {
+        docker: {
+            name: 'Docker',
+            required: true,
+            version: undefined,
+            url: 'https://docs.docker.com/install/#supported-platforms',
+            requiredVersion: DependencyVersions.DOCKER_REQUIRED,
+            requiredLabel: '',
+            tooltip: `Used to download Hyperledger Fabric images and manage containers for local environments.`,
+        },
+        dockerCompose: {
+            name: 'Docker Compose',
+            required: true,
+            version: undefined,
+            url: 'https://docs.docker.com/compose/install/',
+            requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED,
+            requiredLabel: '',
+            tooltip: `Used for managing and operating the individual local environment components.`
+        },
+        systemRequirements: {
+            name: 'System Requirements',
+            required: true,
+            id: 'systemRequirements',
+            complete: undefined,
+            checkbox: false,
+            text: 'In order to support the local runtime, please confirm your system has at least 4GB of RAM'
+        },
+        openssl: {
+            name: 'OpenSSL',
+            required: true,
+            version: undefined,
+            url: 'http://slproweb.com/products/Win32OpenSSL.html',
+            requiredVersion: DependencyVersions.OPENSSL_REQUIRED,
+            requiredLabel: 'for Node 8.x and Node 10.x respectively',
+            tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.'
+        },
+        dockerForWindows: {
+            name: 'Docker for Windows',
+            required: true,
+            id: 'dockerForWindows',
+            complete: undefined,
+            checkbox: true,
+            text: 'Docker for Windows must be configured to use Linux containers (this is the default)'
+        },
+    },
+    optional: {
+        node: {
+            name: 'Node.js',
+            required: false,
+            version: undefined,
+            url: 'https://nodejs.org/en/download/releases',
+            requiredVersion: DependencyVersions.NODEJS_REQUIRED,
+            requiredLabel: 'only',
+            tooltip: 'Required for developing JavaScript and TypeScript smart contracts. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.'
+        },
+        npm: {
+            name: 'npm',
+            required: false,
+            version: undefined,
+            url: 'https://nodejs.org/en/download/releases',
+            requiredVersion: DependencyVersions.NPM_REQUIRED,
+            requiredLabel: '',
+            tooltip: 'Required for installing JavaScript and TypeScript smart contract dependencies. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.'
+        },
+        go: {
+            name: 'Go',
+            required: false,
+            version: undefined,
+            url: 'https://golang.org/dl/',
+            requiredVersion: DependencyVersions.GO_REQUIRED,
+            requiredLabel: '',
+            tooltip: 'Required for developing Go smart contracts.'
+        },
+        goExtension: {
+            name: 'Go Extension',
+            required: false,
+            version: undefined,
+            url: 'vscode:extension/golang.go',
+            requiredVersion: '',
+            requiredLabel: '',
+            tooltip: 'Provides language support for Go.'
+        },
+        java: {
+            name: 'Java OpenJDK 8',
+            required: false,
+            version: undefined,
+            url: 'https://adoptopenjdk.net/?variant=openjdk8',
+            requiredVersion: DependencyVersions.JAVA_REQUIRED,
+            requiredLabel: 'only',
+            tooltip: 'Required for developing Java smart contracts.'
+        },
+        javaLanguageExtension: {
+            name: 'Java Language Support Extension',
+            required: false,
+            version: undefined,
+            url: 'vscode:extension/redhat.java',
+            requiredVersion: undefined,
+            requiredLabel: '',
+            tooltip: 'Provides language support for Java.'
+        },
+        javaDebuggerExtension: {
+            name: 'Java Debugger Extension',
+            required: false,
+            version: undefined,
+            url: 'vscode:extension/vscjava.vscode-java-debug',
+            requiredVersion: undefined,
+            requiredLabel: '',
+            tooltip: 'Used for debugging Java smart contracts.'
+        },
+        javaTestRunnerExtension: {
+            name: 'Java Test Runner Extension',
+            required: false,
+            version: undefined,
+            url: 'vscode:extension/vscjava.vscode-java-test',
+            requiredVersion: undefined,
+            requiredLabel: '',
+            tooltip: 'Used for running Java smart contract functional tests.'
+        },
+    },
+};

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { CommandUtil } from '../util/CommandUtil';
 import { GlobalState, ExtensionData } from '../util/GlobalState';
-import { Dependencies } from './Dependencies';
+import { RequiredDependencies, OptionalDependencies, Dependencies, defaultDependencies } from './Dependencies';
 import OS = require('os');
 
 export class DependencyManager {
@@ -131,8 +131,7 @@ export class DependencyManager {
         return true;
     }
 
-    public async getPreReqVersions(): Promise<any> {
-
+    public async getPreReqVersions(): Promise<Dependencies> {
         // Only want to attempt to get extension context when activated.
         // We store whether the user has confirmed that they have met the System Requirements, so need to access the global state
 
@@ -140,228 +139,19 @@ export class DependencyManager {
 
         // The order that we add dependencies to this object matters, as the webview will create the panels in the same order.
         // So we want to handle the optional dependencies last
+        const getMultipleVersions: Array<Promise<any>> = [
+            this.getRequiredDependencies(extensionData.dockerForWindows),
+            this.getOptionalDependencies(),
+        ];
 
-        const dependencies: any = {};
+        const [requiredDependencies, optionalDependencies] = await Promise.all(getMultipleVersions);
 
-        const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
-        if (localFabricEnabled) {
-            dependencies.docker = { name: 'Docker', required: true, version: undefined, url: 'https://docs.docker.com/install/#supported-platforms', requiredVersion: Dependencies.DOCKER_REQUIRED, requiredLabel: '', tooltip: `Used to download Hyperledger Fabric images and manage containers for local environments.` };
-            dependencies.dockerCompose = { name: 'Docker Compose', required: true, version: undefined, url: 'https://docs.docker.com/compose/install/', requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED, requiredLabel: '', tooltip: `Used for managing and operating the individual local environment components.` };
-
-            // Docker
-            const dockerVersion: string = await this.getDockerVersion();
-            if (dockerVersion) {
-                dependencies.docker.version = dockerVersion;
-            }
-
-            // docker-compose
-            const composeVersion: string = await this.getDockerComposeVersion();
-            if (composeVersion) {
-                dependencies.dockerCompose.version = composeVersion;
-            }
-            dependencies.systemRequirements = { name: 'System Requirements', id: 'systemRequirements', complete: undefined, checkbox: false, required: true, text: 'In order to support the local runtime, please confirm your system has at least 4GB of RAM' };
-            dependencies.systemRequirements.version = OS.totalmem() / 1073741824;
-            if (dependencies.systemRequirements.version >= 4) {
-                dependencies.systemRequirements.complete = true;
-            } else {
-                dependencies.systemRequirements.complete = false;
-            }
-
-        }
-
-        if (process.platform === 'win32') {
-            // Windows
-
-            if (localFabricEnabled) {
-                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively', tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
-                try {
-                    const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);
-                    const win64: boolean = await fs.pathExists(`C:\\OpenSSL-Win64`);
-                    if (win32 || win64) {
-                        const arch: string = (win32) ? '32' : '64';
-                        const binPath: string = path.win32.join(`C:\\OpenSSL-Win${arch}`, 'bin', 'openssl.exe');
-                        const opensslResult: string = await CommandUtil.sendCommand(`${binPath} version`); // Format: OpenSSL 1.0.2k  26 Jan 2017
-                        if (this.isCommandFound(opensslResult)) {
-                            const opensslMatchedVersion: string = opensslResult.match(/OpenSSL (\S*)/)[1]; // Format: 1.0.2k
-                            const opensslVersionCoerced: semver.SemVer = semver.coerce(opensslMatchedVersion); // Format: X.Y.Z
-                            const opensslVersion: string = semver.valid(opensslVersionCoerced); // Returns version
-                            if (opensslVersion) {
-                                dependencies.openssl.version = opensslVersion;
-                            }
-                        }
-                    }
-                } catch (error) {
-                    // Ignore
-                }
-
-                dependencies.dockerForWindows = { name: 'Docker for Windows', id: 'dockerForWindows', complete: undefined, checkbox: true, required: true, text: 'Docker for Windows must be configured to use Linux containers (this is the default)' };
-
-                if (!extensionData.dockerForWindows) {
-                    dependencies.dockerForWindows.complete = false;
-                } else {
-                    dependencies.dockerForWindows.complete = true;
-                }
-            }
-
-        }
-
-        // We want to display the optional dependencies last
-
-        // Node
-        dependencies.node = { name: 'Node.js', required: false, version: undefined, url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NODEJS_REQUIRED, requiredLabel: 'only', tooltip: 'Required for developing JavaScript and TypeScript smart contracts. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.' };
-        try {
-            const nodeResult: string = await CommandUtil.sendCommand('node -v'); // Format: vX.Y.Z
-            if (this.isCommandFound(nodeResult)) {
-                const nodeVersion: string = nodeResult.substr(1);
-                const nodeValid: string = semver.valid(nodeVersion); // Returns version
-                if (nodeValid) {
-                    dependencies.node.version = nodeVersion;
-                }
-            }
-        } catch (error) {
-            // Ignore
-        }
-
-        // npm
-        dependencies.npm = { name: 'npm', required: false, version: undefined, url: 'https://nodejs.org/en/download/releases', requiredVersion: Dependencies.NPM_REQUIRED, requiredLabel: '', tooltip: 'Required for installing JavaScript and TypeScript smart contract dependencies. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.' };
-        try {
-            const npmResult: string = await CommandUtil.sendCommand('npm -v'); // Format: X.Y.Z
-            if (this.isCommandFound(npmResult)) {
-                const npmVersion: string = semver.valid(npmResult); // Returns version
-                if (npmVersion) {
-                    dependencies.npm.version = npmVersion;
-                }
-            }
-        } catch (error) {
-            // Ignore
-        }
-
-        // Go
-        dependencies.go = { name: 'Go', required: false, version: undefined, url: 'https://golang.org/dl/', requiredVersion: Dependencies.GO_REQUIRED, requiredLabel: '', tooltip: 'Required for developing Go smart contracts.' };
-        try {
-            const goResult: string = await CommandUtil.sendCommand('go version'); // Format: go version go1.12.5 darwin/amd64
-            if (this.isCommandFound(goResult)) {
-                const goMatchedVersion: string = goResult.match(/go version go(.*) /)[1]; // Format: X.Y.Z or X.Y
-                const goVersionCoerced: semver.SemVer = semver.coerce(goMatchedVersion); // Format: X.Y.Z
-                const goVersion: string = semver.valid(goVersionCoerced); // Returns version
-                if (goVersion) {
-                    dependencies.go.version = goVersion;
-                }
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-        // Go Extension
-        dependencies.goExtension = { name: 'Go Extension', required: false, version: undefined, url: 'vscode:extension/golang.go', requiredVersion: '', requiredLabel: '', tooltip: 'Provides language support for Go.' };
-        try {
-            const goExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('golang.go');
-            if (goExtensionResult) {
-                const version: string = goExtensionResult.packageJSON.version;
-                dependencies.goExtension.version = version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-        // Java
-        dependencies.java = { name: 'Java OpenJDK 8', required: false, version: undefined, url: 'https://adoptopenjdk.net/?variant=openjdk8', requiredVersion: Dependencies.JAVA_REQUIRED, requiredLabel: 'only', tooltip: 'Required for developing Java smart contracts.' };
-        try {
-
-            let getVersion: boolean = true;
-
-            if (process.platform === 'darwin') {
-                const javaPath: string = '/Library/Java/JavaVirtualMachines'; // This is the standard Mac install location.
-                const javaDirExists: boolean = await fs.pathExists(javaPath);
-                getVersion = javaDirExists;
-            }
-
-            if (getVersion) {
-                // For some reason, the response is going to stderr, so we have to redirect it to stdout.
-                const javaResult: string = await CommandUtil.sendCommand('java -version 2>&1'); // Format: openjdk|java version "1.8.0_212"
-                if (this.isCommandFound(javaResult)) {
-                    const javaMatchedVersion: string = javaResult.match(/(openjdk|java) version "(.*)"/)[2]; // Format: X.Y.Z_A
-                    const javaVersionCoerced: semver.SemVer = semver.coerce(javaMatchedVersion); // Format: X.Y.Z
-                    const javaVersion: string = semver.valid(javaVersionCoerced); // Returns version
-                    if (javaVersion) {
-                        dependencies.java.version = javaVersion;
-                    }
-                }
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-        // Java Language Support Extension
-        dependencies.javaLanguageExtension = { name: 'Java Language Support Extension', required: false, version: undefined, url: 'vscode:extension/redhat.java', requiredVersion: undefined, requiredLabel: '', tooltip: 'Provides language support for Java.' };
-        try {
-            const javaLanguageExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('redhat.java');
-            if (javaLanguageExtensionResult) {
-                const version: string = javaLanguageExtensionResult.packageJSON.version;
-                dependencies.javaLanguageExtension.version = version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-        // Java Debugger Extension
-        dependencies.javaDebuggerExtension = { name: 'Java Debugger Extension', required: false, version: undefined, url: 'vscode:extension/vscjava.vscode-java-debug', requiredVersion: undefined, requiredLabel: '', tooltip: 'Used for debugging Java smart contracts.' };
-        try {
-            const javaDebuggerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-debug');
-            if (javaDebuggerExtensionResult) {
-                const version: string = javaDebuggerExtensionResult.packageJSON.version;
-                dependencies.javaDebuggerExtension.version = version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-        // Java Debugger Extension
-        dependencies.javaTestRunnerExtension = { name: 'Java Test Runner Extension', required: false, version: undefined, url: 'vscode:extension/vscjava.vscode-java-test', requiredVersion: undefined, requiredLabel: '', tooltip: 'Used for running Java smart contract functional tests.' };
-        try {
-            const javaTestRunnerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-test');
-            if (javaTestRunnerExtensionResult) {
-                const version: string = javaTestRunnerExtensionResult.packageJSON.version;
-                dependencies.javaTestRunnerExtension.version = version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
+        const dependencies: Dependencies = {
+            ...requiredDependencies,
+            ...optionalDependencies,
+        };
 
         return dependencies;
-
-    }
-
-    public async getDockerVersion(): Promise<string> {
-        try {
-            const dockerResult: string = await CommandUtil.sendCommand('docker -v'); // Format: Docker version X.Y.Z-ce, build e68fc7a
-            if (this.isCommandFound(dockerResult)) {
-                const dockerMatchedVersion: string = dockerResult.match(/version (.*),/)[1]; // Format: X.Y.Z-ce "version 18.06.1-ce,"
-                const dockerCleaned: string = semver.clean(dockerMatchedVersion, { loose: true });
-                const dockerVersionCoerced: semver.SemVer = semver.coerce(dockerCleaned); // Format: X.Y.Z
-                const dockerVersion: string = semver.valid(dockerVersionCoerced); // Returns version
-                return dockerVersion;
-            }
-        } catch (error) {
-            // Ignore
-            return;
-        }
-    }
-
-    public async getDockerComposeVersion(): Promise<string> {
-        try {
-            const composeResult: string = await CommandUtil.sendCommand('docker-compose -v'); // Format: docker-compose version 1.22.0, build f46880f
-            if (this.isCommandFound(composeResult)) {
-                const composeMatchedVersion: string = composeResult.match(/version (.*),/)[1]; // Format: X.Y.Z
-                const composeCleaned: string = semver.clean(composeMatchedVersion, { loose: true });
-                const composeVersionCoerced: semver.SemVer = semver.coerce(composeCleaned); // Format: X.Y.Z
-                const composeVersion: string = semver.valid(composeVersionCoerced); // Returns version
-                return composeVersion;
-            }
-        } catch (error) {
-            // Ignore
-            return;
-        }
     }
 
     public async clearExtensionCache(): Promise<void> {
@@ -394,5 +184,251 @@ export class DependencyManager {
         } else {
             return true;
         }
+    }
+
+    private async getRequiredDependencies(dockerForWindows: boolean): Promise<RequiredDependencies> {
+        // The order of the dependencies matters
+
+        const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
+
+        const isWindows: boolean = process.platform === 'win32';
+        const dependencies: RequiredDependencies = {};
+
+        if (localFabricEnabled) {
+            const getDockerVersions: Array<Promise<string>> = [this.getDockerVersion(), this.getDockerComposeVersion()];
+            const [dockerVersion, dockerComposeVersion] = await Promise.all(getDockerVersions);
+            const systemRequirementsVersion: number = OS.totalmem() / 1073741824;
+
+            dependencies.docker = {
+                ...defaultDependencies.required.docker,
+                version: dockerVersion,
+            };
+
+            dependencies.dockerCompose = {
+                ...defaultDependencies.required.dockerCompose,
+                version: dockerComposeVersion,
+            };
+
+            dependencies.systemRequirements = {
+                ...defaultDependencies.required.systemRequirements,
+                version: systemRequirementsVersion,
+                complete: systemRequirementsVersion >= 4,
+            };
+
+            if (isWindows) {
+                const opensslVersion: string = await this.getOpensslVersion();
+
+                dependencies.openssl = {
+                    ...defaultDependencies.required.openssl,
+                    version: opensslVersion,
+                };
+
+                dependencies.dockerForWindows = {
+                    ...defaultDependencies.required.dockerForWindows,
+                    complete: !!dockerForWindows,
+                };
+            }
+
+            return dependencies;
+        }
+
+        return {};
+    }
+
+    private async getOptionalDependencies(): Promise<OptionalDependencies> {
+        // The order of the dependencies matters
+
+        // System dependencies
+        const getOptionalVersions: Array<Promise<string>> = [
+            this.getNodeVersion(),
+            this.getNPMVersion(),
+            this.getGoVersion(),
+            this.getJavaVersion(),
+        ];
+        const [nodeVersion, npmVersion, goVersion, javaVersion] = await Promise.all(getOptionalVersions);
+
+        // VSCode extension dependencies
+        const goExtensionVersion: string = this.getGoExtensionVersion();
+        const javaLanguageExtensionVersion: string = this.getJavaLanguageExtensionVersion();
+        const javaDebuggerExtensionVersion: string = this.getJavaDebuggerExtensionVersion();
+        const javaTestRunnerExtensionVersion: string = this.getJavaTestRunnerExtensionVersion();
+
+        const optionalDependencies: OptionalDependencies = {
+            ...defaultDependencies.optional,
+        };
+
+        // Update versions
+        optionalDependencies.node.version = nodeVersion;
+        optionalDependencies.npm.version = npmVersion;
+        optionalDependencies.go.version = goVersion;
+        optionalDependencies.goExtension.version = goExtensionVersion;
+        optionalDependencies.java.version = javaVersion;
+        optionalDependencies.javaLanguageExtension.version = javaLanguageExtensionVersion;
+        optionalDependencies.javaDebuggerExtension.version = javaDebuggerExtensionVersion;
+        optionalDependencies.javaTestRunnerExtension.version = javaTestRunnerExtensionVersion;
+
+        return optionalDependencies;
+    }
+
+    private async getDockerVersion(): Promise<string> {
+        try {
+            const dockerResult: string = await CommandUtil.sendCommand('docker -v'); // Format: Docker version X.Y.Z-ce, build e68fc7a
+            if (this.isCommandFound(dockerResult)) {
+                const dockerMatchedVersion: string = dockerResult.match(/version (.*),/)[1]; // Format: X.Y.Z-ce "version 18.06.1-ce,"
+                const dockerCleaned: string = semver.clean(dockerMatchedVersion, { loose: true });
+                const dockerVersionCoerced: semver.SemVer = semver.coerce(dockerCleaned); // Format: X.Y.Z
+                const dockerVersion: string = semver.valid(dockerVersionCoerced); // Returns version
+                return dockerVersion;
+            }
+        } catch (error) {
+            // Ignore
+            return;
+        }
+    }
+
+    private async getDockerComposeVersion(): Promise<string> {
+        try {
+            const composeResult: string = await CommandUtil.sendCommand('docker-compose -v'); // Format: docker-compose version 1.22.0, build f46880f
+            if (this.isCommandFound(composeResult)) {
+                const composeMatchedVersion: string = composeResult.match(/version (.*),/)[1]; // Format: X.Y.Z
+                const composeCleaned: string = semver.clean(composeMatchedVersion, { loose: true });
+                const composeVersionCoerced: semver.SemVer = semver.coerce(composeCleaned); // Format: X.Y.Z
+                const composeVersion: string = semver.valid(composeVersionCoerced); // Returns version
+                return composeVersion;
+            }
+        } catch (error) {
+            // Ignore
+            return;
+        }
+    }
+
+    private async getOpensslVersion(): Promise<string> {
+        try {
+            const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);
+            const win64: boolean = await fs.pathExists(`C:\\OpenSSL-Win64`);
+            if (win32 || win64) {
+                const arch: string = (win32) ? '32' : '64';
+                const binPath: string = path.win32.join(`C:\\OpenSSL-Win${arch}`, 'bin', 'openssl.exe');
+                const opensslResult: string = await CommandUtil.sendCommand(`${binPath} version`); // Format: OpenSSL 1.0.2k  26 Jan 2017
+                if (this.isCommandFound(opensslResult)) {
+                    const opensslMatchedVersion: string = opensslResult.match(/OpenSSL (\S*)/)[1]; // Format: 1.0.2k
+                    const opensslVersionCoerced: semver.SemVer = semver.coerce(opensslMatchedVersion); // Format: X.Y.Z
+                    const opensslVersion: string = semver.valid(opensslVersionCoerced); // Returns version
+                    return opensslVersion;
+                }
+            }
+        } catch (error) {
+            // Ignore
+        }
+    }
+
+    private async getNodeVersion(): Promise<string> {
+        try {
+            const nodeResult: string = await CommandUtil.sendCommand('node -v'); // Format: vX.Y.Z
+            if (this.isCommandFound(nodeResult)) {
+                const nodeVersion: string = nodeResult.substr(1);
+                const nodeValid: string = semver.valid(nodeVersion); // Returns version
+                return nodeValid;
+            }
+        } catch (error) {
+            // Ignore
+        }
+    }
+
+    private async getNPMVersion(): Promise<string> {
+        try {
+            const npmResult: string = await CommandUtil.sendCommand('npm -v'); // Format: X.Y.Z
+            if (this.isCommandFound(npmResult)) {
+                const npmVersion: string = semver.valid(npmResult); // Returns version
+                return npmVersion;
+            }
+        } catch (error) {
+            // Ignore
+        }
+    }
+
+    private async getGoVersion(): Promise<string> {
+        try {
+            const goResult: string = await CommandUtil.sendCommand('go version'); // Format: go version go1.12.5 darwin/amd64
+            if (this.isCommandFound(goResult)) {
+                const goMatchedVersion: string = goResult.match(/go version go(.*) /)[1]; // Format: X.Y.Z or X.Y
+                const goVersionCoerced: semver.SemVer = semver.coerce(goMatchedVersion); // Format: X.Y.Z
+                const goVersion: string = semver.valid(goVersionCoerced); // Returns version
+                return goVersion;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+    }
+
+    private getGoExtensionVersion(): string {
+        try {
+            const goExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('golang.go');
+            if (goExtensionResult) {
+                return goExtensionResult.packageJSON.version;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+    }
+
+    private async getJavaVersion(): Promise<string> {
+        try {
+
+            let getVersion: boolean = true;
+
+            if (process.platform === 'darwin') {
+                const javaPath: string = '/Library/Java/JavaVirtualMachines'; // This is the standard Mac install location.
+                const javaDirExists: boolean = await fs.pathExists(javaPath);
+                getVersion = javaDirExists;
+            }
+
+            if (getVersion) {
+                // For some reason, the response is going to stderr, so we have to redirect it to stdout.
+                const javaResult: string = await CommandUtil.sendCommand('java -version 2>&1'); // Format: openjdk|java version "1.8.0_212"
+                if (this.isCommandFound(javaResult)) {
+                    const javaMatchedVersion: string = javaResult.match(/(openjdk|java) version "(.*)"/)[2]; // Format: X.Y.Z_A
+                    const javaVersionCoerced: semver.SemVer = semver.coerce(javaMatchedVersion); // Format: X.Y.Z
+                    const javaVersion: string = semver.valid(javaVersionCoerced); // Returns version
+                    return javaVersion;
+                }
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+    }
+
+    private getJavaLanguageExtensionVersion(): string {
+        try {
+            const javaLanguageExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('redhat.java');
+            if (javaLanguageExtensionResult) {
+                return javaLanguageExtensionResult.packageJSON.version;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+    }
+
+    private getJavaDebuggerExtensionVersion(): string {
+        try {
+            const javaDebuggerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-debug');
+            if (javaDebuggerExtensionResult) {
+                return javaDebuggerExtensionResult.packageJSON.version;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+    }
+
+    private getJavaTestRunnerExtensionVersion(): string {
+        try {
+            const javaTestRunnerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-test');
+            if (javaTestRunnerExtensionResult) {
+                return javaTestRunnerExtensionResult.packageJSON.version;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+
     }
 }

--- a/packages/blockchain-extension/extension/extension.ts
+++ b/packages/blockchain-extension/extension/extension.ts
@@ -31,6 +31,7 @@ import { UserInputUtil } from './commands/UserInputUtil';
 import { GlobalState, ExtensionData } from './util/GlobalState';
 import { FabricWalletRegistry, FabricEnvironmentRegistry, LogType, FabricGatewayRegistry, FileSystemUtil } from 'ibm-blockchain-platform-common';
 import { RepositoryRegistry } from './registries/RepositoryRegistry';
+import { Dependencies } from './dependencies/Dependencies';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
 
@@ -101,11 +102,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
     try {
         const dependencyManager: DependencyManager = DependencyManager.instance();
+        const dependencies: Dependencies = await dependencyManager.getPreReqVersions();
 
         const bypassPreReqs: boolean = vscode.workspace.getConfiguration().get(SettingConfigurations.EXTENSION_BYPASS_PREREQS);
         let dependenciesInstalled: boolean;
         if (!bypassPreReqs) {
-            dependenciesInstalled = await dependencyManager.hasPreReqsInstalled();
+            dependenciesInstalled = await dependencyManager.hasPreReqsInstalled(dependencies);
         }
 
         const tempCommandRegistry: TemporaryCommandRegistry = TemporaryCommandRegistry.instance();
@@ -131,7 +133,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             if (!originalExtensionData.preReqPageShown) {
 
                 // Show pre req page
-                await vscode.commands.executeCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE);
+                await vscode.commands.executeCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE, dependencies);
 
                 // Update global state
                 newExtensionData.preReqPageShown = true;
@@ -140,7 +142,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
             } else if (!dependenciesInstalled) {
 
                 // Show prereq page if they don't have everything installed
-                await vscode.commands.executeCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE);
+                await vscode.commands.executeCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE, dependencies);
             }
         }
 

--- a/packages/blockchain-extension/extension/util/ExtensionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionUtil.ts
@@ -114,6 +114,7 @@ import { URL } from 'url';
 import { FeatureFlagManager } from './FeatureFlags';
 import { openConsoleInBrowser } from '../commands/openConsoleInBrowserCommand';
 import { deleteExtensionDirectory } from '../commands/deleteExtensionDirectoryCommand';
+import { Dependencies } from '../dependencies/Dependencies';
 
 let blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -740,8 +741,8 @@ export class ExtensionUtil {
     }
 
     public static async registerPreReqAndReleaseNotesCommand(context: vscode.ExtensionContext): Promise<vscode.ExtensionContext> {
-        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE, async () => {
-            const preReqView: PreReqView = new PreReqView(context);
+        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_PRE_REQ_PAGE, async (d: Dependencies) => {
+            const preReqView: PreReqView = new PreReqView(context, d);
             await preReqView.openView(true);
         }));
         context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_RELEASE_NOTES, () => openReleaseNotes()));

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -23,7 +23,7 @@ import { DependencyManager } from '../../extension/dependencies/DependencyManage
 import { CommandUtil } from '../../extension/util/CommandUtil';
 import { TestUtil } from '../TestUtil';
 import { GlobalState, ExtensionData, DEFAULT_EXTENSION_DATA } from '../../extension/util/GlobalState.js';
-import { Dependencies } from '../../extension/dependencies/Dependencies';
+import { Dependencies, DependencyVersions } from '../../extension/dependencies/Dependencies';
 import * as semver from 'semver';
 import * as OS from 'os';
 
@@ -212,7 +212,7 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '16.0.0',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 }
             };
 
@@ -231,7 +231,7 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '18.1.2',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
                     name: 'Docker Compose',
@@ -254,12 +254,12 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '18.1.2',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
                     name: 'Docker Compose',
                     version: '1.1.2',
-                    requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 }
             };
 
@@ -278,12 +278,12 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '18.1.2',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
                     name: 'Docker Compose',
                     version: '1.21.1',
-                    requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 },
                 systemRequirements: {
                     name: 'System Requirements',
@@ -308,12 +308,12 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '18.1.2',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
                     name: 'Docker Compose',
                     version: '1.21.1',
-                    requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 },
                 systemRequirements: {
                     name: 'System Requirements',
@@ -361,12 +361,12 @@ describe('DependencyManager Tests', () => {
                 docker: {
                     name: 'Docker',
                     version: '18.1.2',
-                    requiredVersion: Dependencies.DOCKER_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
                     name: 'Docker Compose',
                     version: '1.21.1',
-                    requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 },
                 systemRequirements: {
                     name: 'System Requirements',
@@ -390,12 +390,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -424,11 +424,11 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -437,7 +437,7 @@ describe('DependencyManager Tests', () => {
                     openssl: {
                         name: 'OpenSSL',
                         version: '1.0.6',
-                        requiredVersion: Dependencies.OPENSSL_REQUIRED
+                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     }
                 };
 
@@ -458,12 +458,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -472,7 +472,7 @@ describe('DependencyManager Tests', () => {
                     openssl: {
                         name: 'OpenSSL',
                         version: '1.0.2',
-                        requiredVersion: Dependencies.OPENSSL_REQUIRED
+                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     },
                     dockerForWindows: {
                         name: 'Docker for Windows',
@@ -497,12 +497,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -511,7 +511,7 @@ describe('DependencyManager Tests', () => {
                     openssl: {
                         name: 'OpenSSL',
                         version: '1.0.2',
-                        requiredVersion: Dependencies.OPENSSL_REQUIRED
+                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     },
                     dockerForWindows: {
                         name: 'Docker for Windows',
@@ -556,12 +556,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -587,12 +587,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -619,12 +619,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -633,7 +633,7 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '12',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     }
                 };
 
@@ -652,12 +652,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -666,7 +666,7 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
@@ -689,12 +689,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -703,12 +703,12 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '4.0.0',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     }
                 };
 
@@ -729,12 +729,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -743,12 +743,12 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
@@ -773,12 +773,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -787,17 +787,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '1.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     }
                 };
 
@@ -818,12 +818,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -832,17 +832,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -867,12 +867,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -881,17 +881,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -921,12 +921,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -935,17 +935,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -954,7 +954,7 @@ describe('DependencyManager Tests', () => {
                     java: {
                         name: 'Java OpenJDK 8',
                         version: '1.7.1',
-                        requiredVersion: Dependencies.JAVA_REQUIRED
+                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     }
                 };
 
@@ -975,12 +975,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -989,17 +989,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -1008,7 +1008,7 @@ describe('DependencyManager Tests', () => {
                     java: {
                         name: 'Java OpenJDK 8',
                         version: '1.8.0',
-                        requiredVersion: Dependencies.JAVA_REQUIRED
+                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     },
                     javaLanguageExtension: {
                         name: 'Java Language Support Extension',
@@ -1033,12 +1033,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -1047,17 +1047,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -1066,7 +1066,7 @@ describe('DependencyManager Tests', () => {
                     java: {
                         name: 'Java OpenJDK 8',
                         version: '1.8.0',
-                        requiredVersion: Dependencies.JAVA_REQUIRED
+                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     },
                     javaLanguageExtension: {
                         name: 'Java Language Support Extension',
@@ -1095,12 +1095,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -1109,17 +1109,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -1128,7 +1128,7 @@ describe('DependencyManager Tests', () => {
                     java: {
                         name: 'Java OpenJDK 8',
                         version: '1.8.0',
-                        requiredVersion: Dependencies.JAVA_REQUIRED
+                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     },
                     javaLanguageExtension: {
                         name: 'Java Language Support Extension',
@@ -1161,12 +1161,12 @@ describe('DependencyManager Tests', () => {
                     docker: {
                         name: 'Docker',
                         version: '18.1.2',
-                        requiredVersion: Dependencies.DOCKER_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
                         name: 'Docker Compose',
                         version: '1.21.1',
-                        requiredVersion: Dependencies.DOCKER_COMPOSE_REQUIRED
+                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
                         name: 'System Requirements',
@@ -1175,17 +1175,17 @@ describe('DependencyManager Tests', () => {
                     node: {
                         name: 'Node.js',
                         version: '8.12.0',
-                        requiredVersion: Dependencies.NODEJS_REQUIRED
+                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
                         name: 'npm',
                         version: '6.4.1',
-                        requiredVersion: Dependencies.NPM_REQUIRED
+                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     },
                     go: {
                         name: 'Go',
                         version: '2.0.0',
-                        requiredVersion: Dependencies.GO_REQUIRED
+                        requiredVersion: DependencyVersions.GO_REQUIRED
                     },
                     goExtension: {
                         name: 'Go Extension',
@@ -1194,7 +1194,7 @@ describe('DependencyManager Tests', () => {
                     java: {
                         name: 'Java OpenJDK 8',
                         version: '1.8.0',
-                        requiredVersion: Dependencies.JAVA_REQUIRED
+                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     },
                     javaLanguageExtension: {
                         name: 'Java Language Support Extension',
@@ -1259,7 +1259,7 @@ describe('DependencyManager Tests', () => {
             sendCommandStub.withArgs('node -v').resolves('v8.12.0');
 
             const _dependencyManager: DependencyManager = DependencyManager.instance();
-            const result: any = await _dependencyManager.getPreReqVersions();
+            const result: Dependencies = await _dependencyManager.getPreReqVersions();
             result.node.version.should.equal('8.12.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1269,7 +1269,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('node -v').resolves('v8.12.0');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.node.version.should.equal('8.12.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1279,7 +1279,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('node -v').resolves('-bash: node: command not found');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.node.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1289,7 +1289,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('node -v').resolves('something v1.2.3');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.node.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1299,7 +1299,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('npm -v').resolves('6.4.1');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.npm.version.should.equal('6.4.1');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1309,7 +1309,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('npm -v').resolves('-bash: npm: command not found');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.npm.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1319,7 +1319,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('npm -v').resolves('something v1.2.3');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.npm.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1329,7 +1329,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker -v').resolves('Docker version 18.06.1-ce, build e68fc7a');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.docker.version.should.equal('18.6.1');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1339,7 +1339,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker -v').resolves('-bash: /usr/local/bin/docker: No such file or directory');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.docker.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1349,7 +1349,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker -v').resolves('version 1-2-3, community edition');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.docker.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1359,7 +1359,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker-compose -v').resolves('docker-compose version 1.22.0, build f46880f');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.dockerCompose.version.should.equal('1.22.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1369,7 +1369,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker-compose -v').resolves('-bash: docker-compose: command not found');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.dockerCompose.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1379,7 +1379,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('docker-compose -v').resolves('version 1-2-3, something');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.dockerCompose.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1389,7 +1389,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('go version').resolves('go version go1.12.7 darwin/amd64');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.go.version.should.equal('1.12.7');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1399,7 +1399,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('go version').resolves('-bash: go: command not found');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.go.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1409,7 +1409,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('go version').resolves('go version go-version-one.two.three x64');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.go.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1424,7 +1424,7 @@ describe('DependencyManager Tests', () => {
                 }
             });
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.goExtension.version.should.equal('1.0.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1435,7 +1435,7 @@ describe('DependencyManager Tests', () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
             getExtensionStub.withArgs('golang.go').returns(undefined);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.goExtension.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1444,7 +1444,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
             sendCommandStub.withArgs('java -version 2>&1').resolves('openjdk version "1.8.0_212"');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.java.version.should.equal('1.8.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1453,7 +1453,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
             sendCommandStub.withArgs('java -version 2>&1').resolves('command not found');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.java.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1463,7 +1463,7 @@ describe('DependencyManager Tests', () => {
 
             sendCommandStub.withArgs('java -version 2>&1').resolves('openjdk version "version one.two.three"');
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.java.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1478,7 +1478,7 @@ describe('DependencyManager Tests', () => {
                 }
             });
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.javaLanguageExtension.version.should.equal('2.0.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1489,7 +1489,7 @@ describe('DependencyManager Tests', () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
             getExtensionStub.withArgs('redhat.java').returns(undefined);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaLanguageExtension.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1504,7 +1504,7 @@ describe('DependencyManager Tests', () => {
                 }
             });
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.javaDebuggerExtension.version.should.equal('3.0.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1515,7 +1515,7 @@ describe('DependencyManager Tests', () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
             getExtensionStub.withArgs('vscjava.vscode-java-debug').returns(undefined);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaDebuggerExtension.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1528,7 +1528,7 @@ describe('DependencyManager Tests', () => {
                 }
             });
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.javaTestRunnerExtension.version.should.equal('2.0.0');
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1539,7 +1539,7 @@ describe('DependencyManager Tests', () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
             getExtensionStub.withArgs('vscjava.vscode-java-test').returns(undefined);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaTestRunnerExtension.version);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1555,7 +1555,7 @@ describe('DependencyManager Tests', () => {
             newExtensionData.generatorVersion = extDeps['generator-fabric'];
             await GlobalState.update(newExtensionData);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.systemRequirements.complete.should.equal(true);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1572,7 +1572,7 @@ describe('DependencyManager Tests', () => {
             newExtensionData.generatorVersion = extDeps['generator-fabric'];
             await GlobalState.update(newExtensionData);
 
-            const result: any = await dependencyManager.getPreReqVersions();
+            const result: Dependencies = await dependencyManager.getPreReqVersions();
             result.systemRequirements.complete.should.equal(false);
             totalmemStub.should.have.been.calledOnce;
         });
@@ -1600,7 +1600,7 @@ describe('DependencyManager Tests', () => {
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
                 sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2k  26 Jan 2017');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 result.openssl.version.should.equal('1.0.2');
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1612,7 +1612,7 @@ describe('DependencyManager Tests', () => {
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
                 sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('OpenSSL 1.1.1d  26 Jan 2017');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 result.openssl.version.should.equal('1.1.1');
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1624,7 +1624,7 @@ describe('DependencyManager Tests', () => {
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
                 sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('openssl not recognized');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1635,7 +1635,7 @@ describe('DependencyManager Tests', () => {
                 existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(false);
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1647,7 +1647,7 @@ describe('DependencyManager Tests', () => {
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
                 sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL version 1.2.3');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1662,7 +1662,7 @@ describe('DependencyManager Tests', () => {
                 newExtensionData.generatorVersion = extDeps['generator-fabric'];
                 await GlobalState.update(newExtensionData);
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 result.dockerForWindows.complete.should.equal(true);
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1677,7 +1677,7 @@ describe('DependencyManager Tests', () => {
                 newExtensionData.generatorVersion = extDeps['generator-fabric'];
                 await GlobalState.update(newExtensionData);
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 result.dockerForWindows.complete.should.equal(false);
                 totalmemStub.should.have.been.calledOnce;
             });
@@ -1703,7 +1703,7 @@ describe('DependencyManager Tests', () => {
                 const pathExistsStub: sinon.SinonStub = mySandBox.stub(fs, 'pathExists').withArgs('/Library/Java/JavaVirtualMachines').resolves(true);
                 sendCommandStub.withArgs('java -version 2>&1').resolves('openjdk version "1.8.0_212"');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 pathExistsStub.should.have.been.calledOnce;
                 result.java.version.should.equal('1.8.0');
                 totalmemStub.should.have.been.calledOnce;
@@ -1715,7 +1715,7 @@ describe('DependencyManager Tests', () => {
                 const pathExistsStub: sinon.SinonStub = mySandBox.stub(fs, 'pathExists').withArgs('/Library/Java/JavaVirtualMachines').resolves(false);
                 sendCommandStub.withArgs('java -version 2>&1');
 
-                const result: any = await dependencyManager.getPreReqVersions();
+                const result: Dependencies = await dependencyManager.getPreReqVersions();
                 pathExistsStub.should.have.been.calledOnce;
                 sendCommandStub.should.not.have.been.calledWith('java -version 2>&1');
                 should.not.exist(result.java.version);
@@ -1750,7 +1750,7 @@ describe('DependencyManager Tests', () => {
             const getPackageJsonPathStub: sinon.SinonStub = mySandBox.stub(dependencyManager, 'getPackageJsonPath').returns('/some/path');
             const readFileStub: sinon.SinonStub = mySandBox.stub(fs, 'readFile').resolves('{"some":"json"}');
 
-            const rawJson: any = await dependencyManager.getRawPackageJson();
+            const rawJson: Dependencies = await dependencyManager.getRawPackageJson();
 
             getPackageJsonPathStub.should.have.been.calledOnce;
             readFileStub.should.have.been.calledOnceWithExactly('/some/path', 'utf8');

--- a/packages/blockchain-extension/test/index.ts
+++ b/packages/blockchain-extension/test/index.ts
@@ -66,7 +66,7 @@ export async function run(testsRoot: string, cb: (error: any, failures?: number)
     }
 
     try {
-        if (!process.env.WITHOUTCOVERAGE) {
+        if (process.env.WITHOUTCOVERAGE !== 'true') {
             console.log('setting up coverage');
             const coverOptions: ITestRunnerOptions = _readCoverOptions();
             if (coverOptions && coverOptions.enabled) {
@@ -75,6 +75,8 @@ export async function run(testsRoot: string, cb: (error: any, failures?: number)
                 const coverageRunner: CoverageRunner = new CoverageRunner(coverOptions, testsRoot);
                 coverageRunner.setupCoverage();
             }
+        } else {
+            console.log('coverage is disabled');
         }
 
         console.log('finding files', testsRoot);


### PR DESCRIPTION
*The diff for this looks huge but it's mainly just moving code around + adding interfaces*
### Summary
Currently the prerequisites page takes some time to load, I've attempted to improve performance by refactoring the current codebase by:
- [x] Using `Promise.all` where possible so that system version checks (Docker, Node etc) can occur at the same time.
- [x] Pass the dependencies through to the PreReqView optionally so that the `getPreReqVersions` functions only runs once when the user starts the extension (used to run twice).
    * The Prereqs page will re-scan the dependencies whenever a user opens it using the command pallet.

Also:
* Moved the Dependencies/RequiredDependencies/OptionalDependencies into their own `interfaces`.
* Moved the defaults into the `Dependencies.ts` file so that it is easier to manage what a Dependency is and what they are. 
* Slightly refactored the `PreReqsView` test to use the Dependency interface and have less setup for each test.
* Modified the test coverage if statement as it wasn't being triggered for me.

### Tests
* Ensured all unit tests still work.
* Checked that the prereqs page still appears the same as before.