### PR TITLE
[v2-rc] fix install timeout flow

### DIFF
--- a/packages/blockchain-extension/extension/commands/deployCommand.ts
+++ b/packages/blockchain-extension/extension/commands/deployCommand.ts
@@ -43,7 +43,8 @@ export async function deploySmartContract(requireCommit: boolean, fabricEnvironm
             }
 
             progress.report({ message: `Installing Smart Contract on peer(s)` });
-            packageId = await vscode.commands.executeCommand(ExtensionCommands.INSTALL_SMART_CONTRACT, installApproveMap, chosenPackage);
+            const installResult: string[] = await vscode.commands.executeCommand(ExtensionCommands.INSTALL_SMART_CONTRACT, installApproveMap, chosenPackage);
+            packageId = installResult[0];
             if (!packageId) {
                 throw new Error('Package was not installed. No packageId was returned');
             }

--- a/packages/blockchain-extension/extension/commands/upgradeCommand.ts
+++ b/packages/blockchain-extension/extension/commands/upgradeCommand.ts
@@ -40,11 +40,16 @@ export async function upgradeSmartContract(channelName: string, peerNames: Array
         if (!isPackageInstalled) {
             // Install smart contract package
             const channelMap: Map<string, string[]> = await connection.createChannelMap();
-            await vscode.commands.executeCommand(ExtensionCommands.INSTALL_SMART_CONTRACT, channelMap, selectedPackage);
+            const installResult: string[] = await vscode.commands.executeCommand(ExtensionCommands.INSTALL_SMART_CONTRACT, channelMap, selectedPackage);
 
-            // check install was successful:
-            const didInstallWork: boolean = await checkPackageInstalled(connection, peerNames, selectedPackage);
-            if (!didInstallWork) {
+            // If there was a timeout but the package was marked as installed, inform the user and exit. Also exit if it failed for other reasons.
+            if(installResult[1] && installResult[1] !== 'none') {
+                if (installResult[1] === 'timeout') {
+                    const didInstallWork: boolean = await checkPackageInstalled(connection, peerNames, selectedPackage);
+                    if (didInstallWork) {
+                        throw new Error('Chaincode installed but timed out waiting for the chaincode image to build. Please redeploy your chaincode package to attempt upgrade');
+                    }
+                }
                 throw new Error('failed to get contract from peer after install');
             }
         }

--- a/packages/blockchain-extension/test/commands/deployCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/deployCommand.test.ts
@@ -57,7 +57,7 @@ describe('deployCommand', () => {
 
         beforeEach(async () => {
             executeCommandStub = mySandBox.stub(vscode.commands, 'executeCommand');
-            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves('myPackageId');
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves(['myPackageId', undefined]);
             executeCommandStub.withArgs(ExtensionCommands.APPROVE_SMART_CONTRACT).resolves();
             executeCommandStub.withArgs(ExtensionCommands.COMMIT_SMART_CONTRACT).resolves();
             executeCommandStub.withArgs(ExtensionCommands.CONNECT_TO_ENVIRONMENT).resolves();
@@ -191,7 +191,7 @@ describe('deployCommand', () => {
         it('should handle error from install', async () => {
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
-            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves();
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'other']);
             const error: Error = new Error('Package was not installed. No packageId was returned');
 
             await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));

--- a/packages/blockchain-extension/test/commands/instantiateCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/instantiateCommand.test.ts
@@ -103,7 +103,7 @@ describe('InstantiateCommand', () => {
         });
 
         it('should install and instantiate a smart contract', async () => {
-            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves();
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'none']);
             const installedContract: FabricInstalledSmartContract = new FabricInstalledSmartContract('myContract@0.0.1', 'myContract');
             fabricRuntimeMock.getInstalledSmartContracts.onCall(1).resolves([installedContract]);
 
@@ -169,7 +169,7 @@ describe('InstantiateCommand', () => {
         });
 
         it('should handle error if smart contract is not installed properly', async () => {
-            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves();
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'other']);
 
             await vscode.commands.executeCommand(ExtensionCommands.INSTANTIATE_SMART_CONTRACT, channelName, peerNames, selectedPackage, '', [], undefined, undefined);
 
@@ -181,6 +181,42 @@ describe('InstantiateCommand', () => {
             const error: Error = new Error('failed to get contract from peer after install');
             logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Error instantiating smart contract: ${error.message}`, `Error instantiating smart contract: ${error.toString()}`);
             executeCommandStub.withArgs(ExtensionCommands.REFRESH_GATEWAYS).should.not.have.been.called;
+            sendTelemetryEventStub.should.not.have.been.called;
+        });
+
+        it('should handle timeout error and contract not installed', async () => {
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'timeout']);
+
+            await vscode.commands.executeCommand(ExtensionCommands.INSTANTIATE_SMART_CONTRACT, channelName, peerNames, selectedPackage, '', [], undefined, undefined);
+
+            executeCommandStub.should.have.been.calledWithExactly(ExtensionCommands.INSTALL_SMART_CONTRACT, map, selectedPackage);
+            fabricRuntimeMock.instantiateChaincode.should.not.have.been.called;
+
+            dockerLogsOutputSpy.should.not.have.been.called;
+            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
+            const error: Error = new Error('failed to get contract from peer after install');
+            logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Error instantiating smart contract: ${error.message}`, `Error instantiating smart contract: ${error.toString()}`);
+            executeCommandStub.withArgs(ExtensionCommands.REFRESH_GATEWAYS).should.not.have.been.called;
+            fabricRuntimeMock.getInstalledSmartContracts.should.have.been.calledTwice;
+            sendTelemetryEventStub.should.not.have.been.called;
+        });
+
+        it('should handle timeout error but contract marked as installed (image still building)', async () => {
+            executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'timeout']);
+            const installedContract: FabricInstalledSmartContract = new FabricInstalledSmartContract('myContract@0.0.1', 'myContract');
+            fabricRuntimeMock.getInstalledSmartContracts.onCall(1).resolves([installedContract]);
+
+            await vscode.commands.executeCommand(ExtensionCommands.INSTANTIATE_SMART_CONTRACT, channelName, peerNames, selectedPackage, '', [], undefined, undefined);
+
+            executeCommandStub.should.have.been.calledWithExactly(ExtensionCommands.INSTALL_SMART_CONTRACT, map, selectedPackage);
+            fabricRuntimeMock.instantiateChaincode.should.not.have.been.called;
+
+            dockerLogsOutputSpy.should.not.have.been.called;
+            logSpy.getCall(0).should.have.been.calledWith(LogType.INFO, undefined, 'instantiateSmartContract');
+            const error: Error = new Error('Chaincode installed but timed out waiting for the chaincode image to build. Please redeploy your chaincode package to attempt instantiation');
+            logSpy.getCall(1).should.have.been.calledWith(LogType.ERROR, `Error instantiating smart contract: ${error.message}`, `Error instantiating smart contract: ${error.toString()}`);
+            executeCommandStub.withArgs(ExtensionCommands.REFRESH_GATEWAYS).should.not.have.been.called;
+            fabricRuntimeMock.getInstalledSmartContracts.should.have.been.calledTwice;
             sendTelemetryEventStub.should.not.have.been.called;
         });
 


### PR DESCRIPTION
The easier way to test this is to artificially enforce a very low timeout (lower than what we can achieve by modifying the extension's settings):

In installCommand line 75, when calling `connection.installSmartContract`, replace `timeout` with a low value (**I used 10**).

This will allow enough time for fabric to mark the contract as installed, but not enough time to build the image, and the problem we are trying to fix should be exposed.

Naturally this is machine dependent, so if 10 seconds is too low (so we timeout before the contract is marked as installed) you might need to increase it a bit. Sadly trial and error, as using a hook to just mimic the TIMEOUT error will not result in the contract being installed, which is needed to test the fix.

Closes #2876 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>