### PR TITLE
[v1] - update openssl prereqs

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ You will need the following:
 
 - Docker for Windows is configured to use Linux containers (this is the default)
 - You will need to install the C++ Build Tools for Windows from [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools#windows-build-tools)
-- You will need to install OpenSSL v1.0.2 [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
+- You will need to install OpenSSL v1.1.1 [OpenSSL binaries](https://www.openssl.org/community/binaries.html)
   - Install the normal version, not the version marked as "light"
   - Install the Win64 version into `C:\OpenSSL-Win64` on 64-bit systems
 

--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -20,7 +20,7 @@ export class Dependencies {
     static readonly DOCKER_REQUIRED: string = '>=17.6.2';
     static readonly DOCKER_COMPOSE_REQUIRED: string = '>=1.14.0';
 
-    static readonly OPENSSL_REQUIRED: string = '1.0.2';
+    static readonly OPENSSL_REQUIRED: string = '1.1.1';
 
     static readonly GO_REQUIRED: string = '>=1.12.0';
     static readonly JAVA_REQUIRED: string = '1.8.x';

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -271,7 +271,7 @@ export class DependencyManager {
             if (localFabricEnabled) {
                 dependencies.dockerForWindows = { name: 'Docker for Windows', id: 'dockerForWindows', complete: undefined, checkbox: true, required: true, text: 'Docker for Windows must be configured to use Linux containers (this is the default)' };
 
-                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively', tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
+                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'https://www.openssl.org/community/binaries.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'only', tooltip: 'Install the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
                 try {
                     const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);
                     const win64: boolean = await fs.pathExists(`C:\\OpenSSL-Win64`);

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -1038,7 +1038,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.2',
+                        version: '1.1.1',
                         requiredVersion: Dependencies.OPENSSL_REQUIRED
                     },
                     buildTools: {
@@ -1087,7 +1087,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.2',
+                        version: '1.1.1',
                         requiredVersion: Dependencies.OPENSSL_REQUIRED
                     },
                     buildTools: {
@@ -1140,7 +1140,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.2',
+                        version: '1.1.1',
                         requiredVersion: Dependencies.OPENSSL_REQUIRED
                     },
                     buildTools: {
@@ -2262,10 +2262,10 @@ describe('DependencyManager Tests', () => {
 
                 existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2k  26 Jan 2017');
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.1.1k  26 Jan 2017');
 
                 const result: any = await dependencyManager.getPreReqVersions();
-                result.openssl.version.should.equal('1.0.2');
+                result.openssl.version.should.equal('1.1.1');
                 totalmemStub.should.have.been.calledOnce;
             });
 


### PR DESCRIPTION
closes #2680  

OpenSSL 1.0.2 is no longer supported or available for download on the main website.

@ampretia/node-x509, used by both Client SDK and the Chaincode SDK, has been updated to support openSSL 1.1.1.

Need to update pre-reqs to make sure we only mention and accept v1.1.1.

Needs to be tested on a windows machine.

Pre-reqs have been modified in v2, so marking this as an ignore v2 and will open a new PR for that.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>