### PR TITLE
v2 - update node prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ The following dependencies are required on all operating systems:
 
 The following dependencies are optional:
 
-- [Node v8.x or v10.x and npm v6.x or greater](https://nodejs.org/en/download/)
+- [Node v10 (v10.15.3 or greater) or v12 (v12.13.1 or greater) and npm v6.x or greater](https://nodejs.org/en/download/)
 > Node version can be found by running: `node --version`
 >
 > npm version can be found by running: `npm --version`

--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -18,14 +18,14 @@ export class DependencyVersions {
     static readonly DOCKER_REQUIRED: string = '>=17.6.2';
     static readonly DOCKER_COMPOSE_REQUIRED: string = '>=1.14.0';
 
-    static readonly NODEJS_REQUIRED: string = '8.x || 10.x';
+    static readonly NODEJS_REQUIRED: string =  '>=10.15.3 < 11.0.0|| >=12.13.1 < 13.0.0';
     static readonly NPM_REQUIRED: string = '>=6.0.0';
     static readonly OPENSSL_REQUIRED: string = '1.0.2 || 1.1.1';
     static readonly GO_REQUIRED: string = '>=1.12.0';
     static readonly JAVA_REQUIRED: string = '1.8.x';
 }
 
-interface Dependency {
+export interface Dependency {
     name: string;
     required: boolean;
 }

--- a/packages/blockchain-extension/extension/webview/PreReqView.ts
+++ b/packages/blockchain-extension/extension/webview/PreReqView.ts
@@ -24,7 +24,7 @@ import { SettingConfigurations } from '../configurations';
 import { GlobalState, ExtensionData } from '../util/GlobalState';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from 'ibm-blockchain-platform-common';
-import { Dependencies } from '../dependencies/Dependencies';
+import { Dependencies, Dependency, DependencyWithVersion } from '../dependencies/Dependencies';
 
 export class PreReqView extends View {
 
@@ -191,12 +191,21 @@ export class PreReqView extends View {
         let missingPrerequisitesLength: number = 0;
 
         for (const _dependency of Object.keys(dependencies)) {
+            let dependency: Dependency = dependencies[_dependency];
+            if (_dependency === 'node') {
+                // Make node version requirements more readable
+                const modified: DependencyWithVersion = {
+                    ...dependencies[_dependency],
+                    requiredVersion: dependencies[_dependency].requiredVersion.replace(/<.*\|\|/, '||').replace(/<.*/, ''),
+                };
+                dependency = modified;
+            }
 
-            const isInstalled: boolean = dependencyManager.isValidDependency(dependencies[_dependency]);
+            const isInstalled: boolean = dependencyManager.isValidDependency(dependency);
             if (isInstalled) {
-                installedDependencies[_dependency] = dependencies[_dependency];
+                installedDependencies[_dependency] = dependency;
             } else {
-                missingDependencies[_dependency] = dependencies[_dependency];
+                missingDependencies[_dependency] = dependency;
 
                 // Count the required missing prerequisites
                 if (missingDependencies[_dependency].required === true) {

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -621,7 +621,7 @@ describe('DependencyManager Tests', () => {
 
             });
 
-            it(`should return false if the optional Node dependency isn't between 8 and 11`, async () => {
+            it(`should return false if wrong Node version`, async () => {
                 const dependencies: any = {
                     docker: {
                         name: 'Docker',
@@ -639,7 +639,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '12',
+                        version: '8.12.0',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     }
                 };
@@ -647,10 +647,26 @@ describe('DependencyManager Tests', () => {
                 getPreReqVersionsStub.resolves(dependencies);
 
                 const dependencyManager: DependencyManager = DependencyManager.instance();
-                const result: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                const resultNode8: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                resultNode8.should.equal(false);
 
-                result.should.equal(false);
-                getPreReqVersionsStub.should.have.been.calledOnce;
+                dependencies.node.version = '10.15.2';
+                const resultNode10low: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                resultNode10low.should.equal(false);
+
+                dependencies.node.version = '11.1.1';
+                const resultNode11: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                resultNode11.should.equal(false);
+
+                dependencies.node.version = '12.13.0';
+                const resultNode12low: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                resultNode12low.should.equal(false);
+
+                dependencies.node.version = '13.0.0';
+                const resultNode13: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
+                resultNode13.should.equal(false);
+
+                getPreReqVersionsStub.callCount.should.equal(5);
 
             });
 
@@ -672,7 +688,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -709,7 +725,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -749,7 +765,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -793,7 +809,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -838,7 +854,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -887,7 +903,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -941,7 +957,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -995,7 +1011,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1053,7 +1069,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1115,7 +1131,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1167,7 +1183,7 @@ describe('DependencyManager Tests', () => {
                 const dependencies: any = {
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1251,7 +1267,7 @@ describe('DependencyManager Tests', () => {
                     },
                     node: {
                         name: 'Node.js',
-                        version: '8.12.0',
+                        version: '10.15.3',
                         requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     },
                     npm: {
@@ -1337,21 +1353,21 @@ describe('DependencyManager Tests', () => {
         it('should get extension context if not passed to dependency manager', async () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
-            sendCommandStub.withArgs('node -v').resolves('v8.12.0');
+            sendCommandStub.withArgs('node -v').resolves('v10.15.3');
 
             const _dependencyManager: DependencyManager = DependencyManager.instance();
             const result: Dependencies = await _dependencyManager.getPreReqVersions();
-            result.node.version.should.equal('8.12.0');
+            result.node.version.should.equal('10.15.3');
             totalmemStub.should.have.been.calledOnce;
         });
 
         it('should get version of node', async () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
-            sendCommandStub.withArgs('node -v').resolves('v8.12.0');
+            sendCommandStub.withArgs('node -v').resolves('v10.15.3');
 
             const result: Dependencies = await dependencyManager.getPreReqVersions();
-            result.node.version.should.equal('8.12.0');
+            result.node.version.should.equal('10.15.3');
             totalmemStub.should.have.been.calledOnce;
         });
 

--- a/packages/blockchain-extension/test/webview/PreReqView.test.ts
+++ b/packages/blockchain-extension/test/webview/PreReqView.test.ts
@@ -59,7 +59,7 @@ const generateDependencies: any = (versions: VersionOverrides = {}, completes: C
     const dependencies: Dependencies = { ...defaultDependencies.required, ...defaultDependencies.optional };
 
     // Add versions
-    dependencies.node.version = versions.hasOwnProperty('node') ? versions.node : '8.12.0';
+    dependencies.node.version = versions.hasOwnProperty('node') ? versions.node : '10.15.3';
     dependencies.npm.version = versions.hasOwnProperty('npm') ? versions.npm : '6.4.1';
     dependencies.docker.version = versions.hasOwnProperty('docker') ? versions.docker : '17.7.0';
     dependencies.dockerCompose.version = versions.hasOwnProperty('dockerCompose') ? versions.dockerCompose : '1.15.0';
@@ -75,6 +75,9 @@ const generateDependencies: any = (versions: VersionOverrides = {}, completes: C
     // Add complete
     dependencies.dockerForWindows.complete = versions.hasOwnProperty('dockerForWindows') ? completes.dockerForWindows : true;
     dependencies.systemRequirements.complete = versions.hasOwnProperty('systemRequirements') ? completes.systemRequirements : true;
+
+    // Modify html rendering of node version
+    dependencies.node.requiredVersion = '>=10.15.3 || >=12.13.1';
 
     return dependencies;
 };
@@ -159,7 +162,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '8.12.0' }));
+            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '10.15.3' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.optional.npm, version: '6.4.1' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.docker, version: '17.7.0' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.dockerCompose, version: '1.15.0' }));
@@ -219,7 +222,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '8.12.0' }));
+            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '10.15.3' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.optional.npm, version: '6.4.1' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.docker, version: '17.7.0' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.dockerCompose, version: '1.15.0' }));
@@ -257,7 +260,7 @@ describe('PreReqView', () => {
             html.should.contain(`<div id="check-finish-button" class="finish" onclick="finish();">Let's Blockchain!</div>`); // The button should indicate that the dependencies have been installed
             html.should.contain('<span class="prereqs-number">(0)</span>'); // No missing (required) dependencies
 
-            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '8.12.0' }));
+            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '10.15.3' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.optional.npm, version: '6.4.1' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.docker, version: '17.7.0' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.dockerCompose, version: '1.15.0' }));
@@ -296,7 +299,7 @@ describe('PreReqView', () => {
 
             const html: string = await preReqView.getHTMLString();
 
-            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '8.12.0' }));
+            html.should.contain(JSON.stringify({ ...defaultDependencies.optional.node, version: '10.15.3' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.optional.npm, version: '6.4.1' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.docker, version: '17.7.0' }));
             html.should.contain(JSON.stringify({ ...defaultDependencies.required.dockerCompose, version: '1.15.0' }));


### PR DESCRIPTION
I believe pre-req state is now persistent so I can't modify the dependency directly with the readable version requirements for node - hence the dependency clone for the pre-req view.

closes #2693 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>