### PR TITLE
Edit path traversal for mdToPdf script

### DIFF
--- a/packages/blockchain-extension/scripts/mdToPdf.sh
+++ b/packages/blockchain-extension/scripts/mdToPdf.sh
@@ -25,4 +25,4 @@ for D in `find . -mindepth 1 -maxdepth 1 -type d`; do
     cd ../
 done
 
-git checkout ../package.json && git checkout ../package-lock.json
+git checkout ../../package.json && git checkout ../../package-lock.json


### PR DESCRIPTION
https://dev.azure.com/IBPComposer/IBM-Blockchain-VSCode-Extension/_build/results?buildId=3895&view=logs&j=c6780466-bb29-5adb-718c-225932c7a2d4&t=802d76b7-30c6-51ee-b080-10cbf36e444a failed as the path is incorrect for `package.json` and `package-lock.json`. 
Signed-off-by: James Wallis <james.wallis1@ibm.com>