### PR TITLE
Add ability to change smartContract/transaction while the Transaction View is open

### DIFF
--- a/packages/blockchain-extension/extension/webview/TransactionView.ts
+++ b/packages/blockchain-extension/extension/webview/TransactionView.ts
@@ -56,6 +56,16 @@ export class TransactionView extends ReactView {
         TransactionView.appState = appState;
     }
 
+    public async openView(keepContext: boolean, viewColumn: vscode.ViewColumn = vscode.ViewColumn.One): Promise<void> {
+        if (TransactionView.panel) {
+            TransactionView.panel.webview.postMessage({
+                transactionViewData: TransactionView.appState,
+            });
+        }
+
+        return super.openView(keepContext, viewColumn);
+    }
+
     async handleTransactionMessage(message: {command: string, data: any}, panel: vscode.WebviewPanel): Promise<void> {
         const response: string = await vscode.commands.executeCommand(message.command, undefined, undefined, undefined, message.data);
         panel.webview.postMessage({

--- a/packages/blockchain-extension/test/webview/TransactionView.test.ts
+++ b/packages/blockchain-extension/test/webview/TransactionView.test.ts
@@ -452,4 +452,35 @@ describe('TransactionView', () => {
         should.not.exist(TransactionView.panel);
 
     });
+
+    it('Should call postMessage when openView is called and TransactionView.panel exists', async () => {
+        createWebviewPanelStub.returns({
+            title: 'Transaction Page',
+            webview: {
+                postMessage: postMessageStub,
+                onDidReceiveMessage: mySandBox.stub()
+            },
+            reveal: mySandBox.stub(),
+            dispose: mySandBox.stub(),
+            onDidDispose: mySandBox.stub(),
+            onDidChangeViewState: mySandBox.stub()
+        });
+
+        const transactionView: TransactionView = new TransactionView(context, mockAppState);
+        await transactionView.openView(false);
+        createWebviewPanelStub.should.have.been.called;
+        postMessageStub.should.have.been.calledWith({
+            path: '/transaction',
+            transactionViewData: mockAppState,
+        });
+
+        const updatedContract: ISmartContract = { ...greenContract, name: 'updatedContract' };
+        const newTransactionView: TransactionView = new TransactionView(context, { ...mockAppState, smartContract: updatedContract });
+        await newTransactionView.openView(false);
+        createWebviewPanelStub.should.have.been.called;
+        postMessageStub.should.have.been.calledWith({
+            path: '/transaction',
+            transactionViewData: { ...mockAppState, smartContract: updatedContract },
+        });
+    });
 });

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -472,6 +472,30 @@ describe('TransactionInputContainer component', () => {
             expect(dropdown.prop('selectedItem')).toEqual('Select the transaction name');
             expect(manualInputState.activeTransaction).toEqual({ name: '', parameters: [], returns: { type: '' }, tag: [] });
         });
+
+        it('should update the activeTransaction if a new preselectedTransaction is sent', () => {
+            act(() => {
+                component.setProps({ smartContract: greenContract, preselectedTransaction: transactionOne });
+            });
+            component = component.update();
+
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+            let dropdown: any = component.find(transactionNameSelector);
+            expect(dropdown.prop('selectedItem')).toEqual('transactionOne');
+            expect(manualInputState.activeTransaction).toEqual(transactionOne);
+
+            act(() => {
+                component.setProps({ smartContract: greenContract, preselectedTransaction: transactionTwo });
+            });
+            component = component.update();
+
+            dropdown = component.find(transactionNameSelector);
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(dropdown.prop('selectedItem')).toEqual('transactionTwo');
+            expect(manualInputState.activeTransaction).toEqual(transactionTwo);
+        });
     });
 
     describe('Data file input', () => {

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -473,6 +473,34 @@ describe('TransactionInputContainer component', () => {
             expect(manualInputState.activeTransaction).toEqual({ name: '', parameters: [], returns: { type: '' }, tag: [] });
         });
 
+        it('should clear the activeTransaction if a different smartContract is supplied regardless of whether the activeTransaction exists or not', () => {
+            const newContract: ISmartContract = {
+                ...greenContract,
+                name: 'completelyNewSmartContract'
+            };
+            component = updateManualInputValues(component, 'transactionOne', undefined, undefined);
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputSmartContract: ISmartContract = manualInput.prop('smartContract');
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+            let dropdown: any = component.find(transactionNameSelector);
+            expect(manualInputSmartContract).toHaveProperty('name', greenContract.name);
+            expect(manualInputState.activeTransaction).toHaveProperty('name', 'transactionOne');
+            expect(dropdown.prop('selectedItem')).toEqual('transactionOne');
+
+            act(() => {
+                component.setProps({ smartContract: newContract });
+            });
+            component = component.update();
+
+            dropdown = component.find(transactionNameSelector);
+            manualInput = component.find(TransactionManualInput);
+            manualInputSmartContract = manualInput.prop('smartContract');
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputSmartContract).toHaveProperty('name', newContract.name);
+            expect(dropdown.prop('selectedItem')).toEqual('Select the transaction name');
+            expect(manualInputState.activeTransaction).toEqual({ name: '', parameters: [], returns: { type: '' }, tag: [] });
+        });
+
         it('should update the activeTransaction if a new preselectedTransaction is sent', () => {
             act(() => {
                 component.setProps({ smartContract: greenContract, preselectedTransaction: transactionOne });

--- a/packages/blockchain-ui/src/App.tsx
+++ b/packages/blockchain-ui/src/App.tsx
@@ -44,6 +44,7 @@ class App extends Component<{}, AppState> {
 
     componentDidMount(): void {
         window.addEventListener('message', (event: MessageEvent) => {
+
             const newState: any = {
                 redirectPath: event.data.path
             };

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -45,11 +45,15 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
     const [dataInputTransaction, updateDataInputTransaction] = useState<IDataFileTransaction>({ transactionName: '', transactionLabel: '', txDataFile: '', arguments: [], transientData: {} });
 
     useEffect(() => {
-        if (manualInputState.activeTransaction && manualInputState.activeTransaction.name !== '' && !activeTransactionExists(smartContract, manualInputState.activeTransaction)) {
-                // if the smartContract is changed/updated, only persist the activeTransaction if it still exists
-                updateManualInputState({ ...manualInputState, activeTransaction: emptyTransaction, transactionArguments: [] });
+        const { activeTransaction } = manualInputState;
+        if (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction)) {
+            // if the smartContract is changed/updated, only persist the activeTransaction if it still exists
+            updateManualInputState({ ...manualInputState, activeTransaction: emptyTransaction, transactionArguments: [] });
+        } else if (preselectedTransaction && preselectedTransaction.name && activeTransaction !== preselectedTransaction) {
+            // If the preselectedTransaction is changed, update the activeTransaction. Ignore if the preselectedTransaction is empty
+            updateManualInputState({ ...manualInputState, activeTransaction: preselectedTransaction, transactionArguments: [] });
         }
-    }, [smartContract, manualInputState]);
+    }, [smartContract, manualInputState, preselectedTransaction]);
 
     const submitTransaction: any = (evaluate: boolean): void => {
 

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -45,22 +45,34 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
     // When more is needed, convert it to an object like above
     const [dataInputTransaction, updateDataInputTransaction] = useState<IDataFileTransaction>({ transactionName: '', transactionLabel: '', txDataFile: '', arguments: [], transientData: {} });
 
+    const setManualActiveTransaction: any = (activeTransaction: ITransaction) => {
+        if (activeTransaction !== manualInputState.activeTransaction) {
+            updateManualInputState({ ...manualInputState, activeTransaction, transactionArguments: [] });
+        }
+    };
+
     useEffect(() => {
         const { activeTransaction } = manualInputState;
-        const smartContractChanged: boolean = smartContract.name !== smartContractName;
-        if (smartContractChanged || (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction))) {
+        if (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction)) {
             // if the smartContract is changed/updated, only persist the activeTransaction if it still exists
-            updateManualInputState({ ...manualInputState, activeTransaction: emptyTransaction, transactionArguments: [] });
-        } else if (preselectedTransaction && preselectedTransaction.name && activeTransaction !== preselectedTransaction) {
-            // If the preselectedTransaction is changed, update the activeTransaction. Ignore if the preselectedTransaction is empty
-            updateManualInputState({ ...manualInputState, activeTransaction: preselectedTransaction, transactionArguments: [] });
+            setManualActiveTransaction(emptyTransaction);
         }
+    }, [smartContract, manualInputState.activeTransaction]);
 
+    useEffect(() => {
+        // If the preselectedTransaction is changed, update the activeTransaction. Ignore if the preselectedTransaction is empty
+        if (preselectedTransaction && preselectedTransaction.name) {
+            setManualActiveTransaction(preselectedTransaction);
+        }
+    }, [preselectedTransaction]);
+
+    useEffect(() => {
+        const smartContractChanged: boolean = smartContract.name !== smartContractName;
         if (smartContractChanged) {
             setNewSmartContractName(smartContract.name);
+            setManualActiveTransaction(emptyTransaction);
         }
-
-    }, [smartContract, manualInputState, preselectedTransaction]);
+    }, [smartContract.name]);
 
     const submitTransaction: any = (evaluate: boolean): void => {
 

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -30,6 +30,7 @@ const activeTransactionExists: any = (smartContract: ISmartContract, currentlyAc
 
 const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, associatedTxdata, txdataTransactions, preselectedTransaction }) => {
     const { peerNames } = smartContract;
+    const [smartContractName, setNewSmartContractName] = useState(smartContract.name);
 
     const [isManual, setIsManual] = useState(true);
     const [peerTargetNames, setPeerTargetNames] = useState(peerNames);
@@ -46,19 +47,25 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
 
     useEffect(() => {
         const { activeTransaction } = manualInputState;
-        if (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction)) {
+        const smartContractChanged: boolean = smartContract.name !== smartContractName;
+        if (smartContractChanged || (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction))) {
             // if the smartContract is changed/updated, only persist the activeTransaction if it still exists
             updateManualInputState({ ...manualInputState, activeTransaction: emptyTransaction, transactionArguments: [] });
         } else if (preselectedTransaction && preselectedTransaction.name && activeTransaction !== preselectedTransaction) {
             // If the preselectedTransaction is changed, update the activeTransaction. Ignore if the preselectedTransaction is empty
             updateManualInputState({ ...manualInputState, activeTransaction: preselectedTransaction, transactionArguments: [] });
         }
+
+        if (smartContractChanged) {
+            setNewSmartContractName(smartContract.name);
+        }
+
     }, [smartContract, manualInputState, preselectedTransaction]);
 
     const submitTransaction: any = (evaluate: boolean): void => {
 
         const command: string = evaluate ? ExtensionCommands.EVALUATE_TRANSACTION : ExtensionCommands.SUBMIT_TRANSACTION;
-        const { name: smartContractName, channel: channelName, namespace } = smartContract;
+        const { channel: channelName, namespace } = smartContract;
 
         const data: any = {
             evaluate,


### PR DESCRIPTION
### Summary
* Add ability to change Smart Contract in the Transaction View while it is open
* Add ability to change Transaction while it's open too (using the side menu)

### Testing
* Added UI and Extension tests

Signed-off-by: James Wallis <j@wallis.dev>