### PR TITLE
[merge] transaction view without metadata - 2.1

### DIFF
--- a/packages/blockchain-extension/extension/util/MetadataUtil.ts
+++ b/packages/blockchain-extension/extension/util/MetadataUtil.ts
@@ -24,7 +24,7 @@ export class MetadataUtil {
 
     public static async getTransactionNames(connection: IFabricGatewayConnection, instantiatedChaincodeName: string, channelName: string): Promise<Map<string, string[]> | null> {
         const metadataTransactions: Map<string, any[]> = await this.getTransactions(connection, instantiatedChaincodeName, channelName);
-        if (!metadataTransactions) {
+        if (!metadataTransactions || metadataTransactions.size === 0) {
             return null;
         }
 
@@ -82,8 +82,11 @@ export class MetadataUtil {
                 return;
             }
         } catch (error) {
+            // If the problem was collecting metadata, then we can continue - the extension will deal with contracts without metadata.
             outputAdapter.log(LogType.WARNING, null, `Could not get metadata for smart contract ${instantiatedChaincodeName}. The smart contract may not have been developed with the programming model delivered in Hyperledger Fabric v1.4+ for Java, JavaScript and TypeScript. Error: ${error.message}`);
-            return null;
+            if (!error.message.includes('Transaction function "org.hyperledger.fabric:GetMetadata"')) {
+                return null;
+            }
         }
 
         return contractsMap;

--- a/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
@@ -192,6 +192,36 @@ describe('OpenTransactionViewCommand', () => {
             openViewStub.should.have.been.calledOnce;
         });
 
+        it('should open the transaction web view for a contract without metadata', async () => {
+            const blockchainGatewayExplorerProvider: BlockchainGatewayExplorerProvider = ExtensionUtil.getBlockchainGatewayExplorerProvider();
+            const allChildren: BlockchainTreeItem[] = await blockchainGatewayExplorerProvider.getChildren();
+            const channels: Array<ChannelTreeItem> = await blockchainGatewayExplorerProvider.getChildren(allChildren[2]) as Array<ChannelTreeItem>;
+            const contracts: Array<InstantiatedTreeItem> =  await blockchainGatewayExplorerProvider.getChildren(channels[0]) as Array<InstantiatedTreeItem>;
+            fabricClientConnectionMock.getInstantiatedChaincode.resolves([{ name: 'mySmartContract', version: '0.0.1' }, { name: 'mySmartContract2', version: '0.0.2' }]);
+
+            instantiatedSmartContract = contracts[0];
+            fabricClientConnectionMock.getMetadata.rejects('Transaction function "org.hyperledger.fabric:GetMetadata" did not return any metadata');
+
+            const appstate: IAppState = await vscode.commands.executeCommand(ExtensionCommands.OPEN_TRANSACTION_PAGE, instantiatedSmartContract);
+            appstate.should.deep.equal({
+                associatedTxdata: undefined,
+                gatewayName: 'myGateway',
+                smartContract: {
+                    channel: 'myChannel',
+                    label: 'mySmartContract@0.0.1',
+                    name: 'mySmartContract',
+                    namespace: undefined,
+                    peerNames: ['peerOne', 'peerTwo'],
+                    version: '0.0.1',
+                    transactions: []
+                },
+                preselectedTransaction: undefined,
+            });
+
+            logSpy.should.have.been.calledWith(LogType.INFO, undefined, `Open Transaction View`);
+            openViewStub.should.have.been.calledOnce;
+        });
+
         it('should open the transaction web view through the command', async () => {
             const appstate: IAppState = await vscode.commands.executeCommand(ExtensionCommands.OPEN_TRANSACTION_PAGE);
             appstate.should.deep.equal({

--- a/packages/blockchain-extension/test/util/MetadataUtil.test.ts
+++ b/packages/blockchain-extension/test/util/MetadataUtil.test.ts
@@ -165,9 +165,15 @@ describe('Metadata ConnectionProfileUtil tests', () => {
     });
 
     it('should return null if no transaction names', async () => {
-        fabricClientConnectionMock.getMetadata.rejects(new Error('no metadata here jack'));
+        fabricClientConnectionMock.getMetadata.rejects(new Error('Transaction function "org.hyperledger.fabric:GetMetadata" and some message'));
         const names: Map<string, string[]> = await MetadataUtil.getTransactionNames(fabricClientConnectionMock, 'chaincode', 'channel');
         should.equal(names, null);
+    });
+
+    it('should return empty if no contract names', async () => {
+        fabricClientConnectionMock.getMetadata.rejects(new Error('Transaction function "org.hyperledger.fabric:GetMetadata" and some message'));
+        const names: string[] = await MetadataUtil.getContractNames(fabricClientConnectionMock, 'chaincode', 'channel');
+        names.should.deep.equal([]);
     });
 
     it('should return the Transaction objects', async () => {
@@ -177,9 +183,9 @@ describe('Metadata ConnectionProfileUtil tests', () => {
     });
 
     it('should return null if no transaction objects', async () => {
-        fabricClientConnectionMock.getMetadata.rejects(new Error('no metadata here jack'));
+        fabricClientConnectionMock.getMetadata.rejects(new Error('Transaction function "org.hyperledger.fabric:GetMetadata" and some other message'));
         const transactionsMap: Map<string, any[]> = await MetadataUtil.getTransactions(fabricClientConnectionMock, 'chaincode', 'channel', true);
-        should.equal(transactionsMap, null);
+        transactionsMap.should.deep.equal(new Map());
     });
 
     it('should error if no contracts', async () => {
@@ -193,10 +199,31 @@ describe('Metadata ConnectionProfileUtil tests', () => {
     });
 
     it('should handle error getting metadata', async () => {
-        fabricClientConnectionMock.getMetadata.rejects({ message: `some error` });
+        fabricClientConnectionMock.getMetadata.rejects({ message: 'Transaction function "org.hyperledger.fabric:GetMetadata" and yet other message'});
+        const transactionsMap: Map<string, any[]> = await MetadataUtil.getTransactions(fabricClientConnectionMock, 'chaincode', 'channel');
+        transactionsMap.should.deep.equal(new Map());
+        logSpy.should.have.been.calledOnceWithExactly(LogType.WARNING, null, `Could not get metadata for smart contract chaincode. The smart contract may not have been developed with the programming model delivered in Hyperledger Fabric v1.4+ for Java, JavaScript and TypeScript. Error: Transaction function "org.hyperledger.fabric:GetMetadata" and yet other message`);
+    });
+
+    it('should handle error other than when getting metadata', async () => {
+        getGatewayRegistryEntryStub.resolves(localGateway);
+
+        const activeDebugSessionStub: any = {
+            configuration: {
+                env: {
+                    CORE_CHAINCODE_ID_NAME: 'chaincode:0.0.1'
+                },
+                debugEvent: FabricDebugConfigurationProvider.debugEvent
+            }
+        };
+
+        FabricDebugConfigurationProvider.environmentName = FabricRuntimeUtil.LOCAL_FABRIC;
+
+        debugSessionStub.value(activeDebugSessionStub);
+        mockRuntime.killChaincode.rejects({ message: 'some error'});
         const transactionsMap: Map<string, any[]> = await MetadataUtil.getTransactions(fabricClientConnectionMock, 'chaincode', 'channel');
         should.equal(transactionsMap, null);
-        logSpy.should.have.been.calledOnceWithExactly(LogType.WARNING, null, sinon.match(/Could not get metadata for smart contract chaincode.*some error/));
+        logSpy.should.have.been.calledOnceWithExactly(LogType.WARNING, null, `Could not get metadata for smart contract chaincode. The smart contract may not have been developed with the programming model delivered in Hyperledger Fabric v1.4+ for Java, JavaScript and TypeScript. Error: some error`);
     });
 
     it('should kill the chaincode if running in debug', async () => {

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -20,6 +20,7 @@ chai.should();
 chai.use(sinonChai);
 
 const transactionNameSelector: any = Dropdown;
+const transactionNameUser: any = '#transaction-name';
 const transactionParametersSelector: any = '#arguments-text-area';
 const transientDataSelector: any = '#transient-data-input';
 
@@ -31,11 +32,19 @@ function toggleContentSwitcher(component: any): any {
     return component;
 }
 
-function updateManualInputValues(component: any, transactionName: string | undefined, transactionParameters: string | undefined, transientData: string | undefined): any {
+function updateManualInputValues(component: any, transactionName: string | undefined, transactionParameters: string | undefined, transientData: string | undefined, hasMetadata: boolean = true): any {
     if (transactionName !== undefined) {
-        const transactionInput: any = component.find(transactionNameSelector).at(0);
+        let transactionInput: any;
+        let toModify: any;
+        if (hasMetadata) {
+            transactionInput = component.find(transactionNameSelector).at(0);
+            toModify = { selectedItem: transactionName };
+        } else {
+            transactionInput = component.find(transactionNameUser).at(0);
+            toModify = { currentTarget: { value: transactionName }};
+        }
         act(() => {
-            transactionInput.prop('onChange')({ selectedItem: transactionName });
+            transactionInput.prop('onChange')(toModify);
         });
         component = component.update();
     }
@@ -122,6 +131,16 @@ describe('TransactionInputContainer component', () => {
         peerNames: ['peer1', 'peer2']
     };
 
+    const purpleContract: ISmartContract = {
+        name: 'purpleContract',
+        version: '0.0.1',
+        channel: 'mychannel',
+        label: 'purpleContract@0.0.1',
+        transactions: [],
+        namespace: undefined,
+        peerNames: ['peer1', 'peer2']
+    };
+
     const associatedTxdata: IAssociatedTxdata = {
         chaincodeName: 'chaincodeName',
         channelName: 'channelName',
@@ -155,6 +174,13 @@ describe('TransactionInputContainer component', () => {
     it('should render the expected snapshot', () => {
         const snapshotComponent: any = renderer
             .create(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} txdataTransactions={txdataTransactions} preselectedTransaction={preselectedTransaction} />)
+            .toJSON();
+        expect(snapshotComponent).toMatchSnapshot();
+    });
+
+    it('should render the expected snapshot - contract with no Metadata', () => {
+        const snapshotComponent: any = renderer
+            .create(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} txdataTransactions={txdataTransactions} preselectedTransaction={preselectedTransaction} />)
             .toJSON();
         expect(snapshotComponent).toMatchSnapshot();
     });
@@ -236,14 +262,14 @@ describe('TransactionInputContainer component', () => {
         it('does not generate arguments in the event that the chosen transaction doesn\'t have any parameters', () => {
             component = updateManualInputValues(component, 'transactionTwo', undefined, undefined);
             const textarea: any = component.find(transactionParametersSelector).at(0);
-            expect(textarea.prop('value')).toEqual('');
+            expect(textarea.prop('value')).toEqual('[]');
             expect(textarea.prop('disabled')).toBeFalsy();
         });
 
         it('does not generate arguments in the event that the chosen transaction doesn\'t exist', () => {
             component = updateManualInputValues(component, 'anotherTransaction', undefined, undefined);
             const textarea: any = component.find(transactionParametersSelector).at(0);
-            expect(textarea.prop('value')).toEqual('');
+            expect(textarea.prop('value')).toEqual('[]');
             expect(textarea.prop('disabled')).toBeTruthy();
         });
 
@@ -723,4 +749,253 @@ describe('TransactionInputContainer component', () => {
             });
         });
     });
+
+    describe('Manual input for contracts with no metadata', () => {
+        beforeEach(() => {
+            component = mount(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} txdataTransactions={txdataTransactions} preselectedTransaction={preselectedTransaction}/>);
+        });
+
+        it('updates when the user types a transaction name in the inputText', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transactionArguments).toEqual([]);
+
+            component = updateManualInputValues(component, 'someTransaction', undefined, undefined, false);
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.activeTransaction.name).toEqual('someTransaction');
+
+        });
+
+        it('updates when the user types in the textarea', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transactionArguments).toEqual([]);
+
+            component = updateManualInputValues(component, undefined, '["the value"]', undefined, false);
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transactionArguments).toEqual(['the value']);
+        });
+
+        it('updates when the user types in the textarea with extra commas and whitespaces', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transactionArguments).toEqual([]);
+
+            component = updateManualInputValues(component, undefined, '\n  [\n  ,  \n"the value"\n\n  ,\n ]\n  \n ', undefined, false);
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transactionArguments).toEqual(['the value']);
+        });
+
+        it('updates when the user removes all args from the textarea', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transactionArguments).toEqual([]);
+            component = updateManualInputValues(component, undefined, '["the value"]', undefined), false;
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transactionArguments).toEqual(['the value']);
+            component = updateManualInputValues(component, undefined, '', undefined);
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transactionArguments).toEqual([]);
+        });
+
+        it('updates when the user types in the textarea and keeps empty args if some not empty', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transactionArguments).toEqual([]);
+
+            component = updateManualInputValues(component, undefined, '["the value", ""]', undefined), false;
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transactionArguments).toEqual(['the value', '']);
+        });
+
+        it('updates when the user types in the transient data input box', () => {
+            let manualInput: any = component.find(TransactionManualInput);
+            let manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
+
+            expect(manualInputState.transientData).toEqual('');
+
+            component = updateManualInputValues(component, undefined, undefined, 'some transient data', false);
+
+            manualInput = component.find(TransactionManualInput);
+            manualInputState = manualInput.prop('manualInputState');
+            expect(manualInputState.transientData).toEqual('some transient data');
+        });
+
+        it('should update state when a peer is selected', () => {
+            let multiSelect: any = component.find(MultiSelect);
+            let selectedValues: ITransactionManualInput = multiSelect.prop('initialSelectedItems');
+
+            expect(selectedValues).toEqual([{ id: 'peer1', label: 'peer1' }, { id: 'peer2', label: 'peer2' }]);
+
+            component = updateSharedInputValues(component, [{
+                id: 'peer1',
+                label: 'peer1'
+            }]);
+
+            multiSelect = component.find(MultiSelect);
+            selectedValues = multiSelect.prop('initialSelectedItems');
+            expect(selectedValues).toEqual([{ id: 'peer1', label: 'peer1' }]);
+        });
+
+        it('should attempt to submit a transaction when the submit button is clicked ', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', undefined, false);
+
+            component.find('#submit-button').at(0).simulate('click');
+
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.SUBMIT_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: false,
+                    namespace: undefined,
+                    peerTargetNames: purpleContract.peerNames,
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should attempt to evaluate a transaction when the evaluate button is clicked', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', undefined, false);
+
+            component.find('#evaluate-button').at(1).simulate('click');
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.EVALUATE_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: true,
+                    namespace: undefined,
+                    peerTargetNames: purpleContract.peerNames,
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should attempt to submit a transaction with transient data when the submit button is clicked ', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', '{"some": "data"}', false);
+
+            component.find('#submit-button').at(1).simulate('click');
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.SUBMIT_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: false,
+                    namespace: undefined,
+                    peerTargetNames: purpleContract.peerNames,
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '{"some": "data"}',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should attempt to evaluate a transaction with transient data when the evaluate button is clicked', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', '{"some": "data"}', false);
+
+            component.find('#evaluate-button').at(1).simulate('click');
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.EVALUATE_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: true,
+                    namespace: undefined,
+                    peerTargetNames: purpleContract.peerNames,
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '{"some": "data"}',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should attempt to submit a transaction with custom peers when the submit button is clicked', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', '{"some": "data"}', false);
+
+            component = updateSharedInputValues(component, [{
+                id: 'peer1',
+                label: 'peer1'
+            }]);
+
+            component.find('#submit-button').at(1).simulate('click');
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.SUBMIT_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: false,
+                    namespace: undefined,
+                    peerTargetNames: ['peer1'],
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '{"some": "data"}',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should attempt to submit a transaction with custom peers when the evaluate button is clicked', () => {
+            component = updateManualInputValues(component, 'transactionOne', '["Purple"]', '{"some": "data"}', false);
+
+            component = updateSharedInputValues(component, [{
+                id: 'peer1',
+                label: 'peer1'
+            }]);
+
+            component.find('#evaluate-button').at(1).simulate('click');
+            postToVSCodeStub.should.have.been.calledOnceWithExactly({
+                command: ExtensionCommands.EVALUATE_TRANSACTION,
+                data: {
+                    args: ['Purple'],
+                    channelName: 'mychannel',
+                    evaluate: true,
+                    namespace: undefined,
+                    peerTargetNames: ['peer1'],
+                    smartContract: 'purpleContract',
+                    transactionName: 'transactionOne',
+                    transientData: '{"some": "data"}',
+                    txDataFile: undefined,
+                }
+            });
+        });
+
+        it('should not submit if no transaction name has been introduced as the submit button is disabled', () => {
+            component = updateManualInputValues(component, undefined, '["Purple"]', '{"some": "data"}', false);
+            component.find('#submit-button').at(1).simulate('click');
+            postToVSCodeStub.should.not.have.been.called;
+        });
+
+        it('should not submit if no transaction name has been introduced as the evaluate button is disabled', () => {
+            component = updateManualInputValues(component, undefined, '["Purple"]', '{"some": "data"}', false);
+            component.find('#evaluate-button').at(1).simulate('click');
+            postToVSCodeStub.should.not.have.been.called;
+        });
+    });
+
 });

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionInputContainer.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionInputContainer.test.tsx.snap
@@ -1,5 +1,253 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TransactionInputContainer component should render the expected snapshot - contract with no Metadata 1`] = `
+Array [
+  <div
+    className="bx--content-switcher transaction-input-content-switch"
+    onChange={[Function]}
+    role="tablist"
+    selectionMode="manual"
+  >
+    <button
+      aria-selected={true}
+      className="bx--content-switcher-btn bx--content-switcher--selected"
+      data-testid="content-switch-manual"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="tab"
+      tabIndex="0"
+    >
+      <span
+        className="bx--content-switcher__label"
+      >
+        Manual input
+      </span>
+    </button>
+    <button
+      aria-selected={false}
+      className="bx--content-switcher-btn"
+      data-testid="content-switch-data"
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="tab"
+      tabIndex="-1"
+    >
+      <span
+        className="bx--content-switcher__label"
+      >
+        Transaction data directory
+      </span>
+    </button>
+  </div>,
+  <form
+    className="bx--form"
+    id="create-txn-form"
+  >
+     
+    <div
+      className="bx--form-item bx--text-input-wrapper"
+    >
+      <label
+        className="bx--label"
+        htmlFor="transaction-name"
+      >
+        Transaction name
+      </label>
+      <div
+        className="bx--text-input__field-wrapper"
+        data-invalid={null}
+      >
+        <input
+          className="bx--text-input bx--text__input"
+          disabled={false}
+          id="transaction-name"
+          onChange={[Function]}
+          onClick={[Function]}
+          type="text"
+        />
+      </div>
+    </div>
+    <div
+      className="bx--form-item"
+    >
+      <label
+        className="bx--label bx--label--disabled"
+        htmlFor="arguments-text-area"
+      >
+        Transaction arguments
+      </label>
+      <div
+        className="bx--text-area__wrapper"
+        data-invalid={null}
+      >
+        <textarea
+          aria-describedby={null}
+          aria-invalid={null}
+          className="bx--text-area"
+          cols={50}
+          disabled={true}
+          id="arguments-text-area"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder=""
+          rows={4}
+          value="[]"
+        />
+      </div>
+    </div>
+    <div
+      className="bx--form-item"
+    >
+      <label
+        className="bx--label"
+        htmlFor="transient-data-input"
+      >
+        Transient data (optional)
+      </label>
+      <div
+        className="bx--text-area__wrapper"
+        data-invalid={null}
+      >
+        <textarea
+          aria-describedby={null}
+          aria-invalid={null}
+          className="bx--text-area"
+          cols={50}
+          disabled={false}
+          id="transient-data-input"
+          onChange={[Function]}
+          onClick={[Function]}
+          placeholder=""
+          rows={4}
+          value=""
+        />
+      </div>
+    </div>
+    <div
+      className="bx--multi-select__wrapper bx--list-box__wrapper"
+    >
+      <span
+        className="bx--label"
+        id="multiselect-label-2"
+      >
+        Target specific peer (optional)
+      </span>
+      <div
+        className="bx--multi-select bx--multi-select--selected bx--list-box"
+        id="peer-select"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+      >
+        <div
+          aria-controls={null}
+          aria-disabled={false}
+          aria-expanded={false}
+          aria-haspopup={true}
+          aria-labelledby="multiselect-label-2 multiselect-field-label-2"
+          aria-owns={null}
+          className="bx--list-box__field"
+          data-toggle={true}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="button"
+          tabIndex="0"
+          type="button"
+        >
+          <div
+            aria-label="Clear Selection"
+            className="bx--list-box__selection bx--tag--filter bx--list-box__selection--multi"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="button"
+            tabIndex={0}
+            title="Clear all selected items"
+          >
+            2
+            <svg
+              aria-hidden={true}
+              focusable="false"
+              height={16}
+              preserveAspectRatio="xMidYMid meet"
+              viewBox="0 0 32 32"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"
+              />
+            </svg>
+          </div>
+          <span
+            className="bx--list-box__label"
+            id="multiselect-field-label-2"
+          >
+            Select peers
+          </span>
+          <div
+            className="bx--list-box__menu-icon"
+          >
+            <svg
+              aria-label="Open menu"
+              focusable="false"
+              height={16}
+              name="chevron--down"
+              preserveAspectRatio="xMidYMid meet"
+              role="img"
+              viewBox="0 0 16 16"
+              width={16}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <polygon
+                points="8,11 3,6 3.7,5.3 8,9.6 12.3,5.3 13,6"
+              />
+              <title>
+                Open menu
+              </title>
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <fieldset
+      className="bx--fieldset"
+      id="submit-and-evaluate-buttons"
+    >
+      <legend
+        className="bx--label"
+      >
+        
+      </legend>
+      <div
+        className="submit-txn-button-container"
+      >
+        <button
+          className="submit-txn-button bx--btn bx--btn--secondary bx--btn--disabled"
+          disabled={true}
+          id="evaluate-button"
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          Evaluate transaction
+        </button>
+        <button
+          className="submit-txn-button bx--btn bx--btn--primary bx--btn--disabled"
+          disabled={true}
+          id="submit-button"
+          onClick={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          Submit transaction
+        </button>
+      </div>
+    </fieldset>
+     
+  </form>,
+]
+`;
+
 exports[`TransactionInputContainer component should render the expected snapshot 1`] = `
 Array [
   <div
@@ -131,7 +379,7 @@ Array [
           onClick={[Function]}
           placeholder=""
           rows={4}
-          value=""
+          value="[]"
         />
       </div>
     </div>

--- a/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionPage.test.tsx.snap
+++ b/packages/blockchain-ui/enzyme/tests/__snapshots__/TransactionPage.test.tsx.snap
@@ -180,7 +180,7 @@ exports[`TransactionPage component should render the expected snapshot 1`] = `
                   onClick={[Function]}
                   placeholder=""
                   rows={4}
-                  value=""
+                  value="[]"
                 />
               </div>
             </div>

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -53,7 +53,7 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
 
     useEffect(() => {
         const { activeTransaction } = manualInputState;
-        if (activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction)) {
+        if (smartContract.namespace !== undefined && activeTransaction && activeTransaction.name !== '' && !activeTransactionExists(smartContract, activeTransaction)) {
             // if the smartContract is changed/updated, only persist the activeTransaction if it still exists
             setManualActiveTransaction(emptyTransaction);
         }

--- a/packages/blockchain-ui/src/interfaces/ISmartContract.ts
+++ b/packages/blockchain-ui/src/interfaces/ISmartContract.ts
@@ -6,7 +6,7 @@ interface ISmartContract {
     channel: string;
     label: string;
     transactions: Array<ITransaction>;
-    namespace: string;
+    namespace: string | undefined;
     peerNames: string[];
 }
 


### PR DESCRIPTION
Closes #2832 

To test:

- Using the v1 extension, create a local fabric (ansible)
- Install and instantiate low level go fabcar contract.
- Using this PR (merge extension), connect to the gateway of the v1 local fabric using the connection profile (connection profile json in `~/.fabric-vscode/environments/<yourlocalfabric>/gateways/Org1/Org1.json`)
- Test the new feature.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>