### PR TITLE
Add IBM Cloud Account Extension as optional dependency

### DIFF
--- a/packages/blockchain-extension/ExtensionCommands.ts
+++ b/packages/blockchain-extension/ExtensionCommands.ts
@@ -92,4 +92,5 @@ export class ExtensionCommands {
     static readonly MANAGE_FEATURE_FLAGS: string = 'manageFeatureFlags';
     static readonly OPEN_NEW_INSTANCE_LINK: string = 'openNewInstanceLink';
     static readonly DELETE_DIRECTORY: string = 'deleteExtensionDirectory';
+    static readonly OPEN_IBM_CLOUD_EXTENSION: string = 'openIBMCloudExtension';
 }

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -85,7 +85,7 @@ export class DependencyManager {
             } else {
                 return false;
             }
-        } else if (name === 'C++ Build Tools' || name === 'Xcode' || name === 'Go Extension' || name === 'Java Language Support Extension' || name === 'Java Debugger Extension' || name === 'Java Test Runner Extension' || name === 'Node Test Runner Extension') {
+        } else if (name === 'C++ Build Tools' || name === 'Xcode' || name === 'Go Extension' || name === 'Java Language Support Extension' || name === 'Java Debugger Extension' || name === 'Java Test Runner Extension' || name === 'Node Test Runner Extension' || name === 'IBM Cloud Account Extension') {
             if (dependency.version) {
                 return true;
             } else {
@@ -177,6 +177,10 @@ export class DependencyManager {
             }
 
             if (!this.isValidDependency(dependencies.nodeTestRunnerExtension)) {
+                return false;
+            }
+
+            if (!this.isValidDependency(dependencies.ibmCloudAccountExtension)) {
                 return false;
             }
         }
@@ -421,6 +425,18 @@ export class DependencyManager {
         } catch (error) {
             // Ignore the error
         }
+
+        dependencies.ibmCloudAccountExtension = { name: 'IBM Cloud Account Extension', required: false, version: undefined, url: 'vscode:extension/IBM.ibmcloud-account', requiredVersion: undefined, requiredLabel: '', tooltip: 'Required for discovering IBM Blockchain Platform on IBM Cloud networks.' };
+        try {
+            const ibmCloudAccountExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('IBM.ibmcloud-account');
+            if (ibmCloudAccountExtensionResult) {
+                const version: string = ibmCloudAccountExtensionResult.packageJSON.version;
+                dependencies.ibmCloudAccountExtension.version = version;
+            }
+        } catch (error) {
+            // Ignore the error
+        }
+
         return dependencies;
 
     }

--- a/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
+++ b/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
@@ -268,7 +268,7 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
                 arguments: []
             };
 
-            tree.push(new TextTreeItem(this, '+ add local or remote environment', command));
+            tree.push(new TextTreeItem(this, '+ Add local or remote environment', command));
 
             // if there are no environments at all we should still show the option to log in to IBM Cloud
             const treeItem: EnvironmentGroupTreeItem = await this.getIBMCloudInteractionItem(true) as EnvironmentGroupTreeItem;
@@ -385,6 +385,21 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
     }
 
     private async getIBMCloudInteractionItem(returnGroupItem: boolean): Promise<BlockchainTreeItem> {
+        const ibmCloudExtensionInstalled: boolean = ExtensionsInteractionUtil.isIBMCloudExtensionInstalled();
+        if (!ibmCloudExtensionInstalled) {
+            if (returnGroupItem) {
+                return new EnvironmentGroupTreeItem(this, 'IBM Blockchain Platform on cloud', [], vscode.TreeItemCollapsibleState.Expanded);
+            } else {
+                const label: string = '+ Install IBM Cloud Account extension';
+                const command: vscode.Command = {
+                    command: ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION,
+                    title: '',
+                    arguments: []
+                };
+                return new TextTreeItem(this, label, command);
+            }
+        }
+
         const isLoggedIn: boolean = await ExtensionsInteractionUtil.cloudAccountIsLoggedIn();
         const hasAccountSelected: boolean = await ExtensionsInteractionUtil.cloudAccountHasSelectedAccount();
         if ( !isLoggedIn || !hasAccountSelected) {

--- a/packages/blockchain-extension/extension/util/ExtensionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionUtil.ts
@@ -370,6 +370,11 @@ export class ExtensionUtil {
             await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('https://cloud.ibm.com/catalog/services/blockchain-platform'));
             Reporter.instance().sendTelemetryEvent('openNewInstanceLink');
         }));
+
+        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION, async () => {
+            await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse('vscode:extension/IBM.ibmcloud-account'));
+        }));
+
         // Teardown old containers and delete environments, wallets, gateways.
         await this.purgeOldRuntimes();
 

--- a/packages/blockchain-extension/extension/util/ExtensionsInteractionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionsInteractionUtil.ts
@@ -25,6 +25,10 @@ import { URL } from 'url';
  */
 export class ExtensionsInteractionUtil {
 
+    public static isIBMCloudExtensionInstalled(): boolean {
+        return !!vscode.extensions.getExtension( 'IBM.ibmcloud-account' );
+    }
+
     public static async cloudAccountGetAccessToken(userInteraction: boolean = true): Promise<string> {
         const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension( 'IBM.ibmcloud-account' );
         if ( !cloudAccountExtension ) {

--- a/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
+++ b/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
@@ -2789,7 +2789,7 @@ describe('UserInputUtil', () => {
 
     describe('getWorkspaceFolders', () => {
 
-        it(' getWorkspaceFolders should not show package chooser when only one folder to package', async () => {
+        it('getWorkspaceFolders should not show package chooser when only one folder to package', async () => {
 
             const pathOne: string = path.join('some', 'path');
             const uriOne: vscode.Uri = vscode.Uri.file(pathOne);

--- a/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
@@ -70,12 +70,14 @@ describe('environmentExplorer', () => {
     describe('getChildren', () => {
         describe('unconnected tree', () => {
             let executeCommandStub: sinon.SinonStub;
+            let isIBMCloudExtensionInstalled: sinon.SinonStub;
             let loggedInStub: sinon.SinonStub;
             let accountSelectedStub: sinon.SinonStub;
             let logSpy: sinon.SinonSpy;
 
             beforeEach(async () => {
                 mySandBox.stub(FabricEnvironmentManager.instance(), 'getConnection').returns(undefined);
+                isIBMCloudExtensionInstalled = mySandBox.stub(ExtensionsInteractionUtil, 'isIBMCloudExtensionInstalled').returns(true);
                 loggedInStub = mySandBox.stub(ExtensionsInteractionUtil, 'cloudAccountIsLoggedIn').resolves(false);
                 accountSelectedStub = mySandBox.stub(ExtensionsInteractionUtil, 'cloudAccountHasSelectedAccount').resolves(false);
 
@@ -365,7 +367,7 @@ describe('environmentExplorer', () => {
                 const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
                 allChildren.length.should.equal(2);
-                allChildren[0].label.should.equal(`+ add local or remote environment`);
+                allChildren[0].label.should.equal(`+ Add local or remote environment`);
                 allChildren[0].command.should.deep.equal({
                     command: ExtensionCommands.ADD_ENVIRONMENT,
                     title: '',
@@ -398,7 +400,7 @@ describe('environmentExplorer', () => {
                 const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
                 allChildren.length.should.equal(2);
-                allChildren[0].label.should.equal(`+ add local or remote environment`);
+                allChildren[0].label.should.equal(`+ Add local or remote environment`);
                 allChildren[0].command.should.deep.equal({
                     command: ExtensionCommands.ADD_ENVIRONMENT,
                     title: '',
@@ -417,6 +419,26 @@ describe('environmentExplorer', () => {
                 loggedInStub.should.have.been.calledTwice;
                 accountSelectedStub.should.have.been.calledTwice;
                 anyResourcesStub.should.have.been.calledTwice;
+            });
+
+            it(`should show a 'install IBM Cloud Account Extension' tree item if the IBM Cloud Account Extension is not installed`, async () => {
+                await FabricEnvironmentRegistry.instance().clear();
+
+                isIBMCloudExtensionInstalled.returns(false);
+
+                const blockchainRuntimeExplorerProvider: BlockchainEnvironmentExplorerProvider = ExtensionUtil.getBlockchainEnvironmentExplorerProvider();
+                const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
+
+                allChildren.length.should.equal(2);
+                allChildren[1].label.should.equal('IBM Blockchain Platform on cloud');
+                const ibmCloudItems: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren(allChildren[1]);
+                ibmCloudItems.length.should.equal(1);
+                ibmCloudItems[0].label.should.equal(`+ Install IBM Cloud Account extension`);
+                ibmCloudItems[0].command.should.deep.equal({
+                    command: ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION,
+                    title: '',
+                    arguments: []
+                });
             });
 
             it('should show log in item if there are ops tools environments but no saas environments', async () => {
@@ -498,7 +520,7 @@ describe('environmentExplorer', () => {
                 const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
                 allChildren.length.should.equal(1);
-                allChildren[0].label.should.equal(`+ add local or remote environment`);
+                allChildren[0].label.should.equal(`+ Add local or remote environment`);
                 allChildren[0].command.should.deep.equal({
                     command: ExtensionCommands.ADD_ENVIRONMENT,
                     title: '',
@@ -584,7 +606,7 @@ describe('environmentExplorer', () => {
                 const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
                 allChildren.length.should.equal(1);
-                allChildren[0].label.should.equal(`+ add local or remote environment`);
+                allChildren[0].label.should.equal(`+ Add local or remote environment`);
                 allChildren[0].command.should.deep.equal({
                     command: ExtensionCommands.ADD_ENVIRONMENT,
                     title: '',
@@ -1662,6 +1684,7 @@ describe('environmentExplorer', () => {
         let accountSelectedStub: sinon.SinonStub;
 
         beforeEach(async () => {
+            mySandBox.stub(ExtensionsInteractionUtil, 'isIBMCloudExtensionInstalled').returns(true);
             loggedInStub = mySandBox.stub(ExtensionsInteractionUtil, 'cloudAccountIsLoggedIn').resolves(false);
             accountSelectedStub = mySandBox.stub(ExtensionsInteractionUtil, 'cloudAccountHasSelectedAccount').resolves(false);
         });

--- a/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
+++ b/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
@@ -786,6 +786,22 @@ describe('ExtensionUtil Tests', () => {
             sendTelemetryEventStub.should.have.been.calledOnceWithExactly('openNewInstanceLink');
         });
 
+        it('should register and open ibm cloud account extension link', async () => {
+            const executeCommandStub: sinon.SinonStub = mySandBox.stub(vscode.commands, 'executeCommand').callThrough();
+            executeCommandStub.withArgs('vscode.open').resolves();
+
+            const ctx: vscode.ExtensionContext = GlobalState.getExtensionContext();
+            const registerPreReqAndReleaseNotesCommandStub: sinon.SinonStub = mySandBox.stub(ExtensionUtil, 'registerPreReqAndReleaseNotesCommand').resolves(ctx);
+
+            await ExtensionUtil.registerCommands(ctx);
+            purgeOldRuntimesStub.should.have.been.calledOnce;
+
+            await vscode.commands.executeCommand(ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION);
+
+            registerPreReqAndReleaseNotesCommandStub.should.have.been.calledOnce;
+            executeCommandStub.should.have.been.calledWith('vscode.open', vscode.Uri.parse('vscode:extension/IBM.ibmcloud-account'));
+        });
+
         it('should reload blockchain explorer when debug event emitted', async () => {
             await vscode.workspace.getConfiguration().update(SettingConfigurations.HOME_SHOW_ON_STARTUP, false, vscode.ConfigurationTarget.Global);
 


### PR DESCRIPTION
### Summary
Added IBM Cloud Account Extension as an optional dependency
* Shows in the prereqs page like other optional dependencies
* Shows on the side bar Fabric Environments to prompt the user to install the extension to use their IBM Cloud Account (see screenshot)
* Stops the "IBM Cloud Account extension must be installed" message from showing on startup (#2682)

### Testing
* Ran and added new tests for the optional dependency
* Tested manually that:
  * When the extension was uninstalled the prereqs page displayed it as an optional dependency 
  * When the extension was uninstalled the side bar displayed a link to install it (see screenshot)
  * When the extension was installed the prereqs page showed it as installed
  * When the extension was installed the side bar appeared as normal

### Screenshots
![image](https://user-images.githubusercontent.com/17385115/96161784-a1e50900-0f0f-11eb-9704-ae40fec59efd.png)


Signed-off-by: James Wallis <james.wallis1@ibm.com>