### PR TITLE
[merge] allow import of v1 and v2 package with same name and version

### DIFF
--- a/packages/blockchain-extension/extension/commands/importSmartContractPackageCommand.ts
+++ b/packages/blockchain-extension/extension/commands/importSmartContractPackageCommand.ts
@@ -61,6 +61,7 @@ export async function importSmartContractPackageCommand(): Promise<void> {
         }
 
         const newName: string = result[1];
+        const newExt: string = result[2];
 
         let existingPackages: string[] = await fs.readdir(resolvedPkgDir);
 
@@ -71,11 +72,14 @@ export async function importSmartContractPackageCommand(): Promise<void> {
                 return false;
             }
 
-            return newName === existingName[1];
+            const existingIsCds: boolean = existingName[2] === '.cds';
+            const newIsCds: boolean = newExt === '.cds';
+            return newName === existingName[1] && existingIsCds === newIsCds;
         });
 
         if (existingPackages.length > 0) {
-            throw new Error(`Package with name ${newName} already exists`);
+            const extText: string = newExt === nameRegex.exec(existingPackages[0])[2] ? 'same' : 'equivalent';
+            throw new Error(`Package with name ${newName} and ${extText} file extension already exists`);
         }
 
         await fs.copy(packagePath, resolvedPkgPath);

--- a/packages/blockchain-extension/extension/commands/packageSmartContractCommand.ts
+++ b/packages/blockchain-extension/extension/commands/packageSmartContractCommand.ts
@@ -126,7 +126,11 @@ export async function packageSmartContract(workspace?: vscode.WorkspaceFolder, o
             // Determine the filename of the new package.
             const pkgFileExtension: string = (fabricVersion === 1) ? 'cds' : 'tar.gz';
             const pkgFile: string = path.join(resolvedPkgDir, `${properties.workspacePackageName}@${properties.workspacePackageVersion}.${pkgFileExtension}`);
-            const pkgFileExists: boolean = await fs.pathExists(pkgFile);
+            let pkgFileExists: boolean = await fs.pathExists(pkgFile);
+            if (!pkgFileExists && fabricVersion === 2) {
+                const altPkgFile: string = path.join(resolvedPkgDir, `${properties.workspacePackageName}@${properties.workspacePackageVersion}.tgz`);
+                pkgFileExists = await fs.pathExists(altPkgFile);
+            }
             if (pkgFileExists) {
                 if (language === 'golang') {
                     throw new Error('Package with name and version already exists. Please input a different name or version for your Go project.');


### PR DESCRIPTION
To review this you'll need to change `nameRegex` in `importSmartContractPackageCommand` to:
- `const nameRegex: RegExp = new RegExp(/^(.+?)(\.tar\.gz|\.tgz|\.cds)$/);`

This change to allow import of CDS already exists as part of another PR, so including it here would create unnecessary work to that dev.

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>