### PR TITLE
[v1] - fix openSSL label and tooltip in pre-reqs, and link to binaries page

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ You will need the following:
 
 - Docker for Windows is configured to use Linux containers (this is the default)
 - You will need to install the C++ Build Tools for Windows from [windows-build-tools](https://github.com/felixrieseberg/windows-build-tools#windows-build-tools)
-- You will need to install OpenSSL v1.0.2 [Win32 OpenSSL](http://slproweb.com/products/Win32OpenSSL.html)
+- You will need to install OpenSSL v1.0.2 [OpenSSL binaries](https://www.openssl.org/community/binaries.html)
   - Install the normal version, not the version marked as "light"
   - Install the Win64 version into `C:\OpenSSL-Win64` on 64-bit systems
 

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -271,13 +271,11 @@ export class DependencyManager {
             if (localFabricEnabled) {
                 dependencies.dockerForWindows = { name: 'Docker for Windows', id: 'dockerForWindows', complete: undefined, checkbox: true, required: true, text: 'Docker for Windows must be configured to use Linux containers (this is the default)' };
 
-                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'http://slproweb.com/products/Win32OpenSSL.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'for Node 8.x and Node 10.x respectively', tooltip: 'Install the Win32 version into `C:\\OpenSSL-Win32` on 32-bit systems and the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
+                dependencies.openssl = { name: 'OpenSSL', required: true, version: undefined, url: 'https://www.openssl.org/community/binaries.html', requiredVersion: Dependencies.OPENSSL_REQUIRED, requiredLabel: 'only', tooltip: 'Install the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.' };
                 try {
-                    const win32: boolean = await fs.pathExists(`C:\\OpenSSL-Win32`);
                     const win64: boolean = await fs.pathExists(`C:\\OpenSSL-Win64`);
-                    if (win32 || win64) {
-                        const arch: string = (win32) ? '32' : '64';
-                        const binPath: string = path.win32.join(`C:\\OpenSSL-Win${arch}`, 'bin', 'openssl.exe');
+                    if (win64) {
+                        const binPath: string = path.win32.join('C:\\OpenSSL-Win64', 'bin', 'openssl.exe');
                         const opensslResult: string = await CommandUtil.sendCommand(`${binPath} version`); // Format: OpenSSL 1.0.2k  26 Jan 2017
                         if (this.isCommandFound(opensslResult)) {
                             const opensslMatchedVersion: string = opensslResult.match(/OpenSSL (\S*)/)[1]; // Format: 1.0.2k

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -2257,36 +2257,22 @@ describe('DependencyManager Tests', () => {
                 existsStub = mySandBox.stub(fs, 'pathExists');
             });
 
-            it('should check if OpenSSL (32-bit) is installed', async () => {
+            it('should check if OpenSSL (64-bit) is installed', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
-                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2k  26 Jan 2017');
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('OpenSSL 1.0.2d  26 Jan 2017');
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 result.openssl.version.should.equal('1.0.2');
                 totalmemStub.should.have.been.calledOnce;
             });
 
-            it('should check if OpenSSL (64-bit) is installed', async () => {
-                mySandBox.stub(process, 'platform').value('win32');
-
-                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(false);
-                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('OpenSSL 1.1.1d  26 Jan 2017');
-
-                const result: any = await dependencyManager.getPreReqVersions();
-                result.openssl.version.should.equal('1.1.1');
-                totalmemStub.should.have.been.calledOnce;
-            });
-
             it('should not get version of OpenSSL if command not found', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
-                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('openssl not recognized');
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('openssl not recognized');
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);
@@ -2296,7 +2282,6 @@ describe('DependencyManager Tests', () => {
             it('should not get version of OpenSSL if installation path(s) not found', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(false);
                 existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
 
                 const result: any = await dependencyManager.getPreReqVersions();
@@ -2307,9 +2292,8 @@ describe('DependencyManager Tests', () => {
             it('should not get version of OpenSSL if unexpected format is returned', async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                existsStub.withArgs(`C:\\OpenSSL-Win32`).resolves(true);
-                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(false);
-                sendCommandStub.withArgs(`C:\\OpenSSL-Win32\\bin\\openssl.exe version`).resolves('OpenSSL version 1.2.3');
+                existsStub.withArgs(`C:\\OpenSSL-Win64`).resolves(true);
+                sendCommandStub.withArgs(`C:\\OpenSSL-Win64\\bin\\openssl.exe version`).resolves('OpenSSL version 1.2.3');
 
                 const result: any = await dependencyManager.getPreReqVersions();
                 should.not.exist(result.openssl.version);


### PR DESCRIPTION
Some changes were accidentally removed by another windows pre-req update code merge - putting those back.

Also changed link to binaries page instead of possible sources and removed support for windows 32-bit architecture.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>