### PR TITLE
Add initial IBM Account extension code to V2, further Dependency refactor

### DIFF
--- a/packages/blockchain-extension/ExtensionCommands.ts
+++ b/packages/blockchain-extension/ExtensionCommands.ts
@@ -99,4 +99,5 @@ export class ExtensionCommands {
     static readonly OPEN_NEW_INSTANCE_LINK: string = 'openNewInstanceLink';
     static readonly DELETE_DIRECTORY: string = 'deleteExtensionDirectory';
     static readonly OPEN_RESOURCE_FILE: string = 'openResourceFile';
+    static readonly OPEN_IBM_CLOUD_EXTENSION: string = 'openIBMCloudExtension';
 }

--- a/packages/blockchain-extension/extension/dependencies/Dependencies.ts
+++ b/packages/blockchain-extension/extension/dependencies/Dependencies.ts
@@ -13,16 +13,21 @@
 */
 'use strict';
 
-export class DependencyVersions {
+export class DependencyProperties {
+    static readonly DOCKER_REQUIRED_VERSION: string = '>=17.6.2';
+    static readonly DOCKER_COMPOSE_REQUIRED_VERSION: string = '>=1.14.0';
+    static readonly NODEJS_REQUIRED_VERSION: string =  '>=10.15.3 < 11.0.0|| >=12.13.1 < 13.0.0';
+    static readonly NPM_REQUIRED_VERSION: string = '>=6.0.0';
+    static readonly OPENSSL_REQUIRED_VERSION: string = '1.0.2 || 1.1.1';
+    static readonly GO_REQUIRED_VERSION: string = '>=1.12.0';
+    static readonly JAVA_REQUIRED_VERSION: string = '1.8.x';
 
-    static readonly DOCKER_REQUIRED: string = '>=17.6.2';
-    static readonly DOCKER_COMPOSE_REQUIRED: string = '>=1.14.0';
-
-    static readonly NODEJS_REQUIRED: string =  '>=10.15.3 < 11.0.0|| >=12.13.1 < 13.0.0';
-    static readonly NPM_REQUIRED: string = '>=6.0.0';
-    static readonly OPENSSL_REQUIRED: string = '1.0.2 || 1.1.1';
-    static readonly GO_REQUIRED: string = '>=1.12.0';
-    static readonly JAVA_REQUIRED: string = '1.8.x';
+    static readonly NODEJS_TEST_RUNNER_EXTENSION: string = 'oshri6688.javascript-test-runner';
+    static readonly GO_LANGUAGE_EXTENSION: string = 'golang.go';
+    static readonly JAVA_LANGUAGE_EXTENSION: string = 'redhat.java';
+    static readonly JAVA_DEBUG_EXTENSION: string = 'vscjava.vscode-java-debug';
+    static readonly JAVA_TEST_RUNNER_EXTENSION: string = 'vscjava.vscode-java-test';
+    static readonly IBM_CLOUD_ACCOUNT_EXTENSION: string = 'IBM.ibmcloud-account';
 }
 
 export interface Dependency {
@@ -65,6 +70,7 @@ export interface OptionalDependencies {
     javaLanguageExtension: DependencyWithVersion;
     javaDebuggerExtension: DependencyWithVersion;
     javaTestRunnerExtension: DependencyWithVersion;
+    ibmCloudAccountExtension: DependencyWithVersion;
 }
 
 export interface Dependencies extends RequiredDependencies, OptionalDependencies {}
@@ -76,7 +82,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: true,
             version: undefined,
             url: 'https://docs.docker.com/install/#supported-platforms',
-            requiredVersion: DependencyVersions.DOCKER_REQUIRED,
+            requiredVersion: DependencyProperties.DOCKER_REQUIRED_VERSION,
             requiredLabel: '',
             tooltip: `Used to download Hyperledger Fabric images and manage containers for local environments.`,
         },
@@ -85,7 +91,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: true,
             version: undefined,
             url: 'https://docs.docker.com/compose/install/',
-            requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED,
+            requiredVersion: DependencyProperties.DOCKER_COMPOSE_REQUIRED_VERSION,
             requiredLabel: '',
             tooltip: `Used for managing and operating the individual local environment components.`
         },
@@ -102,7 +108,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: true,
             version: undefined,
             url: 'https://www.openssl.org/community/binaries.html',
-            requiredVersion: DependencyVersions.OPENSSL_REQUIRED,
+            requiredVersion: DependencyProperties.OPENSSL_REQUIRED_VERSION,
             requiredLabel: 'only',
             tooltip: 'Install the Win64 version into `C:\\OpenSSL-Win64` on 64-bit systems`.'
         },
@@ -121,7 +127,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: false,
             version: undefined,
             url: 'https://nodejs.org/en/download/releases',
-            requiredVersion: DependencyVersions.NODEJS_REQUIRED,
+            requiredVersion: DependencyProperties.NODEJS_REQUIRED_VERSION,
             requiredLabel: 'only',
             tooltip: 'Required for developing JavaScript and TypeScript smart contracts. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.'
         },
@@ -129,7 +135,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'Node Test Runner Extension',
             required: false,
             version: undefined,
-            url: 'vscode:extension/oshri6688.javascript-test-runner',
+            url: `vscode:extension/${DependencyProperties.NODEJS_TEST_RUNNER_EXTENSION}`,
             requiredVersion: undefined,
             requiredLabel: '',
             tooltip: 'Used for running Node smart contract functional tests.'
@@ -139,7 +145,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: false,
             version: undefined,
             url: 'https://nodejs.org/en/download/releases',
-            requiredVersion: DependencyVersions.NPM_REQUIRED,
+            requiredVersion: DependencyProperties.NPM_REQUIRED_VERSION,
             requiredLabel: '',
             tooltip: 'Required for installing JavaScript and TypeScript smart contract dependencies. If installing Node and npm using a manager such as \'nvm\' or \'nodenv\', you will need to set the default/global version and restart VS Code for the version to be detected by the Prerequisites page.'
         },
@@ -148,7 +154,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: false,
             version: undefined,
             url: 'https://golang.org/dl/',
-            requiredVersion: DependencyVersions.GO_REQUIRED,
+            requiredVersion: DependencyProperties.GO_REQUIRED_VERSION,
             requiredLabel: '',
             tooltip: 'Required for developing Go smart contracts.'
         },
@@ -156,7 +162,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'Go Extension',
             required: false,
             version: undefined,
-            url: 'vscode:extension/golang.go',
+            url: `vscode:extension/${DependencyProperties.GO_LANGUAGE_EXTENSION}`,
             requiredVersion: '',
             requiredLabel: '',
             tooltip: 'Provides language support for Go.'
@@ -166,7 +172,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             required: false,
             version: undefined,
             url: 'https://adoptopenjdk.net/?variant=openjdk8',
-            requiredVersion: DependencyVersions.JAVA_REQUIRED,
+            requiredVersion: DependencyProperties.JAVA_REQUIRED_VERSION,
             requiredLabel: 'only',
             tooltip: 'Required for developing Java smart contracts.'
         },
@@ -174,7 +180,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'Java Language Support Extension',
             required: false,
             version: undefined,
-            url: 'vscode:extension/redhat.java',
+            url: `vscode:extension/${DependencyProperties.JAVA_LANGUAGE_EXTENSION}`,
             requiredVersion: undefined,
             requiredLabel: '',
             tooltip: 'Provides language support for Java.'
@@ -183,7 +189,7 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'Java Debugger Extension',
             required: false,
             version: undefined,
-            url: 'vscode:extension/vscjava.vscode-java-debug',
+            url: `vscode:extension/${DependencyProperties.JAVA_DEBUG_EXTENSION}`,
             requiredVersion: undefined,
             requiredLabel: '',
             tooltip: 'Used for debugging Java smart contracts.'
@@ -192,10 +198,19 @@ export const defaultDependencies: { required: RequiredDependencies, optional: Op
             name: 'Java Test Runner Extension',
             required: false,
             version: undefined,
-            url: 'vscode:extension/vscjava.vscode-java-test',
+            url: `vscode:extension/${DependencyProperties.JAVA_TEST_RUNNER_EXTENSION}`,
             requiredVersion: undefined,
             requiredLabel: '',
             tooltip: 'Used for running Java smart contract functional tests.'
+        },
+        ibmCloudAccountExtension: {
+            name: 'IBM Cloud Account Extension',
+            required: false,
+            version: undefined,
+            url: `vscode:extension/${DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION}`,
+            requiredVersion: undefined,
+            requiredLabel: '',
+            tooltip: 'Required for discovering IBM Blockchain Platform on IBM Cloud networks.',
         },
     },
 };

--- a/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
+++ b/packages/blockchain-extension/extension/dependencies/DependencyManager.ts
@@ -20,7 +20,7 @@ import * as vscode from 'vscode';
 import * as semver from 'semver';
 import { CommandUtil } from '../util/CommandUtil';
 import { GlobalState, ExtensionData } from '../util/GlobalState';
-import { RequiredDependencies, OptionalDependencies, Dependencies, defaultDependencies } from './Dependencies';
+import { RequiredDependencies, OptionalDependencies, Dependencies, defaultDependencies, DependencyProperties } from './Dependencies';
 import OS = require('os');
 
 export class DependencyManager {
@@ -37,25 +37,54 @@ export class DependencyManager {
 
     public isValidDependency(dependency: any): boolean {
         const name: string = dependency.name;
-        if (name === 'Node.js' || name === 'Java OpenJDK 8' || name === 'npm' || name === 'Docker' || name === 'Docker Compose' || name === 'Go' || name === 'OpenSSL' ) {
+
+        const needsToBeInstalledWithSemver: Array<string> = [
+            defaultDependencies.optional.node.name,
+            defaultDependencies.optional.java.name,
+            defaultDependencies.optional.npm.name,
+            defaultDependencies.required.docker.name,
+            defaultDependencies.required.dockerCompose.name,
+            defaultDependencies.optional.go.name,
+            defaultDependencies.required.openssl.name,
+        ];
+
+        const needsToBeInstalled: Array<string> = [
+            defaultDependencies.optional.goExtension.name,
+            defaultDependencies.optional.javaLanguageExtension.name,
+            defaultDependencies.optional.javaDebuggerExtension.name,
+            defaultDependencies.optional.javaTestRunnerExtension.name,
+            defaultDependencies.optional.nodeTestRunnerExtension.name,
+            defaultDependencies.optional.ibmCloudAccountExtension.name,
+        ];
+
+        const needsToBeComplete: Array<string> = [
+            defaultDependencies.required.dockerForWindows.name,
+            defaultDependencies.required.systemRequirements.name
+        ];
+
+        if (needsToBeInstalledWithSemver.includes(name)) {
             if (dependency.version) {
                 return semver.satisfies(dependency.version, dependency.requiredVersion);
             } else {
                 return false;
             }
-        } else if (name === 'Go Extension' || name === 'Java Language Support Extension' || name === 'Java Debugger Extension' || name === 'Java Test Runner Extension' || name === 'Node Test Runner Extension') {
+        } else if (needsToBeInstalled.includes(name)) {
             if (dependency.version) {
                 return true;
             } else {
                 return false;
             }
-        } else if (name === 'Docker for Windows' || name === 'System Requirements') {
+        } else if (needsToBeComplete.includes(name)) {
             if (!dependency.complete) {
                 dependency.complete = false;
             }
             return dependency.complete;
         }
         return false;
+    }
+
+    public areAllValidDependencies(properties: Array<string>, dependencies: any): boolean {
+        return properties.every((property) => dependencies.hasOwnProperty(property) && this.isValidDependency(dependencies[property]));
     }
 
     public async hasPreReqsInstalled(dependencies?: any, optionalInstalled: boolean = false): Promise<boolean> {
@@ -65,15 +94,8 @@ export class DependencyManager {
 
         const localFabricEnabled: boolean = ExtensionUtil.getExtensionLocalFabricSetting();
         if (localFabricEnabled) {
-            if (!this.isValidDependency(dependencies.docker)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.dockerCompose)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.systemRequirements)) {
+            const localFabricProperties: Array<string> = ['docker', 'dockerCompose', 'systemRequirements'];
+            if (!this.areAllValidDependencies(localFabricProperties, dependencies)) {
                 return false;
             }
         }
@@ -81,11 +103,8 @@ export class DependencyManager {
         if (process.platform === 'win32') {
             // Windows
             if (localFabricEnabled) {
-                if (!this.isValidDependency(dependencies.openssl)) {
-                    return false;
-                }
-
-                if (!this.isValidDependency(dependencies.dockerForWindows)) {
+                const windowsProperties: Array<string> = ['openssl', 'dockerForWindows'];
+                if (!this.areAllValidDependencies(windowsProperties, dependencies)) {
                     return false;
                 }
             }
@@ -94,39 +113,9 @@ export class DependencyManager {
 
         // Optional installs
         if (optionalInstalled) {
-            if (!this.isValidDependency(dependencies.node)) {
-                return false;
-            }
+            const optionalInstallProperties: Array<string> = Object.getOwnPropertyNames(defaultDependencies.optional);
 
-            if (!this.isValidDependency(dependencies.npm)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.go)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.goExtension)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.java)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.javaLanguageExtension)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.javaDebuggerExtension)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.javaTestRunnerExtension)) {
-                return false;
-            }
-
-            if (!this.isValidDependency(dependencies.nodeTestRunnerExtension)) {
+            if (!this.areAllValidDependencies(optionalInstallProperties, dependencies)) {
                 return false;
             }
         }
@@ -251,11 +240,12 @@ export class DependencyManager {
         const [nodeVersion, npmVersion, goVersion, javaVersion] = await Promise.all(getOptionalVersions);
 
         // VSCode extension dependencies
-        const goExtensionVersion: string = this.getGoExtensionVersion();
-        const javaLanguageExtensionVersion: string = this.getJavaLanguageExtensionVersion();
-        const javaDebuggerExtensionVersion: string = this.getJavaDebuggerExtensionVersion();
-        const javaTestRunnerExtensionVersion: string = this.getJavaTestRunnerExtensionVersion();
-        const nodeTestRunnerExtensionVersion: string = this.getNodeTestRunnerExtensionVersion();
+        const goExtensionVersion: string = this.getExtensionVersion(DependencyProperties.GO_LANGUAGE_EXTENSION);
+        const javaLanguageExtensionVersion: string = this.getExtensionVersion(DependencyProperties.JAVA_LANGUAGE_EXTENSION);
+        const javaDebuggerExtensionVersion: string = this.getExtensionVersion(DependencyProperties.JAVA_DEBUG_EXTENSION);
+        const javaTestRunnerExtensionVersion: string = this.getExtensionVersion(DependencyProperties.JAVA_TEST_RUNNER_EXTENSION);
+        const nodeTestRunnerExtensionVersion: string = this.getExtensionVersion(DependencyProperties.NODEJS_TEST_RUNNER_EXTENSION);
+        const ibmCloudAccountExtensionVersion: string = this.getExtensionVersion(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION);
 
         const optionalDependencies: OptionalDependencies = {
             ...defaultDependencies.optional,
@@ -271,6 +261,7 @@ export class DependencyManager {
         optionalDependencies.javaLanguageExtension.version = javaLanguageExtensionVersion;
         optionalDependencies.javaDebuggerExtension.version = javaDebuggerExtensionVersion;
         optionalDependencies.javaTestRunnerExtension.version = javaTestRunnerExtensionVersion;
+        optionalDependencies.ibmCloudAccountExtension.version = ibmCloudAccountExtensionVersion;
 
         return optionalDependencies;
     }
@@ -364,17 +355,6 @@ export class DependencyManager {
         }
     }
 
-    private getGoExtensionVersion(): string {
-        try {
-            const goExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('golang.go');
-            if (goExtensionResult) {
-                return goExtensionResult.packageJSON.version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-    }
-
     private async getJavaVersion(): Promise<string> {
         try {
 
@@ -401,45 +381,11 @@ export class DependencyManager {
         }
     }
 
-    private getJavaLanguageExtensionVersion(): string {
+    private getExtensionVersion(extension: string): string {
         try {
-            const javaLanguageExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('redhat.java');
-            if (javaLanguageExtensionResult) {
-                return javaLanguageExtensionResult.packageJSON.version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-    }
-
-    private getJavaDebuggerExtensionVersion(): string {
-        try {
-            const javaDebuggerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-debug');
-            if (javaDebuggerExtensionResult) {
-                return javaDebuggerExtensionResult.packageJSON.version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-    }
-
-    private getJavaTestRunnerExtensionVersion(): string {
-        try {
-            const javaTestRunnerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('vscjava.vscode-java-test');
-            if (javaTestRunnerExtensionResult) {
-                return javaTestRunnerExtensionResult.packageJSON.version;
-            }
-        } catch (error) {
-            // Ignore the error
-        }
-
-    }
-
-    private getNodeTestRunnerExtensionVersion(): string {
-        try {
-            const nodeTestRunnerExtensionResult: vscode.Extension<any> = vscode.extensions.getExtension('oshri6688.javascript-test-runner');
-            if (nodeTestRunnerExtensionResult) {
-                return nodeTestRunnerExtensionResult.packageJSON.version;
+            const nextensionResult: vscode.Extension<any> = vscode.extensions.getExtension(extension);
+            if (nextensionResult) {
+                return nextensionResult.packageJSON.version;
             }
         } catch (error) {
             // Ignore the error

--- a/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
+++ b/packages/blockchain-extension/extension/explorer/environmentExplorer.ts
@@ -251,7 +251,7 @@ export class BlockchainEnvironmentExplorerProvider implements BlockchainExplorer
                 arguments: []
             };
 
-            tree.push(new TextTreeItem(this, '+ add local or remote environment', command));
+            tree.push(new TextTreeItem(this, '+ Add local or remote environment', command));
 
             // TODO - comment back in when IBP supports v2
             // if there are no environments at all we should still show the option to log in to IBM Cloud

--- a/packages/blockchain-extension/extension/util/ExtensionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionUtil.ts
@@ -114,7 +114,7 @@ import { URL } from 'url';
 import { FeatureFlagManager } from './FeatureFlags';
 import { openConsoleInBrowser } from '../commands/openConsoleInBrowserCommand';
 import { deleteExtensionDirectory } from '../commands/deleteExtensionDirectoryCommand';
-import { Dependencies } from '../dependencies/Dependencies';
+import { defaultDependencies, Dependencies } from '../dependencies/Dependencies';
 
 let blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -307,6 +307,10 @@ export class ExtensionUtil {
             const extensionPath: string = ExtensionUtil.getExtensionPath();
             const fullPath: string = path.join(extensionPath, relativePath);
             await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(fullPath));
+        }));
+
+        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION, async () => {
+            await vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(defaultDependencies.optional.ibmCloudAccountExtension.url));
         }));
 
         const goDebugProvider: FabricGoDebugConfigurationProvider = new FabricGoDebugConfigurationProvider();

--- a/packages/blockchain-extension/extension/util/ExtensionsInteractionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionsInteractionUtil.ts
@@ -19,14 +19,19 @@ import { CloudAccountApi } from '../interfaces/cloud-account-api';
 import { VSCodeBlockchainOutputAdapter } from '../logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from 'ibm-blockchain-platform-common';
 import { URL } from 'url';
+import { DependencyProperties } from '../dependencies/Dependencies';
 
 /*
  * This file will hold functions to allow interaction with other extensions.
  */
 export class ExtensionsInteractionUtil {
 
+    // public static isIBMCloudExtensionInstalled(): boolean {
+    //     return !!vscode.extensions.getExtension(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION);
+    // }
+
     public static async cloudAccountGetAccessToken(userInteraction: boolean = true): Promise<string> {
-        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension( 'IBM.ibmcloud-account' );
+        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION);
         if ( !cloudAccountExtension ) {
             throw new Error('IBM Cloud Account extension must be installed');
         } else if ( !cloudAccountExtension.isActive ) {
@@ -69,7 +74,7 @@ export class ExtensionsInteractionUtil {
     }
 
     public static async cloudAccountIsLoggedIn(): Promise<boolean> {
-        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension( 'IBM.ibmcloud-account' );
+        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION);
         if ( !cloudAccountExtension ) {
             throw new Error('IBM Cloud Account extension must be installed');
         } else if ( !cloudAccountExtension.isActive ) {
@@ -81,7 +86,7 @@ export class ExtensionsInteractionUtil {
     }
 
     public static async cloudAccountHasSelectedAccount(): Promise<boolean> {
-        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension( 'IBM.ibmcloud-account' );
+        const  cloudAccountExtension: vscode.Extension<any> = vscode.extensions.getExtension(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION);
         if ( !cloudAccountExtension ) {
             throw new Error('IBM Cloud Account extension must be installed');
         } else if ( !cloudAccountExtension.isActive ) {

--- a/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
+++ b/packages/blockchain-extension/test/commands/UserInputUtil.test.ts
@@ -2795,7 +2795,7 @@ describe('UserInputUtil', () => {
 
     describe('getWorkspaceFolders', () => {
 
-        it(' getWorkspaceFolders should not show package chooser when only one folder to package', async () => {
+        it('getWorkspaceFolders should not show package chooser when only one folder to package', async () => {
 
             const pathOne: string = path.join('some', 'path');
             const uriOne: vscode.Uri = vscode.Uri.file(pathOne);

--- a/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
+++ b/packages/blockchain-extension/test/dependencies/DependencyManager.test.ts
@@ -23,7 +23,7 @@ import { DependencyManager } from '../../extension/dependencies/DependencyManage
 import { CommandUtil } from '../../extension/util/CommandUtil';
 import { TestUtil } from '../TestUtil';
 import { GlobalState, ExtensionData, DEFAULT_EXTENSION_DATA } from '../../extension/util/GlobalState.js';
-import { Dependencies, DependencyVersions } from '../../extension/dependencies/Dependencies';
+import { Dependencies, defaultDependencies, DependencyProperties } from '../../extension/dependencies/Dependencies';
 import * as semver from 'semver';
 import * as OS from 'os';
 
@@ -31,6 +31,61 @@ chai.should();
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
 const should: Chai.Should = chai.should();
+
+const validDependencies: Dependencies = {
+    docker: {
+        ...defaultDependencies.required.docker,
+        version: '18.1.2',
+    },
+    dockerCompose: {
+        ...defaultDependencies.required.dockerCompose,
+        version: '1.21.1',
+    },
+    systemRequirements: {
+        ...defaultDependencies.required.systemRequirements,
+        complete: true
+    },
+    node: {
+        ...defaultDependencies.optional.node,
+        version: '10.15.3',
+    },
+    npm: {
+        ...defaultDependencies.optional.npm,
+        version: '6.4.1',
+    },
+    go: {
+        ...defaultDependencies.optional.go,
+        version: '2.0.0',
+    },
+    goExtension: {
+        ...defaultDependencies.optional.goExtension,
+        version: '1.0.0'
+    },
+    java: {
+        ...defaultDependencies.optional.java,
+        version: '1.8.0',
+    },
+    javaLanguageExtension: {
+        ...defaultDependencies.optional.javaLanguageExtension,
+        version: '1.0.0'
+    },
+    javaDebuggerExtension: {
+        ...defaultDependencies.optional.javaDebuggerExtension,
+        version: '1.0.0'
+    },
+    javaTestRunnerExtension: {
+        ...defaultDependencies.optional.javaTestRunnerExtension,
+        version: '1.0.0'
+    },
+    nodeTestRunnerExtension: {
+        ...defaultDependencies.optional.nodeTestRunnerExtension,
+        version: '1.0.0'
+    },
+    ibmCloudAccountExtension: {
+        ...defaultDependencies.optional.ibmCloudAccountExtension,
+        version: '1.0.0',
+    },
+};
 
 // tslint:disable no-unused-expression
 describe('DependencyManager Tests', () => {
@@ -57,50 +112,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false when dependency version is incorrect, absent or incomplete`, async () => {
-            const dependenciesKeys: string[] = ['node', 'nodeTestRunner', 'java', 'docker', 'compose', 'go', 'goExtension', 'javaLangSupp', 'javaDebug', 'javaTestRunner', 'dockerWin', 'sysReq'];
-
-            const dependencies: any = {
-                node: {
-                    name: 'Node.js'
-                },
-                nodeTestRunner: {
-                    name: 'Node Test Runner Extension'
-                },
-                java: {
-                    name: 'Java OpenJDK 8'
-                },
-                docker: {
-                    name: 'Docker'
-                },
-                compose: {
-                    name: 'Docker Compose'
-                },
-                go: {
-                    name: 'Go'
-                },
-                goExtension: {
-                    name: 'Go Extension'
-                },
-                javaLangSupp: {
-                    name: 'Java Language Support Extension'
-                },
-                javaDebug: {
-                    name: 'Java Debugger Extension'
-                },
-                javaTestRunner: {
-                    name: 'Java Test Runner Extension'
-                },
-                dockerWin: {
-                    name: 'Docker for Windows',
-                    complete: false
-                },
-                sysReq: {
-                    name: 'System Requirements'
-                }
-            };
+            const dependenciesWithoutVersions: object = [defaultDependencies.required, defaultDependencies.optional];
+            const dependenciesKeys: string[] = Object.getOwnPropertyNames(dependenciesWithoutVersions);
 
             for (let i: number = 0; i < dependenciesKeys.length; i++) {
-                const result: boolean = dependencyManager.isValidDependency(dependencies[dependenciesKeys[i]]);
+                const result: boolean = dependencyManager.isValidDependency(dependenciesWithoutVersions[dependenciesKeys[i]]);
                 try {
                     result.should.equal(false);
                 } catch (error) {
@@ -111,61 +127,10 @@ describe('DependencyManager Tests', () => {
 
         it(`should return true when dependency version is correct, present or complete`, async () => {
             semverSatisfiesStub.returns(true);
-            const dependenciesKeys: string[] = ['node', 'nodeTestRunner', 'java', 'docker', 'compose', 'go', 'goExtension', 'javaLangSupp', 'javaDebug', 'javaTestRunner', 'dockerWin', 'sysReq'];
-
-            const dependencies: any = {
-                node: {
-                    name: 'Node.js',
-                    version: 'x'
-                },
-                nodeTestRunner: {
-                    name: 'Node Test Runner Extension',
-                    version: 'x'
-                },
-                java: {
-                    name: 'Java OpenJDK 8',
-                    version: 'x'
-                },
-                docker: {
-                    name: 'Docker',
-                    version: 'x'
-                },
-                compose: {
-                    name: 'Docker Compose',
-                    version: 'x'
-                },
-                go: {
-                    name: 'Go',
-                    version: 'x'
-                },
-                goExtension: {
-                    name: 'Go Extension',
-                    version: 'x'
-                },
-                javaLangSupp: {
-                    name: 'Java Language Support Extension',
-                    version: 'x'
-                },
-                javaDebug: {
-                    name: 'Java Debugger Extension',
-                    version: 'x'
-                },
-                javaTestRunner: {
-                    name: 'Java Test Runner Extension',
-                    version: 'x'
-                },
-                dockerWin: {
-                    name: 'Docker for Windows',
-                    complete: true
-                },
-                sysReq: {
-                    name: 'System Requirements',
-                    complete: true
-                }
-            };
+            const dependenciesKeys: string[] = Object.getOwnPropertyNames(validDependencies);
 
             for (let i: number = 0; i < dependenciesKeys.length; i++) {
-                const result: boolean = dependencyManager.isValidDependency(dependencies[dependenciesKeys[i]]);
+                const result: boolean = dependencyManager.isValidDependency(validDependencies[dependenciesKeys[i]]);
                 try {
                     result.should.equal(true);
                 } catch (error) {
@@ -197,10 +162,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false if there's no Docker version`, async () => {
-            const dependencies: any = {
+            const dependencies: Dependencies = {
+                ...validDependencies,
                 docker: {
-                    name: 'Docker',
-                    version: undefined
+                    ...defaultDependencies.required.docker,
+                    version: undefined,
                 }
             };
 
@@ -215,11 +181,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false if Docker version is less than required version`, async () => {
-            const dependencies: any = {
+            const dependencies: Dependencies = {
+                ...validDependencies,
                 docker: {
-                    name: 'Docker',
+                    ...defaultDependencies.required.docker,
                     version: '16.0.0',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 }
             };
 
@@ -234,15 +200,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false if there's no Docker Compose version`, async () => {
-            const dependencies: any = {
-                docker: {
-                    name: 'Docker',
-                    version: '18.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                },
+            const dependencies: Dependencies = {
+                ...validDependencies,
                 dockerCompose: {
-                    name: 'Docker Compose',
-                    version: undefined
+                    ...defaultDependencies.required.dockerCompose,
+                    version: undefined,
                 }
             };
 
@@ -257,16 +219,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false if Docker Compose version is less than required version`, async () => {
-            const dependencies: any = {
-                docker: {
-                    name: 'Docker',
-                    version: '18.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                },
+            const dependencies: Dependencies = {
+                ...validDependencies,
                 dockerCompose: {
-                    name: 'Docker Compose',
+                    ...defaultDependencies.required.dockerCompose,
                     version: '1.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 }
             };
 
@@ -281,20 +238,11 @@ describe('DependencyManager Tests', () => {
         });
 
         it(`should return false if they haven't confirmed to have system requirements`, async () => {
-            const dependencies: any = {
-                docker: {
-                    name: 'Docker',
-                    version: '18.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                },
-                dockerCompose: {
-                    name: 'Docker Compose',
-                    version: '1.21.1',
-                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                },
+            const dependencies: Dependencies = {
+                ...validDependencies,
                 systemRequirements: {
-                    name: 'System Requirements',
-                    complete: undefined
+                    ...defaultDependencies.required.systemRequirements,
+                    complete: undefined,
                 }
             };
 
@@ -313,17 +261,15 @@ describe('DependencyManager Tests', () => {
 
             const dependencies: any = {
                 docker: {
-                    name: 'Docker',
+                    ...defaultDependencies.required.docker,
                     version: '18.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
                 },
                 dockerCompose: {
-                    name: 'Docker Compose',
+                    ...defaultDependencies.required.dockerCompose,
                     version: '1.21.1',
-                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                 },
                 systemRequirements: {
-                    name: 'System Requirements',
+                    ...defaultDependencies.required.systemRequirements,
                     complete: true
                 }
             };
@@ -364,25 +310,8 @@ describe('DependencyManager Tests', () => {
             getExtensionLocalFabricSetting.returns(false);
             mySandBox.stub(process, 'platform').value('linux'); // We don't have any Linux only prereqs, so this is okay.
 
-            const dependencies: any = {
-                docker: {
-                    name: 'Docker',
-                    version: '18.1.2',
-                    requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                },
-                dockerCompose: {
-                    name: 'Docker Compose',
-                    version: '1.21.1',
-                    requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                },
-                systemRequirements: {
-                    name: 'System Requirements',
-                    complete: true
-                }
-            };
-
             const dependencyManager: DependencyManager = DependencyManager.instance();
-            const result: boolean = await dependencyManager.hasPreReqsInstalled(dependencies);
+            const result: boolean = await dependencyManager.hasPreReqsInstalled(validDependencies);
 
             result.should.equal(true);
             getPreReqVersionsStub.should.not.have.been.called;
@@ -393,24 +322,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if there's no OpenSSL version (Windows)`, async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     openssl: {
-                        name: 'OpenSSL',
-                        version: undefined
+                        ...defaultDependencies.required.openssl,
+                        version: undefined,
                     }
                 };
 
@@ -427,24 +343,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if version of OpenSSL is not equal to the required version (Windows)`, async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     openssl: {
-                        name: 'OpenSSL',
+                        ...defaultDependencies.required.openssl,
                         version: '1.0.6',
-                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     }
                 };
 
@@ -461,28 +364,10 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the user hasn't confirmed the Docker for Windows setup (Windows)`, async () => {
                 mySandBox.stub(process, 'platform').value('win32');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    openssl: {
-                        name: 'OpenSSL',
-                        version: '1.0.2',
-                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     dockerForWindows: {
-                        name: 'Docker for Windows',
+                        ...defaultDependencies.required.dockerForWindows,
                         complete: undefined
                     }
                 };
@@ -502,26 +387,23 @@ describe('DependencyManager Tests', () => {
 
                 const dependencies: any = {
                     docker: {
-                        name: 'Docker',
+                        ...defaultDependencies.required.docker,
                         version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
-                        name: 'Docker Compose',
+                        ...defaultDependencies.required.dockerCompose,
                         version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
-                        name: 'System Requirements',
+                        ...defaultDependencies.required.systemRequirements,
                         complete: true
                     },
                     openssl: {
-                        name: 'OpenSSL',
+                        ...defaultDependencies.required.openssl,
                         version: '1.0.2',
-                        requiredVersion: DependencyVersions.OPENSSL_REQUIRED
                     },
                     dockerForWindows: {
-                        name: 'Docker for Windows',
+                        ...defaultDependencies.required.dockerForWindows,
                         complete: true
                     }
                 };
@@ -561,17 +443,15 @@ describe('DependencyManager Tests', () => {
 
                 const dependencies: any = {
                     docker: {
-                        name: 'Docker',
+                        ...defaultDependencies.required.docker,
                         version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
                     },
                     dockerCompose: {
-                        name: 'Docker Compose',
+                        ...defaultDependencies.required.dockerCompose,
                         version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
                     },
                     systemRequirements: {
-                        name: 'System Requirements',
+                        ...defaultDependencies.required.systemRequirements,
                         complete: true
                     }
                 };
@@ -590,24 +470,11 @@ describe('DependencyManager Tests', () => {
         describe('optional dependencies', () => {
 
             it(`should return false the optional Node dependency hasn't been installed`, async () => {
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     node: {
-                        name: 'Node.js',
-                        version: undefined
+                        ...defaultDependencies.optional.node,
+                        version: undefined,
                     }
                 };
 
@@ -622,25 +489,11 @@ describe('DependencyManager Tests', () => {
             });
 
             it(`should return false if wrong Node version`, async () => {
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     node: {
-                        name: 'Node.js',
+                        ...defaultDependencies.optional.node,
                         version: '8.12.0',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
                     }
                 };
 
@@ -671,29 +524,11 @@ describe('DependencyManager Tests', () => {
             });
 
             it(`should return false if the optional npm dependency hasn't been installed`, async () => {
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     npm: {
-                        name: 'npm',
-                        version: undefined
+                        ...defaultDependencies.optional.npm,
+                        version: undefined,
                     }
                 };
 
@@ -708,30 +543,11 @@ describe('DependencyManager Tests', () => {
             });
 
             it(`should return false if the optional npm dependency version is less than required version`, async () => {
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     npm: {
-                        name: 'npm',
+                        ...defaultDependencies.optional.npm,
                         version: '4.0.0',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
                     }
                 };
 
@@ -748,34 +564,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Go dependency hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     go: {
-                        name: 'Go',
-                        version: undefined
+                        ...defaultDependencies.optional.go,
+                        version: undefined,
                     }
                 };
 
@@ -792,35 +585,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Go dependency isn't greater than the required version`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     go: {
-                        name: 'Go',
+                        ...defaultDependencies.optional.go,
                         version: '1.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
                     }
                 };
 
@@ -837,39 +606,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Go Extension hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     goExtension: {
-                        name: 'Go Extension',
-                        version: undefined
+                        ...defaultDependencies.optional.goExtension,
+                        version: undefined,
                     }
                 };
 
@@ -886,45 +627,12 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Java dependency hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     java: {
-                        name: 'Java OpenJDK 8',
-                        version: undefined
+                        ...defaultDependencies.optional.java,
+                        version: undefined,
                     }
-
                 };
 
                 getPreReqVersionsStub.resolves(dependencies);
@@ -940,44 +648,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Java dependency doesn't satisfy the required version`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     java: {
-                        name: 'Java OpenJDK 8',
+                        ...defaultDependencies.optional.java,
                         version: '1.7.1',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
                     }
                 };
 
@@ -994,48 +669,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Java Language Support Extension hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
-                    java: {
-                        name: 'Java OpenJDK 8',
-                        version: '1.8.0',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     javaLanguageExtension: {
-                        name: 'Java Language Support Extension',
-                        version: undefined
+                        ...defaultDependencies.optional.javaLanguageExtension,
+                        version: undefined,
                     }
                 };
 
@@ -1052,52 +690,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Java Debugger Extension hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
-                    java: {
-                        name: 'Java OpenJDK 8',
-                        version: '1.8.0',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
-                    },
-                    javaLanguageExtension: {
-                        name: 'Java Language Support Extension',
-                        version: '1.0.0'
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     javaDebuggerExtension: {
-                        name: 'Java Debugger Extension',
-                        version: undefined
+                        ...defaultDependencies.optional.javaDebuggerExtension,
+                        version: undefined,
                     }
                 };
 
@@ -1114,56 +711,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Java Test Runner Extension hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
-                    java: {
-                        name: 'Java OpenJDK 8',
-                        version: '1.8.0',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
-                    },
-                    javaLanguageExtension: {
-                        name: 'Java Language Support Extension',
-                        version: '1.0.0'
-                    },
-                    javaDebuggerExtension: {
-                        name: 'Java Debugger Extension',
-                        version: '1.0.0'
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     javaTestRunnerExtension: {
-                        name: 'Java Test Runner Extension',
-                        version: undefined
+                        ...defaultDependencies.optional.javaTestRunnerExtension,
+                        version: undefined,
                     }
                 };
 
@@ -1180,60 +732,11 @@ describe('DependencyManager Tests', () => {
             it(`should return false if the optional Node Test Runner Extension hasn't been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
-                    java: {
-                        name: 'Java OpenJDK 8',
-                        version: '1.8.0',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
-                    },
-                    javaLanguageExtension: {
-                        name: 'Java Language Support Extension',
-                        version: '1.0.0'
-                    },
-                    javaDebuggerExtension: {
-                        name: 'Java Debugger Extension',
-                        version: '1.0.0'
-                    },
-                    javaTestRunnerExtension: {
-                        name: 'Java Test Runner Extension',
-                        version: '1.0.0'
-                    },
+                const dependencies: Dependencies = {
+                    ...validDependencies,
                     nodeTestRunnerExtension: {
-                        name: 'Node Test Runner Extension',
-                        version: undefined
+                        ...defaultDependencies.optional.nodeTestRunnerExtension,
+                        version: undefined,
                     }
                 };
 
@@ -1250,64 +753,7 @@ describe('DependencyManager Tests', () => {
             it(`should return true if all the optional prereqs have been installed`, async () => {
                 mySandBox.stub(process, 'platform').value('linux');
 
-                const dependencies: any = {
-                    docker: {
-                        name: 'Docker',
-                        version: '18.1.2',
-                        requiredVersion: DependencyVersions.DOCKER_REQUIRED
-                    },
-                    dockerCompose: {
-                        name: 'Docker Compose',
-                        version: '1.21.1',
-                        requiredVersion: DependencyVersions.DOCKER_COMPOSE_REQUIRED
-                    },
-                    systemRequirements: {
-                        name: 'System Requirements',
-                        complete: true
-                    },
-                    node: {
-                        name: 'Node.js',
-                        version: '10.15.3',
-                        requiredVersion: DependencyVersions.NODEJS_REQUIRED
-                    },
-                    npm: {
-                        name: 'npm',
-                        version: '6.4.1',
-                        requiredVersion: DependencyVersions.NPM_REQUIRED
-                    },
-                    go: {
-                        name: 'Go',
-                        version: '2.0.0',
-                        requiredVersion: DependencyVersions.GO_REQUIRED
-                    },
-                    goExtension: {
-                        name: 'Go Extension',
-                        version: '1.0.0'
-                    },
-                    java: {
-                        name: 'Java OpenJDK 8',
-                        version: '1.8.0',
-                        requiredVersion: DependencyVersions.JAVA_REQUIRED
-                    },
-                    javaLanguageExtension: {
-                        name: 'Java Language Support Extension',
-                        version: '1.0.0'
-                    },
-                    javaDebuggerExtension: {
-                        name: 'Java Debugger Extension',
-                        version: '1.0.0'
-                    },
-                    javaTestRunnerExtension: {
-                        name: 'Java Test Runner Extension',
-                        version: '1.0.0'
-                    },
-                    nodeTestRunnerExtension: {
-                        name: 'Node Test Runner Extension',
-                        version: '1.0.0'
-                    }
-                };
-
-                getPreReqVersionsStub.resolves(dependencies);
+                getPreReqVersionsStub.resolves(validDependencies);
 
                 const dependencyManager: DependencyManager = DependencyManager.instance();
                 const result: boolean = await dependencyManager.hasPreReqsInstalled(undefined, true);
@@ -1515,7 +961,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('golang.go').returns({
+            getExtensionStub.withArgs(DependencyProperties.GO_LANGUAGE_EXTENSION).returns({
                 packageJSON: {
                     version: '1.0.0'
                 }
@@ -1530,7 +976,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('golang.go').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.GO_LANGUAGE_EXTENSION).returns(undefined);
 
             const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.goExtension.version);
@@ -1569,7 +1015,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('redhat.java').returns({
+            getExtensionStub.withArgs(DependencyProperties.JAVA_LANGUAGE_EXTENSION).returns({
                 packageJSON: {
                     version: '2.0.0'
                 }
@@ -1584,7 +1030,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('redhat.java').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.JAVA_LANGUAGE_EXTENSION).returns(undefined);
 
             const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaLanguageExtension.version);
@@ -1595,7 +1041,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('vscjava.vscode-java-debug').returns({
+            getExtensionStub.withArgs(DependencyProperties.JAVA_DEBUG_EXTENSION).returns({
                 packageJSON: {
                     version: '3.0.0'
                 }
@@ -1610,7 +1056,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('vscjava.vscode-java-debug').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.JAVA_DEBUG_EXTENSION).returns(undefined);
 
             const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaDebuggerExtension.version);
@@ -1619,7 +1065,7 @@ describe('DependencyManager Tests', () => {
 
         it('should get version of Java Test Runner Extension', async () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('vscjava.vscode-java-test').returns({
+            getExtensionStub.withArgs(DependencyProperties.JAVA_TEST_RUNNER_EXTENSION).returns({
                 packageJSON: {
                     version: '2.0.0'
                 }
@@ -1634,7 +1080,7 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('vscjava.vscode-java-test').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.JAVA_TEST_RUNNER_EXTENSION).returns(undefined);
 
             const result: Dependencies = await dependencyManager.getPreReqVersions();
             should.not.exist(result.javaTestRunnerExtension.version);
@@ -1643,7 +1089,7 @@ describe('DependencyManager Tests', () => {
 
         it('should get version of Node Test Runner Extension', async () => {
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('oshri6688.javascript-test-runner').returns({
+            getExtensionStub.withArgs(DependencyProperties.NODEJS_TEST_RUNNER_EXTENSION).returns({
                 packageJSON: {
                     version: '2.0.0'
                 }
@@ -1658,10 +1104,34 @@ describe('DependencyManager Tests', () => {
             mySandBox.stub(process, 'platform').value('some_other_platform');
 
             const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
-            getExtensionStub.withArgs('oshri6688.javascript-test-runner').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.NODEJS_TEST_RUNNER_EXTENSION).returns(undefined);
 
             const result: any = await dependencyManager.getPreReqVersions();
             should.not.exist(result.nodeTestRunnerExtension.version);
+            totalmemStub.should.have.been.calledOnce;
+        });
+
+        it('should get version of IBM Cloud Account Extension', async () => {
+            const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns({
+                packageJSON: {
+                    version: '2.0.0'
+                }
+            });
+
+            const result: any = await dependencyManager.getPreReqVersions();
+            result.ibmCloudAccountExtension.version.should.equal('2.0.0');
+            totalmemStub.should.have.been.calledOnce;
+        });
+
+        it('should not get version of IBM Cloud Account Extension if it cannot be found', async () => {
+            mySandBox.stub(process, 'platform').value('some_other_platform');
+
+            const getExtensionStub: sinon.SinonStub = mySandBox.stub(vscode.extensions, 'getExtension');
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(undefined);
+
+            const result: any = await dependencyManager.getPreReqVersions();
+            should.not.exist(result.ibmCloudAccountExtension.version);
             totalmemStub.should.have.been.calledOnce;
         });
 

--- a/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
+++ b/packages/blockchain-extension/test/explorer/environmentExplorer.test.ts
@@ -359,7 +359,7 @@ describe('environmentExplorer', () => {
                 const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
                 allChildren.length.should.equal(1);
-                allChildren[0].label.should.equal(`+ add local or remote environment`);
+                allChildren[0].label.should.equal(`+ Add local or remote environment`);
                 allChildren[0].command.should.deep.equal({
                     command: ExtensionCommands.ADD_ENVIRONMENT,
                     title: '',
@@ -392,7 +392,7 @@ describe('environmentExplorer', () => {
             //     const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
             //     allChildren.length.should.equal(2);
-            //     allChildren[0].label.should.equal(`+ add local or remote environment`);
+            //     allChildren[0].label.should.equal(`+ Add local or remote environment`);
             //     allChildren[0].command.should.deep.equal({
             //         command: ExtensionCommands.ADD_ENVIRONMENT,
             //         title: '',
@@ -492,7 +492,7 @@ describe('environmentExplorer', () => {
             //     const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
             //     allChildren.length.should.equal(1);
-            //     allChildren[0].label.should.equal(`+ add local or remote environment`);
+            //     allChildren[0].label.should.equal(`+ Add local or remote environment`);
             //     allChildren[0].command.should.deep.equal({
             //         command: ExtensionCommands.ADD_ENVIRONMENT,
             //         title: '',
@@ -578,7 +578,7 @@ describe('environmentExplorer', () => {
             //     const allChildren: BlockchainTreeItem[] = await blockchainRuntimeExplorerProvider.getChildren();
 
             //     allChildren.length.should.equal(1);
-            //     allChildren[0].label.should.equal(`+ add local or remote environment`);
+            //     allChildren[0].label.should.equal(`+ Add local or remote environment`);
             //     allChildren[0].command.should.deep.equal({
             //         command: ExtensionCommands.ADD_ENVIRONMENT,
             //         title: '',

--- a/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
+++ b/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
@@ -59,6 +59,7 @@ import { ManagedAnsibleEnvironment } from '../../extension/fabric/environments/M
 import Axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { FeatureFlagManager } from '../../extension/util/FeatureFlags';
+import { defaultDependencies } from '../../extension/dependencies/Dependencies';
 
 const should: Chai.Should = chai.should();
 chai.use(sinonChai);
@@ -523,6 +524,21 @@ describe('ExtensionUtil Tests', () => {
 
             registerPreReqAndReleaseNotesCommandStub.should.have.been.calledOnce;
             executeCommandStub.should.have.been.calledWith('vscode.open', vscode.Uri.parse(url));
+        });
+
+        it('should register and open ibm cloud account extension link', async () => {
+            const executeCommandStub: sinon.SinonStub = mySandBox.stub(vscode.commands, 'executeCommand').callThrough();
+            executeCommandStub.withArgs('vscode.open').resolves();
+
+            const ctx: vscode.ExtensionContext = GlobalState.getExtensionContext();
+            const registerPreReqAndReleaseNotesCommandStub: sinon.SinonStub = mySandBox.stub(ExtensionUtil, 'registerPreReqAndReleaseNotesCommand').resolves(ctx);
+
+            await ExtensionUtil.registerCommands(ctx);
+
+            await vscode.commands.executeCommand(ExtensionCommands.OPEN_IBM_CLOUD_EXTENSION);
+
+            registerPreReqAndReleaseNotesCommandStub.should.have.been.calledOnce;
+            executeCommandStub.should.have.been.calledWith('vscode.open', vscode.Uri.parse(defaultDependencies.optional.ibmCloudAccountExtension.url));
         });
 
         // it('should reload blockchain explorer when debug event emitted', async () => {

--- a/packages/blockchain-extension/test/util/ExtensionsInteractionUtil.test.ts
+++ b/packages/blockchain-extension/test/util/ExtensionsInteractionUtil.test.ts
@@ -21,6 +21,7 @@ import Axios from 'axios';
 import { ExtensionsInteractionUtil } from '../../extension/util/ExtensionsInteractionUtil';
 import { VSCodeBlockchainOutputAdapter } from '../../extension/logging/VSCodeBlockchainOutputAdapter';
 import { LogType } from 'ibm-blockchain-platform-common';
+import { DependencyProperties } from '../../extension/dependencies/Dependencies';
 
 // tslint:disable no-unused-expression
 chai.use(sinonChai);
@@ -68,7 +69,7 @@ describe('ExtensionsInteractionUtil Test', () => {
                             getAccessToken: getAccessTokenStub
                          }
             };
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(cloudExtensionStub);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(cloudExtensionStub);
 
             selectAccountStub = executeCommandStub.withArgs('ibmcloud-account.selectAccount');
             selectAccountStub.resolves(true);
@@ -215,7 +216,7 @@ describe('ExtensionsInteractionUtil Test', () => {
             chai.should().equal(undefined, accessToken);
             isLoggedInStub.onFirstCall().resolves(false);
             cloudExtensionStub.isActive = false;
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(cloudExtensionStub);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(cloudExtensionStub);
 
             try {
                 accessToken = await ExtensionsInteractionUtil.cloudAccountGetAccessToken();
@@ -234,7 +235,7 @@ describe('ExtensionsInteractionUtil Test', () => {
 
         it('should throw if ibmcloud-account not installed', async () => {
             chai.should().equal(undefined, accessToken);
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(undefined);
             const expectedError: Error = new Error('IBM Cloud Account extension must be installed');
 
             try {
@@ -291,7 +292,7 @@ describe('ExtensionsInteractionUtil Test', () => {
                             loggedIn: isLoggedInStub,
                          }
             };
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(cloudExtensionStub);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(cloudExtensionStub);
 
             isLoggedIn = undefined;
         });
@@ -327,7 +328,7 @@ describe('ExtensionsInteractionUtil Test', () => {
 
         it('should error if no cloud extension', async () => {
             chai.should().equal(undefined, isLoggedIn);
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(undefined);
             const expectedError: Error = new Error('IBM Cloud Account extension must be installed');
 
             try {
@@ -359,7 +360,7 @@ describe('ExtensionsInteractionUtil Test', () => {
                             accountSelected: hasAccountSelectedStub,
                          }
             };
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(cloudExtensionStub);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(cloudExtensionStub);
 
             hasAccountSelected = undefined;
         });
@@ -395,7 +396,7 @@ describe('ExtensionsInteractionUtil Test', () => {
 
         it('should error if no cloud extension', async () => {
             chai.should().equal(undefined, hasAccountSelected);
-            getExtensionStub.withArgs('IBM.ibmcloud-account').returns(undefined);
+            getExtensionStub.withArgs(DependencyProperties.IBM_CLOUD_ACCOUNT_EXTENSION).returns(undefined);
             const expectedError: Error = new Error('IBM Cloud Account extension must be installed');
 
             try {


### PR DESCRIPTION
Some v2 changes from: https://github.com/IBM-Blockchain/blockchain-vscode-extension/pull/2713.
This PR is missing the following bits from the above PR:
* https://github.com/IBM-Blockchain/blockchain-vscode-extension/pull/2713/files#diff-89b902d64e28492c09b92a431e706b4acff9aef7cd6680ece3b86ee1b18aad9fR388-R402
* This whole file: https://github.com/IBM-Blockchain/blockchain-vscode-extension/pull/2713/files#diff-a3f11b8c8952092cddb5d8e6251f0711b655834217776e09ad3cf19c705a97f2R73 

### Summary
IBM Cloud Account extension changes:
* Added IBM Cloud Account extension dependency
* Added a function to open the IBM Cloud Account marketplace page in VSCode

Dependency refactor changes:
* Removed duplicated strings such as dependency name/extension name into Dependency to make maintenance easier
* Refactored duplicated functions into a single function to make adding a new dependency require less of a change
* Cleaned up the DependencyManager tests to take advantage of the `defaultDependencies` object

### Testing

* Added tests for the IBM Cloud Account functionality
* Checked all unit tests passed locally after making refactor

Signed-off-by: James Wallis <james.wallis1@ibm.com>