### PR TITLE
Update Transaction view smart contract on a contract update (Merge for #2812)

### DIFF
--- a/packages/blockchain-extension/extension/commands/openTransactionViewCommand.ts
+++ b/packages/blockchain-extension/extension/commands/openTransactionViewCommand.ts
@@ -22,17 +22,11 @@ import { InstantiatedTreeItem } from '../explorer/model/InstantiatedTreeItem';
 import { IFabricGatewayConnection, FabricSmartContractDefinition, LogType, FabricGatewayRegistryEntry } from 'ibm-blockchain-platform-common';
 import { GlobalState } from '../util/GlobalState';
 import ITransaction from '../interfaces/ITransaction';
+import ISmartContract from '../interfaces/ISmartContract';
 
 interface IAppState {
     gatewayName: string;
-    smartContract: {
-        name: string,
-        version: string,
-        channel: string,
-        label: string,
-        transactions: ITransaction[],
-        namespace: string
-    };
+    smartContract: ISmartContract;
     associatedTxdata: {
         chaincodeName: string,
         channelName: string,
@@ -41,15 +35,53 @@ interface IAppState {
     preselectedTransaction: ITransaction;
 }
 
+export async function getSmartContract(connection: IFabricGatewayConnection, smartContractName: string, smartContractVersion?: string): Promise<ISmartContract> {
+    let contract: { name: string, contractInstance: {}, transactions: ITransaction[], info: {} };
+    let data: ISmartContract;
+    let selectedSmartContract: ISmartContract;
+
+    const channelMap: Map<string, Array<string>> = await connection.createChannelMap();
+
+    for (const [thisChannelName] of channelMap) {
+        const chaincodes: Array<FabricSmartContractDefinition> = await connection.getInstantiatedChaincode(thisChannelName); // returns array of objects
+        const channelPeerInfo: {name: string, mspID: string}[] = await connection.getChannelPeersInfo(thisChannelName);
+        const peerNames: string[] = channelPeerInfo.map((peer: {name: string, mspID: string}) => {
+            return peer.name;
+        });
+        for (const chaincode of chaincodes) {
+            const metadataObj: any = await connection.getMetadata(chaincode.name, thisChannelName);
+            const contractsObject: any = metadataObj.contracts;
+            Object.keys(contractsObject).forEach((key: string) => {
+                if (key !== 'org.hyperledger.fabric' && (contractsObject[key].transactions.length > 0)) {
+                    // Always match name, match version if smartContractVersion is supplied
+                    if ((chaincode.name === smartContractName) && (!smartContractVersion || chaincode.version === smartContractVersion)) {
+                        contract = metadataObj.contracts[key];
+                        data = {
+                            name: chaincode.name,
+                            version: chaincode.version,
+                            channel: thisChannelName,
+                            label: chaincode.name + '@' + chaincode.version,
+                            transactions: contract.transactions,
+                            namespace: contract.name,
+                            peerNames
+                        };
+                        selectedSmartContract = data;
+                        return;
+                    }
+                }
+            });
+        }
+    }
+    return selectedSmartContract;
+}
+
 export async function openTransactionView(treeItem?: InstantiatedTreeItem, selectedTransactionName?: string): Promise<IAppState> {
     const outputAdapter: VSCodeBlockchainOutputAdapter = VSCodeBlockchainOutputAdapter.instance();
     outputAdapter.log(LogType.INFO, undefined, `Open Transaction View`);
-    let smartContractLabel: string;
-    let contract: { name: string, contractInstance: {}, transactions: ITransaction[], info: {} };
-    let data: { name: string, version: string, channel: string, label: string, transactions: ITransaction[], namespace: string, peerNames: string[] };
+    let smartContractName: string;
+    let smartContractVersion: string;
 
     let connection: IFabricGatewayConnection = FabricGatewayConnectionManager.instance().getConnection();
-
     if (!connection) {
         await vscode.commands.executeCommand(ExtensionCommands.CONNECT_TO_GATEWAY);
         connection = FabricGatewayConnectionManager.instance().getConnection();
@@ -63,59 +95,20 @@ export async function openTransactionView(treeItem?: InstantiatedTreeItem, selec
     const gatewayName: string = gatewayRegistryEntry.name;
 
     if (treeItem) {
-        smartContractLabel = treeItem.name + '@' + treeItem.version;
+        smartContractName = treeItem.name;
+        smartContractVersion = treeItem.version;
     } else {
         const chosenSmartContract: IBlockchainQuickPickItem<{ name: string, channel: string, version: string }> = await UserInputUtil.showClientInstantiatedSmartContractsQuickPick(`Choose a smart contract`, null);
         if (!chosenSmartContract) {
             return;
         }
-        smartContractLabel = chosenSmartContract.data.name + '@' + chosenSmartContract.data.version;
+        smartContractName = chosenSmartContract.data.name;
+        smartContractVersion = chosenSmartContract.data.version;
     }
 
-    const channelMap: Map<string, Array<string>> = await connection.createChannelMap();
+    const selectedSmartContract: ISmartContract = await getSmartContract(connection, smartContractName, smartContractVersion);
 
-    let selectedSmartContract: { name: string, version: string, channel: string, label: string, transactions: ITransaction[], namespace: string };
-    let preselectedTransaction: ITransaction;
-
-    let metadataObj: any = {
-        contracts: {
-            '' : {
-                name: '',
-                transactions: [],
-            }
-        }
-    };
-
-    for (const [thisChannelName] of channelMap) {
-        const chaincodes: Array<FabricSmartContractDefinition> = await connection.getInstantiatedChaincode(thisChannelName); // returns array of objects
-        const channelPeerInfo: {name: string, mspID: string}[] = await connection.getChannelPeersInfo(thisChannelName);
-        const peerNames: string[] = channelPeerInfo.map((peer: {name: string, mspID: string}) => {
-            return peer.name;
-        });
-        for (const chaincode of chaincodes) {
-            metadataObj = await connection.getMetadata(chaincode.name, thisChannelName);
-            const contractsObject: any = metadataObj.contracts;
-            Object.keys(contractsObject).forEach((key: string) => {
-                if (key !== 'org.hyperledger.fabric' && (contractsObject[key].transactions.length > 0)) {
-                    if ((chaincode.name + '@' + chaincode.version) === smartContractLabel) {
-                        contract = metadataObj.contracts[key];
-                        data = {
-                            name: chaincode.name,
-                            version: chaincode.version,
-                            channel: thisChannelName,
-                            label: chaincode.name + '@' + chaincode.version,
-                            transactions: contract.transactions,
-                            namespace: contract.name,
-                            peerNames
-                        };
-                        selectedSmartContract = data;
-                        preselectedTransaction = data.transactions.find(({ name }: { name: string }) => name === selectedTransactionName);
-                        return;
-                    }
-                }
-            });
-        }
-    }
+    const preselectedTransaction: ITransaction = selectedSmartContract && selectedSmartContract.transactions.find(({ name }: { name: string }) => name === selectedTransactionName);
 
     let associatedTxdata: {chaincodeName: string, channelName: string, transactionDataPath: string};
     if (gatewayRegistryEntry.transactionDataDirectories) {

--- a/packages/blockchain-extension/extension/fabric/FabricGatewayConnectionManager.ts
+++ b/packages/blockchain-extension/extension/fabric/FabricGatewayConnectionManager.ts
@@ -12,10 +12,12 @@
  * limitations under the License.
 */
 
+import * as vscode from 'vscode';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { EventEmitter } from 'events';
 import { FabricWalletRegistryEntry, IFabricGatewayConnection, FabricGatewayRegistryEntry } from 'ibm-blockchain-platform-common';
+import { TransactionView } from '../webview/TransactionView';
 
 export class FabricGatewayConnectionManager extends EventEmitter {
 
@@ -76,6 +78,11 @@ export class FabricGatewayConnectionManager extends EventEmitter {
             this.gatewayRegistryEntry = null;
         }
         this.emit('disconnected');
+
+        const panel: vscode.WebviewPanel = TransactionView.panel;
+        if (panel) {
+            TransactionView.closeView();
+        }
     }
 
     public getConnectionIdentity(): string {

--- a/packages/blockchain-extension/extension/interfaces/ISmartContract.ts
+++ b/packages/blockchain-extension/extension/interfaces/ISmartContract.ts
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+import ITransaction from './ITransaction';
+
+interface ISmartContract {
+    name: string;
+    version: string;
+    channel: string;
+    label: string;
+    transactions: ITransaction[];
+    namespace: string;
+    peerNames: string[]; // change this to not any
+}
+
+export default ISmartContract;

--- a/packages/blockchain-extension/test/commands/deployCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/deployCommand.test.ts
@@ -89,7 +89,7 @@ describe('deployCommand', () => {
 
             const map: Map<string, Array<string>> = new Map<string, Array<string>>();
             map.set('myChannel', ['peerOne']);
-            fabricClientConnectionMock.createChannelMap.resolves({channelMap: map, v1channels: []});
+            fabricClientConnectionMock.createChannelMap.resolves(map);
             fabricConnectionManager = FabricGatewayConnectionManager.instance();
             getConnectionStub = mySandBox.stub(fabricConnectionManager, 'getConnection').returns(fabricClientConnectionMock);
             fabricConnectionManager = FabricGatewayConnectionManager.instance();

--- a/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
+++ b/packages/blockchain-extension/test/util/ExtensionUtil.test.ts
@@ -1931,7 +1931,7 @@ describe('ExtensionUtil Tests', () => {
 
             });
 
-            it('should should handle any errors when initializing', async () => {
+            it('should handle any errors when initializing', async () => {
                 runtimeManager['runtimes'].clear();
                 getSettingsStub.withArgs(SettingConfigurations.EXTENSION_BYPASS_PREREQS).returns(false);
                 const error: Error = new Error('Unable to initialize');

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -448,6 +448,30 @@ describe('TransactionInputContainer component', () => {
             component.find('#evaluate-button').at(1).simulate('click');
             postToVSCodeStub.should.not.have.been.called;
         });
+
+        it('should clear the activeTransaction if a new/updated smartContract is supplied and the activeTransaction no longer exists', () => {
+            const newContract: ISmartContract = {
+                ...greenContract,
+                transactions: [transactionTwo],
+            };
+            component = updateManualInputValues(component, 'transactionOne', undefined, undefined);
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+            let dropdown: any = component.find(transactionNameSelector);
+            expect(manualInputState.activeTransaction).toHaveProperty('name', 'transactionOne');
+            expect(dropdown.prop('selectedItem')).toEqual('transactionOne');
+
+            act(() => {
+                component.setProps({ smartContract: newContract });
+            });
+            component = component.update();
+
+            dropdown = component.find(transactionNameSelector);
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(dropdown.prop('selectedItem')).toEqual('Select the transaction name');
+            expect(manualInputState.activeTransaction).toEqual({ name: '', parameters: [], returns: { type: '' }, tag: [] });
+        });
     });
 
     describe('Data file input', () => {

--- a/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
@@ -75,6 +75,22 @@ describe('TransactionPage component', () => {
         expect(component).toMatchSnapshot();
     });
 
+    it('should update the smartContract when a new one is passed down through props', async () => {
+        const componentDidUpdateSpy: sinon.SinonSpy = mySandBox.spy(TransactionPage.prototype, 'componentDidUpdate');
+        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        expect(component.state()).toHaveProperty('smartContract', greenContract);
+
+        const newContract: ISmartContract =  { ...greenContract, name: 'updatedContract' };
+        component.setProps({
+            transactionViewData: {
+                smartContract: newContract,
+            }
+        });
+
+        componentDidUpdateSpy.should.have.been.called;
+        component.state().smartContract.should.equal(newContract);
+    });
+
     it('should update the associatedTxdata when something new is passed down through props', async () => {
         const componentDidUpdateSpy: sinon.SinonSpy = mySandBox.spy(TransactionPage.prototype, 'componentDidUpdate');
         const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
@@ -82,6 +98,7 @@ describe('TransactionPage component', () => {
 
         component.setProps({
             transactionViewData: {
+                smartContract: greenContract,
                 associatedTxdata: 'new data',
             }
         });

--- a/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FunctionComponent, SetStateAction, useState } from 'react';
+import React, { Dispatch, FunctionComponent, SetStateAction, useEffect, useState } from 'react';
 import './TransactionManualInput.scss';
 import { Dropdown, TextArea } from 'carbon-components-react';
 import ITransaction from '../../../interfaces/ITransaction';
@@ -33,10 +33,24 @@ function convertJSONToArgs(transactionArguments: string): Array<string> {
     return array;
 }
 
+const getInitialUnparsedArgsFromTransaction: any = (transaction: ITransaction, transactionArguments: Array<string>): string => {
+    if (transaction && transaction.name !== '' && transaction.parameters && transaction.parameters.length > 0) {
+        return convertArgsToJSON(transaction.parameters, transactionArguments);
+    }
+    return '';
+};
+
 const TransactionManualInput: FunctionComponent<IProps> = ({ smartContract, manualInputState, setManualInput }) => {
     const { activeTransaction, transactionArguments, transientData } = manualInputState;
 
-    const [unparsedArgs, setUnparsedArgs] = useState(activeTransaction && activeTransaction.parameters ? convertArgsToJSON(activeTransaction.parameters, transactionArguments) : '');
+    const [unparsedArgs, setUnparsedArgs] = useState(getInitialUnparsedArgsFromTransaction(activeTransaction, transactionArguments));
+
+    useEffect(() => {
+        const newUnparsedArgs: string = getInitialUnparsedArgsFromTransaction(activeTransaction, transactionArguments);
+        if (newUnparsedArgs !== unparsedArgs) {
+            setUnparsedArgs(newUnparsedArgs);
+        }
+    }, [activeTransaction, transactionArguments, unparsedArgs]);
 
     function setActiveTransaction(data: any): void {
         const { transactions } = smartContract;

--- a/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
+++ b/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
@@ -34,7 +34,14 @@ class TransactionPage extends Component<IProps, IState> {
     }
 
     componentDidUpdate(prevProps: IProps): void {
-        const { transactionViewData: { associatedTxdata, txdataTransactions }, transactionOutput } = this.props;
+        const { transactionViewData: { associatedTxdata, txdataTransactions, smartContract }, transactionOutput } = this.props;
+
+        if (prevProps.transactionViewData.smartContract !== smartContract) {
+            this.setState({
+                smartContract,
+            });
+        }
+
         if (prevProps.transactionViewData.associatedTxdata !== associatedTxdata) {
             this.setState({
                 associatedTxdata,


### PR DESCRIPTION
Updates the Transaction View's smart contract when a contract is updated, meaning that if an updated smart contract has a new function it will be shown and if it

 Clear or remain selected for the previously selected item depending on whether or not the function still exists
 Clear arguments OR persist them if they have the same parameters (Clears)
 Clear transient data OR keep it (it's not dependant on the smart contract) (Persists)
 Tests to get 100% coverage
 Potentially close view when gateway is disconnected - #2818

Signed-off-by: James Wallis <j@wallis.dev>