### PR TITLE
Add cucumber tests for instantiate and upgrade commands

### DIFF
--- a/packages/blockchain-extension/cucumber/features/deploy.feature
+++ b/packages/blockchain-extension/cucumber/features/deploy.feature
@@ -49,3 +49,19 @@ Feature: Deploy Smart Contracts
       | JavaScript | PrivateConga | PrivateJavaScriptContract | PrivateJavaScriptContract@0.0.1 | 0.0.1   |
       | TypeScript | PrivateConga | PrivateTypeScriptContract | PrivateTypeScriptContract@0.0.1 | 0.0.1   |
       | Java       | PrivateConga | PrivateJavaContract       | PrivateJavaContract@0.0.1       | 0.0.1   |
+
+  Scenario Outline: Install and instantiate a v1 smart contract
+          Given a <language> smart contract for <assetType> assets with the name <name> and version <version>
+          And a local environment 'v1Fabric' with V1_4_2 capabilities exists
+          And the 'v1Fabric' environment is connected
+          And the contract has been created
+          And the contract has been packaged as a cds
+          When I install and instantiate the package with the transaction '' and args '', not using private data on channel 'mychannel'
+          Then there should be an committed smart contract tree item with a label '<instantiatedName>' in the 'Fabric Environments' panel for item mychannel
+          And the tree item should have a tooltip equal to '<instantiatedName>'
+          Examples:
+          | language   | assetType | name               | instantiatedName          | version |
+          | JavaScript | Conga     | JavaScriptContractV1 | JavaScriptContractV1@0.0.1  | 0.0.1   |
+          | TypeScript | Conga     | TypeScriptContractV1 | TypeScriptContractV1@0.0.1  | 0.0.1   |
+          | Java       | Conga     | JavaContractV1       | JavaContractV1@0.0.1        | 0.0.1   |
+          | Go         | Conga     | GoContractV1         | GoContractV1@0.0.1          | 0.0.1   |

--- a/packages/blockchain-extension/cucumber/features/upgrade.feature
+++ b/packages/blockchain-extension/cucumber/features/upgrade.feature
@@ -48,3 +48,23 @@ Feature: Upgrade Smart Contracts
       | language   | assetType | name               | version | version2 | committedName            |
       | JavaScript | Conga     | JavaScriptContract | 0.0.1   | 0.0.2    | JavaScriptContract@0.0.2 |
       | Java       | Conga     | JavaContract       | 0.0.1   | 0.0.2    | JavaContract@0.0.2       |
+
+  Scenario Outline: It should upgrade a v1 smart contract
+    Scenario Outline: Upgrade a smart contract
+        Given a <language> smart contract for <assetType> assets with the name <name> and version <version>
+        And a local environment 'v1Fabric' with V1_4_2 capabilities exists
+        And the 'v1Fabric' environment is connected
+        And the contract has been created
+        And the contract has been packaged as a cds
+        And the contract has been installed and instantiated with the transaction '' and args '', not using private data on channel 'mychannel'
+        And the contract version has been updated to '0.0.2'
+        And the contract has been packaged as a cds
+        When I upgrade the installed package with the transaction '' and args '', not using private data on channel 'mychannel'
+        Then there should be an committed smart contract tree item with a label '<upgradedName>' in the 'Fabric Environments' panel for item mychannel
+        And the tree item should have a tooltip equal to '<upgradedName>'
+        Examples:
+        | language   | assetType | name               | upgradedName              | version |
+        | JavaScript | Conga     | JavaScriptContractV1 | JavaScriptContractV1@0.0.2  | 0.0.1   |
+        | TypeScript | Conga     | TypeScriptContractV1 | TypeScriptContractV1@0.0.2  | 0.0.1   |
+        | Java       | Conga     | JavaContractV1       | JavaContractV1@0.0.2        | 0.0.1   |
+        | Go         | Conga     | GoContractV1         | GoContractV1@0.0.2          | 0.0.1   |

--- a/packages/blockchain-extension/cucumber/steps/smartContract.steps.ts
+++ b/packages/blockchain-extension/cucumber/steps/smartContract.steps.ts
@@ -61,13 +61,13 @@ module.exports = function(): any {
     });
 
     this.Given(/the( private)? contract has been created/, this.timeout, async (_privateOrNot: string) => {
-        const contractDirectory: string = this.smartContractHelper.getContractDirectory(this.contractDefinitionName, this.contractLanguage);
+        const contractDirectory: string = this.smartContractHelper.getContractDirectory(this.contractDefinitionName, this.contractLanguage, this.capability);
         const exists: boolean = await fs.pathExists(contractDirectory);
         if (!exists) {
             if (_privateOrNot === ' private') {
-                this.contractDirectory = await this.smartContractHelper.createSmartContract(this.contractLanguage, this.contractAssetType, this.contractDefinitionName, this.mspid);
+                this.contractDirectory = await this.smartContractHelper.createSmartContract(this.contractLanguage, this.contractAssetType, this.contractDefinitionName, this.mspid, this.capability);
             } else {
-                this.contractDirectory = await this.smartContractHelper.createSmartContract(this.contractLanguage, this.contractAssetType, this.contractDefinitionName);
+                this.contractDirectory = await this.smartContractHelper.createSmartContract(this.contractLanguage, this.contractAssetType, this.contractDefinitionName, undefined, this.capability);
             }
         } else {
             this.contractDirectory = contractDirectory;
@@ -96,6 +96,16 @@ module.exports = function(): any {
         }
     });
 
+    this.Given(/the contract has been installed and instantiated with the transaction '(.*?)' and args '(.*?)', (not )?using private data on channel '(.*?)'/, this.timeout, async (transaction: string, args: string, usingPrivateData: string, channel: string) => {
+        let privateData: boolean;
+        if (usingPrivateData === 'not ') {
+            privateData = false;
+        } else {
+            privateData = true;
+        }
+        await this.smartContractHelper.instantiateSmartContract(this.contractDefinitionName, this.contractDefinitionVersion, transaction, args, privateData, channel);
+    });
+
     /**
      * When
      */
@@ -106,6 +116,27 @@ module.exports = function(): any {
         } else {
             this.contractDirectory = await this.smartContractHelper.createSmartContract(this.contractLanguage, this.contractAssetType, this.contractDefinitionName);
         }
+    });
+
+    this.When(/I install and instantiate the package with the transaction '(.*?)' and args '(.*?)', (not )?using private data on channel '(.*?)'/, this.timeout, async (transaction: string, args: string, usingPrivateData: string, channel: string) => {
+        let privateData: boolean;
+        if (usingPrivateData === 'not ') {
+            privateData = false;
+        } else {
+            privateData = true;
+        }
+        await this.smartContractHelper.instantiateSmartContract(this.contractDefinitionName, this.contractDefinitionVersion, transaction, args, privateData, channel);
+    });
+
+    this.When(/I upgrade the installed package with the transaction '(.*?)' and args '(.*?)', (not )?using private data on channel '(.*?)'/, this.timeout, async (transaction: string, args: string, usingPrivateData: string, channel: string) => {
+        let privateData: boolean;
+        if (usingPrivateData === 'not ') {
+            privateData = false;
+        } else {
+            privateData = true;
+        }
+
+        await this.smartContractHelper.upgradeSmartContract(this.contractDefinitionName, this.contractDefinitionVersion, transaction, args, privateData, channel);
     });
 
     /**

--- a/packages/blockchain-ui/cypress/integration/deploy_page.spec.ts
+++ b/packages/blockchain-ui/cypress/integration/deploy_page.spec.ts
@@ -436,7 +436,6 @@ describe('V1 Deploy Page', () => {
         backButton.click();
     });
 
-    // this one
     it('should be able to select a workspace', () => {
         const _package: string = `workspaceOne (open project)`;
 


### PR DESCRIPTION
Decided not to add separate tests for the install command as it can no longer be called independently of the instantiate or upgrade commands.

Closes #2865. 

Signed-off-by: Erin Hughes <Erin.Hughes@ibm.com>