### PR TITLE
[v2] - force pdf creation - take2

### DIFF
--- a/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a9.md
+++ b/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a9.md
@@ -7,7 +7,6 @@ In Hyperledger Fabric, smart contracts can generate events that can be received 
 In order to successfully complete this tutorial, you must have first completed tutorial <a href='./a5.md'>A5: Invoking a smart contract from an external application</a> in the active workspace. It is desirable to have completed up to tutorial <a href='./a8.md'>A8: Testing a smart contract</a>.
 
 <img src="./images/bullet.png" alt="[]"></img> &nbsp;&nbsp;&nbsp;&nbsp; `A9.1`: &nbsp;&nbsp;&nbsp;&nbsp;
-
 Expand the first section below to get started.
 
 ---


### PR DESCRIPTION
Removing an empty line from a tutorial md file to force the pipeline to trigger the md 2 pdf build after merge.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>