### PR TITLE
Refactor transaction arguments to validate instead of force JSON

### DIFF
--- a/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.scss
+++ b/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.scss
@@ -32,5 +32,9 @@ fieldset > legend {
         width: 100%;
         resize: vertical;
     }
+
+    .bx--text-area__invalid-icon {
+        display: none;
+    }
 }
 

--- a/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionManualInput/TransactionManualInput.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FunctionComponent, SetStateAction, useEffect, useState } from 'react';
+import React, { Dispatch, FunctionComponent, SetStateAction } from 'react';
 import './TransactionManualInput.scss';
 import { Dropdown, TextArea, TextInput } from 'carbon-components-react';
 import ITransaction from '../../../interfaces/ITransaction';
@@ -9,85 +9,28 @@ interface IProps {
     smartContract: ISmartContract;
     manualInputState: ITransactionManualInput;
     setManualInput: Dispatch<SetStateAction<ITransactionManualInput>>;
+    setActiveTransaction: Dispatch<SetStateAction<ITransaction>>;
+    transactionArgumentsAreValid: boolean;
 }
 
-function convertArgsToJSON(parameters: Array<{ description: string, name: string, schema: {} }>, values?: Array<string>): string {
-    const args: { [key: string]: any } = {};
-
-    if (parameters && parameters.length > 0) {
-        parameters.forEach(({ name }, i) => {
-            args[name] = (values && values[i]) ? values[i] : '';
-        });
-        return JSON.stringify(args, null, 2);
-    }
-
-    return '';
-}
-
-function convertJSONToArgs(transactionArguments: string): Array<string> {
-    if (!transactionArguments) {
-        return [];
-    }
-    const args: { [key: string]: any } = JSON.parse(transactionArguments);
-    const array: Array<any> = Object.keys(args).map((key: string) => `${args[key]}`);
-    return array;
-}
-
-function convertInputToArgs(inputArguments: string): string[] {
-    // trim: remove white spaces, square brackets and commas from top and end of string.
-    // Split by comma between quotes. Remove quotes from top and end of each entry.
-    // Return empty if all elements are empty
-    const noMetadataArgs: string[] = inputArguments.replace(/(^\s*\[\s*,*\s*|\s*,*\s*\]\s*$)/g, '').split(/\"\s*,\s*\"/);
-    noMetadataArgs.forEach( (arg, i) => noMetadataArgs[i] = arg.replace(/(^\"|\"$)/g, ''));
-    if (noMetadataArgs.filter((arg) => arg !== undefined && !arg.match(/^\s*$/)).length === 0) {
-        return [];
-    }
-    return noMetadataArgs;
-}
-
-const getInitialUnparsedArgsFromTransaction: any = (transaction: ITransaction, transactionArguments: Array<string>): string => {
-    if (transaction && transaction.name !== '' && transaction.parameters && transaction.parameters.length > 0) {
-        return convertArgsToJSON(transaction.parameters, transactionArguments);
-    }
-    return '[]';
-};
-
-const TransactionManualInput: FunctionComponent<IProps> = ({ smartContract, manualInputState, setManualInput }) => {
+const TransactionManualInput: FunctionComponent<IProps> = ({ smartContract, manualInputState, setManualInput, setActiveTransaction, transactionArgumentsAreValid }: IProps) => {
     const { activeTransaction, transactionArguments, transientData } = manualInputState;
     const hasMetadata: boolean = smartContract.namespace !== undefined;
-    const [unparsedArgs, setUnparsedArgs] = useState(getInitialUnparsedArgsFromTransaction(activeTransaction, transactionArguments));
 
-    useEffect(() => {
-        if (hasMetadata) {
-            const newUnparsedArgs: string = getInitialUnparsedArgsFromTransaction(activeTransaction, transactionArguments);
-            if (newUnparsedArgs !== unparsedArgs) {
-                setUnparsedArgs(newUnparsedArgs);
-            }
-        }
-    }, [activeTransaction, transactionArguments, unparsedArgs]);
-
-    function setActiveTransaction(data: any): void {
+    function setActiveTransactionWrapper(data: any): void {
         const { transactions } = smartContract;
         const transaction: ITransaction | undefined = transactions.find((txn: ITransaction) => txn.name === data.selectedItem);
         if (transaction) {
-            const args: string = convertArgsToJSON(transaction.parameters);
-
-            setUnparsedArgs(args);
-            setManualInput({
-                ...manualInputState,
-                activeTransaction: transaction,
-                transactionArguments: convertJSONToArgs(args),
-            });
+            setActiveTransaction(transaction);
         }
     }
 
     function updateTransactionArguments(event: React.FormEvent<HTMLTextAreaElement>): void {
         const newArgs: string = event.currentTarget.value;
-        setUnparsedArgs(newArgs);
-        // TODO handle invalid JSON
+
         setManualInput({
             ...manualInputState,
-            transactionArguments: hasMetadata ? convertJSONToArgs(newArgs) : convertInputToArgs(newArgs),
+            transactionArguments: newArgs,
         });
     }
 
@@ -106,7 +49,7 @@ const TransactionManualInput: FunctionComponent<IProps> = ({ smartContract, manu
                         titleText='Transaction name'
                         type='default'
                         selectedItem={transactionHasBeenChosen ? activeTransaction.name : 'Select the transaction name'}
-                        onChange={setActiveTransaction}
+                        onChange={setActiveTransactionWrapper}
                     />
                 ) : (
                     <TextInput
@@ -121,8 +64,10 @@ const TransactionManualInput: FunctionComponent<IProps> = ({ smartContract, manu
                 labelText='Transaction arguments'
                 id='arguments-text-area'
                 onChange={updateTransactionArguments}
-                value={unparsedArgs}
+                value={transactionArguments}
                 disabled={!transactionHasBeenChosen}
+                invalidText='The transaction arguments should be valid JSON'
+                invalid={transactionHasBeenChosen && !transactionArgumentsAreValid}
             />
             <TextArea
                 id='transient-data-input'

--- a/packages/blockchain-ui/src/interfaces/ITransactionManualInput.ts
+++ b/packages/blockchain-ui/src/interfaces/ITransactionManualInput.ts
@@ -2,7 +2,7 @@ import ITransaction from './ITransaction';
 
 interface ITransactionManualInput {
     activeTransaction: ITransaction;
-    transactionArguments: Array<string>;
+    transactionArguments: string;
     transientData: string;
 }
 


### PR DESCRIPTION
### Summary
Currently the transaction view forces the transaction arguments to be in a JSON format and won't let the user deviate from it. This makes it difficult to enter data unless it is exactly valid JSON.
I hit this when making a private contract as I was trying to enter a nested object but the transaction view would not allow me to add anything without it being surrounded in double quotes.

E.g. I needed and couldn't enter:
```
{
  "myPrivateAssetId": "",
  "objectToVerify": {"Something": "value"}
}
```

I've changed it to:
* allow anything in the transaction argument box
* show a validation error if it's invalid JSON
* disable the submit/evaluate buttons if it's invalid JSON

![image](https://user-images.githubusercontent.com/17385115/101542040-1e3d1b00-399a-11eb-94c7-53046e267d58.png)


Signed-off-by: James Wallis <j@wallis.dev>