### PR TITLE
Add go mod vendor command if go.mod file exists

### DIFF
--- a/packages/blockchain-extension/cucumber/features/package.feature
+++ b/packages/blockchain-extension/cucumber/features/package.feature
@@ -13,7 +13,7 @@ Feature: Smart Contracts packages
         | JavaScript | Conga     | JavaScriptContract | JavaScriptContract@0.0.1 | 52       | 0.0.1   |
         | TypeScript | Conga     | TypeScriptContract | TypeScriptContract@0.0.1 | 49       | 0.0.1   |
         | Java       | Conga     | JavaContract       | JavaContract@0.0.1       | 56       | 0.0.1   |
-        | Go         | null      | GoContract         | GoContract@0.0.1         | 1        | 0.0.1   |
+        | Go         | null      | GoContract         | GoContract@0.0.1         | 3672     | 0.0.1   |
 
     Scenario Outline: Inspect smart contract contents
         Given a <language> smart contract for <assetType> assets with the name <name> and version <version>


### PR DESCRIPTION
### Summary
Added functionality to run `go mod vendor` if the users project contains a `go.mod` file.

### Testing
* Added tests to support this functionality
* Manually tested that I could still install, instantiate a Go chaincode and call submit/evaluate functions.

Signed-off-by: James Wallis <james.wallis1@ibm.com>