### PR TITLE
Add syntax highlighting using react-syntax-highlighter

### DIFF
--- a/packages/blockchain-ui/enzyme/tests/TutorialSinglePage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TutorialSinglePage.test.tsx
@@ -10,7 +10,7 @@ import ITutorialObject from '../../src/interfaces/ITutorialObject';
 chai.should();
 chai.use(sinonChai);
 
-describe.only('TutorialPage component', () => {
+describe('TutorialPage component', () => {
 
     const tutorial: ITutorialObject = {
       title: 'a2',

--- a/packages/blockchain-ui/enzyme/tests/TutorialSinglePage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TutorialSinglePage.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import chai from 'chai';
+import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
 import TutorialPage from '../../src/components/pages/TutorialSinglePage/TutorialSinglePage';
@@ -9,7 +10,7 @@ import ITutorialObject from '../../src/interfaces/ITutorialObject';
 chai.should();
 chai.use(sinonChai);
 
-describe('TutorialPage component', () => {
+describe.only('TutorialPage component', () => {
 
     const tutorial: ITutorialObject = {
       title: 'a2',
@@ -31,6 +32,9 @@ describe('TutorialPage component', () => {
             '<a href="https://ibm.com">Link to external webpage</a>',
             '<a>Bad anchor tag ignore me</a>',
             '<a href="./a1.md"><img src="./image/within/link" alt="alt"></img></a>',
+            '```typescript\nconst astring: string = "string"\n```',
+            '```\ncode block without language\n```',
+            '`single line codeblock`',
       ].join('\n'),
     };
 
@@ -71,6 +75,16 @@ describe('TutorialPage component', () => {
         }
     ];
 
+    let mySandBox: sinon.SinonSandbox;
+
+    beforeEach(async () => {
+        mySandBox = sinon.createSandbox();
+    });
+
+    afterEach(async () => {
+        mySandBox.restore();
+    });
+
     it('should render the expected snapshot', () => {
         const component: any = renderer
             .create(<TutorialPage tutorialData={tutorialData} tutorial={tutorial} />)
@@ -78,8 +92,15 @@ describe('TutorialPage component', () => {
         expect(component).toMatchSnapshot();
     });
 
+    it('should render the expected snapshot (when the style is dark)', () => {
+        sinon.stub(document, 'getElementsByTagName').withArgs('body').returns([{ className: 'vscode-dark' }]);
+        const component: any = renderer
+            .create(<TutorialPage tutorialData={tutorialData} tutorial={tutorial} />)
+            .toJSON();
+        expect(component).toMatchSnapshot();
+    });
+
     it('should render the component when no tutorialData is passed in', async () => {
-        // const component: any = mount(<TutorialPage tutorialData={tutorialData} tutorial={tutorial} />);
         const component: any = renderer
               .create(<TutorialPage tutorialData={[]} tutorial={tutorial} />)
               .toJSON();

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TutorialSinglePage.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TutorialSinglePage.test.tsx.snap
@@ -75,8 +75,326 @@ exports[`TutorialPage component should render the component when no tutorialData
             />
           </a>
         </p>
+        <pre
+          style={
+            Object {
+              "background": "#1d1f21",
+              "color": "#c5c8c6",
+              "display": "block",
+              "overflowX": "auto",
+              "padding": "0.5em",
+            }
+          }
+        >
+          <code
+            className="language-typescript"
+            style={
+              Object {
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              1
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#b294bb",
+                }
+              }
+            >
+              const
+            </span>
+            <span
+              style={Object {}}
+            >
+               astring: 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#de935f",
+                }
+              }
+            >
+              string
+            </span>
+            <span
+              style={Object {}}
+            >
+               = 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#b5bd68",
+                }
+              }
+            >
+              "string"
+            </span>
+            <span
+              style={Object {}}
+            >
+              
+
+            </span>
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              2
+            </span>
+            
+
+          </code>
+        </pre>
+        <pre>
+          <code>
+            code block without language
+
+          </code>
+        </pre>
+        <p>
+          <code>
+            single line codeblock
+          </code>
+        </p>
       </div>
       <hr />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`TutorialPage component should render the expected snapshot (when the style is dark) 1`] = `
+<div
+  className="bx--grid tutorial-page-container"
+>
+  <div
+    className="bx--row"
+  >
+    <div
+      className="tutorial-page"
+    >
+      <p>
+        <strong>
+          IBM Blockchain Platform
+        </strong>
+      </p>
+      <div
+        className="tutorial-previous"
+      >
+        <a
+          className="bx--link"
+          href=""
+          onClick={[Function]}
+        >
+          ← a1
+        </a>
+      </div>
+      <img
+        alt="IBM Blockchain Platform"
+        className="ibp-icon"
+        src="test-file-stub"
+      />
+      <h2
+        className="tutorial-name"
+      >
+        a2
+      </h2>
+      <hr />
+      <p>
+        Estimated time: 
+        <code>
+          4 weeks
+        </code>
+      </p>
+      <div
+        className="tutorial-content"
+      >
+        <h2>
+          Heading
+        </h2>
+        <p>
+          paragraph
+
+          <img
+            alt="alt"
+            src="../resources/tutorials/some/file/relative/link"
+          />
+          mailto ignore me
+          <a
+            className="bx--link"
+            href=""
+            onClick={[Function]}
+          >
+            Link to resource file
+          </a>
+          <a
+            className="bx--link"
+            href=""
+            onClick={[Function]}
+          >
+            Link to another tutorial
+          </a>
+          <a
+            href="https://ibm.com"
+          >
+            Link to external webpage
+          </a>
+          <a>
+            Bad anchor tag ignore me
+          </a>
+          <a
+            className="bx--link"
+            href=""
+            onClick={[Function]}
+          >
+            <img
+              alt="alt"
+              src="../resources/tutorials/some/file/image/within/link"
+            />
+          </a>
+        </p>
+        <pre
+          style={
+            Object {
+              "background": "#1d1f21",
+              "color": "#c5c8c6",
+              "display": "block",
+              "overflowX": "auto",
+              "padding": "0.5em",
+            }
+          }
+        >
+          <code
+            className="language-typescript"
+            style={
+              Object {
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              1
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#b294bb",
+                }
+              }
+            >
+              const
+            </span>
+            <span
+              style={Object {}}
+            >
+               astring: 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#de935f",
+                }
+              }
+            >
+              string
+            </span>
+            <span
+              style={Object {}}
+            >
+               = 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#b5bd68",
+                }
+              }
+            >
+              "string"
+            </span>
+            <span
+              style={Object {}}
+            >
+              
+
+            </span>
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              2
+            </span>
+            
+
+          </code>
+        </pre>
+        <pre>
+          <code>
+            code block without language
+
+          </code>
+        </pre>
+        <p>
+          <code>
+            single line codeblock
+          </code>
+        </p>
+      </div>
+      <hr />
+      <div
+        className="tutorial-next"
+      >
+        <a
+          className="bx--link"
+          href=""
+          onClick={[Function]}
+        >
+          → a3
+        </a>
+      </div>
     </div>
   </div>
 </div>
@@ -171,6 +489,111 @@ exports[`TutorialPage component should render the expected snapshot 1`] = `
               src="../resources/tutorials/some/file/image/within/link"
             />
           </a>
+        </p>
+        <pre
+          style={
+            Object {
+              "background": "white",
+              "color": "#4d4d4c",
+              "display": "block",
+              "overflowX": "auto",
+              "padding": "0.5em",
+            }
+          }
+        >
+          <code
+            className="language-typescript"
+            style={
+              Object {
+                "whiteSpace": "pre",
+              }
+            }
+          >
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              1
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#8959a8",
+                }
+              }
+            >
+              const
+            </span>
+            <span
+              style={Object {}}
+            >
+               astring: 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#f5871f",
+                }
+              }
+            >
+              string
+            </span>
+            <span
+              style={Object {}}
+            >
+               = 
+            </span>
+            <span
+              style={
+                Object {
+                  "color": "#718c00",
+                }
+              }
+            >
+              "string"
+            </span>
+            <span
+              style={Object {}}
+            >
+              
+
+            </span>
+            <span
+              className="comment linenumber react-syntax-highlighter-line-number"
+              style={
+                Object {
+                  "display": "inline-block",
+                  "minWidth": "1em",
+                  "paddingRight": "1em",
+                  "textAlign": "right",
+                  "userSelect": "none",
+                }
+              }
+            >
+              2
+            </span>
+            
+
+          </code>
+        </pre>
+        <pre>
+          <code>
+            code block without language
+
+          </code>
+        </pre>
+        <p>
+          <code>
+            single line codeblock
+          </code>
         </p>
       </div>
       <hr />

--- a/packages/blockchain-ui/package-lock.json
+++ b/packages/blockchain-ui/package-lock.json
@@ -1922,6 +1922,14 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/hast": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.1.tgz",
+			"integrity": "sha512-viwwrB+6xGzw+G1eWpF9geV3fnsDgXqHG+cqgiHrvQfDUW5hzhCyV7Sy3UJxhfRFBsgky2SSW33qi/YrIkjX5Q==",
+			"requires": {
+				"@types/unist": "*"
+			}
+		},
 		"@types/history": {
 			"version": "4.7.5",
 			"resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
@@ -2063,6 +2071,14 @@
 				"@types/history": "*",
 				"@types/react": "*",
 				"@types/react-router": "*"
+			}
+		},
+		"@types/react-syntax-highlighter": {
+			"version": "13.5.0",
+			"resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-13.5.0.tgz",
+			"integrity": "sha512-U7DrUaQRv3b+fsbPXMf7vC21K7DOkdNCQtp14Wm0Z5YLI9fPhndN4YTZ9eVXwmAivIg6lZ3YBVtGYucAS3H76A==",
+			"requires": {
+				"@types/react": "*"
 			}
 		},
 		"@types/react-test-renderer": {
@@ -4307,6 +4323,17 @@
 			"integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
 			"dev": true
 		},
+		"clipboard": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
+			"integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
+			"optional": true,
+			"requires": {
+				"good-listener": "^1.2.2",
+				"select": "^1.1.2",
+				"tiny-emitter": "^2.0.0"
+			}
+		},
 		"cliui": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -5523,6 +5550,12 @@
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
 			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
 			"dev": true
+		},
+		"delegate": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+			"optional": true
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -7027,6 +7060,14 @@
 			"integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ==",
 			"dev": true
 		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
+			}
+		},
 		"faye-websocket": {
 			"version": "0.10.0",
 			"resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -7325,6 +7366,11 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -7678,6 +7724,15 @@
 				"minimatch": "~3.0.2"
 			}
 		},
+		"good-listener": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+			"optional": true,
+			"requires": {
+				"delegate": "^3.1.2"
+			}
+		},
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
@@ -7826,6 +7881,11 @@
 			"resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-1.1.0.tgz",
 			"integrity": "sha512-oUmNua0bFbdrD/ELDSSEadRVtWZOf3iF6Lbv81naqsIV99RnSCieTbWuWCY8BAeEfKJTKl0gRdokv+dELutHGQ=="
 		},
+		"hast-util-parse-selector": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
+			"integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
+		},
 		"hast-util-sanitize": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/hast-util-sanitize/-/hast-util-sanitize-3.0.0.tgz",
@@ -7856,6 +7916,18 @@
 			"resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-1.0.4.tgz",
 			"integrity": "sha512-I5GTdSfhYfAPNztx2xJRQpG8cuDSNt599/7YUn7Gx/WxNMsG+a835k97TDkFgk123cwjfwINaZknkKkphx/f2A=="
 		},
+		"hastscript": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/hastscript/-/hastscript-6.0.0.tgz",
+			"integrity": "sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==",
+			"requires": {
+				"@types/hast": "^2.0.0",
+				"comma-separated-tokens": "^1.0.0",
+				"hast-util-parse-selector": "^2.0.0",
+				"property-information": "^5.0.0",
+				"space-separated-tokens": "^1.0.0"
+			}
+		},
 		"he": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -7867,6 +7939,11 @@
 			"resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
 			"integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
 			"dev": true
+		},
+		"highlight.js": {
+			"version": "10.3.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.3.1.tgz",
+			"integrity": "sha512-jeW8rdPdhshYKObedYg5XGbpVgb1/DT4AHvDFXhkU7UnGSIjy9kkJ7zHG7qplhFHMitTSzh5/iClKQk3Kb2RFQ=="
 		},
 		"history": {
 			"version": "4.10.1",
@@ -10974,6 +11051,15 @@
 				"tslib": "^1.10.0"
 			}
 		},
+		"lowlight": {
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.16.0.tgz",
+			"integrity": "sha512-ECLdzIJvBEjK4ef51sWiGZyz21yx4IEPaF/62DRxLehoOHkWqN3OsLB1GUMfc6Mcf87rR5eW7z6lI9cNEXZDsQ==",
+			"requires": {
+				"fault": "^1.0.0",
+				"highlight.js": "~10.3.0"
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -13979,6 +14065,14 @@
 				}
 			}
 		},
+		"prismjs": {
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.22.0.tgz",
+			"integrity": "sha512-lLJ/Wt9yy0AiSYBf212kK3mM5L8ycwlyTlSxHBAneXLR0nzFMlZ5y7riFPF3E33zXOF2IH95xdY5jIyZbM9z/w==",
+			"requires": {
+				"clipboard": "^2.0.0"
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -14789,6 +14883,18 @@
 				}
 			}
 		},
+		"react-syntax-highlighter": {
+			"version": "15.2.1",
+			"resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-15.2.1.tgz",
+			"integrity": "sha512-xrSfqX5Rztf9x4Fa6W+DbbKaJmi5zvh+tAvG2MnktZPDLeX/iMkumwxJdGYn5M1jM3d4+EJTloVAB8UvD7O0nA==",
+			"requires": {
+				"@babel/runtime": "^7.3.1",
+				"highlight.js": "^10.1.1",
+				"lowlight": "^1.14.0",
+				"prismjs": "^1.21.0",
+				"refractor": "^3.1.0"
+			}
+		},
 		"react-test-renderer": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
@@ -14917,6 +15023,16 @@
 			"resolved": "https://registry.npmjs.org/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz",
 			"integrity": "sha1-dJrO7H8/34tj+SegSAnpDFwLNGA=",
 			"dev": true
+		},
+		"refractor": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/refractor/-/refractor-3.2.0.tgz",
+			"integrity": "sha512-hSo+EyMIZTLBvNNgIU5lW4yjCzNYMZ4dcEhBq/3nReGfqzd2JfVhdlPDfU9rEsgcAyWx+OimIIUoL4ZU7NtYHQ==",
+			"requires": {
+				"hastscript": "^6.0.0",
+				"parse-entities": "^2.0.0",
+				"prismjs": "~1.22.0"
+			}
 		},
 		"regenerate": {
 			"version": "1.4.0",
@@ -16122,6 +16238,12 @@
 					}
 				}
 			}
+		},
+		"select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+			"optional": true
 		},
 		"select-hose": {
 			"version": "2.0.0",
@@ -17660,6 +17782,12 @@
 			"resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
 			"integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
 			"dev": true
+		},
+		"tiny-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+			"optional": true
 		},
 		"tiny-invariant": {
 			"version": "1.1.0",

--- a/packages/blockchain-ui/package.json
+++ b/packages/blockchain-ui/package.json
@@ -98,11 +98,13 @@
     },
     "dependencies": {
         "@types/react-html-parser": "^2.0.1",
+        "@types/react-syntax-highlighter": "^13.5.0",
         "fs-extra": "^7.0.1",
         "react": "16.10.2",
         "react-dom": "16.10.2",
         "react-html-parser": "^2.0.2",
         "react-router-dom": "^4.3.1",
+        "react-syntax-highlighter": "^15.2.1",
         "remark-html": "^13.0.1",
         "remark-parse": "^8.0.3",
         "unified": "^9.2.0"


### PR DESCRIPTION
### Summary
* Add syntax highlighting to the React Tutorial view, see screenshots.
* Adds `react-syntax-highlighter` as a dependency.
Note: As it uses JavaScript to detect the theme, it won't automatically update the syntax colour if you change your VSCode theme with the tutorial open. If you close it and reopen it the syntax colour should be updated.

### Testing
* Modified and ran the tests

### Screenshots
Light:
![image](https://user-images.githubusercontent.com/17385115/96608969-e3036180-12f1-11eb-813a-5849fce5cf9d.png)

Dark:
![image](https://user-images.githubusercontent.com/17385115/96609023-f6163180-12f1-11eb-8962-2e0674e8cdcd.png)


Signed-off-by: James Wallis <james.wallis1@ibm.com>