### PR TITLE
[v2] - update openSSL prereqs

### DIFF
--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -20,7 +20,7 @@ export class DependencyVersions {
 
     static readonly NODEJS_REQUIRED: string = '8.x || 10.x';
     static readonly NPM_REQUIRED: string = '>=6.0.0';
-    static readonly OPENSSL_REQUIRED: string = '1.0.2 || 1.1.1';
+    static readonly OPENSSL_REQUIRED: string = '1.1.1';
     static readonly GO_REQUIRED: string = '>=1.12.0';
     static readonly JAVA_REQUIRED: string = '1.8.x';
 }
@@ -101,10 +101,10 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'OpenSSL',
             required: true,
             version: undefined,
-            url: 'http://slproweb.com/products/Win32OpenSSL.html',
+            url: 'https://www.openssl.org/community/binaries.html',
             requiredVersion: DependencyVersions.OPENSSL_REQUIRED,
-            requiredLabel: 'for Node 8.x and Node 10.x respectively',
-            tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.'
+            requiredLabel: 'only',
+            tooltip: 'Install the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.'
         },
         dockerForWindows: {
             name: 'Docker for Windows',

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -478,7 +478,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.2',
+                        version: '1.1.1',
                         requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     },
                     dockerForWindows: {
@@ -517,7 +517,7 @@ describe('DependencyManager Tests', () => {
                     },
                     openssl: {
                         name: 'OpenSSL',
-                        version: '1.0.2',
+                        version: '1.1.1',
                         requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     },
                     dockerForWindows: {
@@ -1703,10 +1703,10 @@ describe('DependencyManager Tests', () => {
 
                 existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2k  26 Jan 2017');
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.1.1k  26 Jan 2017');
 
                 const result: Dependencies = await dependencyManager.getPreReqVersions();
-                result.openssl.version.should.equal('1.0.2');
+                result.openssl.version.should.equal('1.1.1');
                 totalmemStub.should.have.been.calledOnce;
             });
 


### PR DESCRIPTION
OpenSSL 1.0.2 is no longer supported or available for download on the main website.

@ampretia/node-x509, used by both Client SDK and the Chaincode SDK, has been updated to support openSSL 1.1.1.

Need to update pre-reqs to make sure we only mention and accept v1.1.1.

Needs to be tested on a windows machine.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>