### PR TITLE
Add loading spinner on transaction submission

### DIFF
--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -171,9 +171,12 @@ describe('TransactionInputContainer component', () => {
         tag: [],
     };
 
+    let setTransactionSubmittedStub: (setSubmitted: boolean) => void;
+
     beforeEach(async () => {
         mySandbox = sinon.createSandbox();
         postToVSCodeStub = mySandbox.stub(Utils, 'postToVSCode');
+        setTransactionSubmittedStub = sinon.stub();
     });
 
     afterEach(async () => {
@@ -182,21 +185,21 @@ describe('TransactionInputContainer component', () => {
 
     it('should render the expected snapshot', () => {
         const snapshotComponent: any = renderer
-            .create(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} />)
+            .create(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub} />)
             .toJSON();
         expect(snapshotComponent).toMatchSnapshot();
     });
 
     it('should render the expected snapshot - contract with no Metadata', () => {
         const snapshotComponent: any = renderer
-            .create(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} />)
+            .create(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub} />)
             .toJSON();
         expect(snapshotComponent).toMatchSnapshot();
     });
 
     describe('Content switcher', () => {
         beforeEach(() => {
-            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} />);
+            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub} />);
         });
 
         it('shows the manual input by default', () => {
@@ -222,14 +225,14 @@ describe('TransactionInputContainer component', () => {
                 switchComponent = component.find(`[data-testid="${dataId}"]`).at(1);
                 switchComponent.prop('onKeyDown')({ key: 'Enter' });
                 component = component.update();
-                expect(component.matchesElement(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} />)).toEqual(true);
+                expect(component.matchesElement(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>)).toEqual(true);
             });
         });
     });
 
     describe('Manual input', () => {
         beforeEach(() => {
-            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction}/>);
+            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>);
         });
 
         it('updates the dropdown when the transaction is chosen', () => {
@@ -308,7 +311,7 @@ describe('TransactionInputContainer component', () => {
         it('sets the activeTransaction to the preselectedTransaction prop when it is passed in', () => {
             const selectedTransaction: ITransaction = greenContract.transactions[0];
             // Use a different component as we need to pass in the preselectedTransaction
-            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={selectedTransaction} />);
+            component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={selectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>);
             const dropdown: any = component.find(transactionNameSelector);
             const manualInput: any = component.find(TransactionManualInput);
             const manualInputState: ITransactionManualInput = manualInput.prop('manualInputState');
@@ -416,6 +419,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to evaluate a transaction when the evaluate button is clicked', () => {
@@ -436,6 +440,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with no parameters', () => {
@@ -457,6 +462,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with transient data when the submit button is clicked ', () => {
@@ -477,6 +483,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to evaluate a transaction with transient data when the evaluate button is clicked', () => {
@@ -497,6 +504,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with custom peers when the submit button is clicked', () => {
@@ -522,6 +530,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to evaluate a transaction with custom peers when the evaluate button is clicked', () => {
@@ -547,18 +556,23 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should not submit if no transaction has been selected as the submit button is disabled', () => {
             component = updateManualInputValues(component, undefined, '{"key": "Green"}', '{"some": "data"}');
             component.find('#submit-button').at(1).simulate('click');
             postToVSCodeStub.should.not.have.been.called;
+            setTransactionSubmittedStub.should.not.have.been.calledOnce;
+
         });
 
         it('should not submit if no transaction has been selected as the evaluate button is disabled', () => {
             component = updateManualInputValues(component, undefined, '{"key": "Green"}', '{"some": "data"}');
             component.find('#evaluate-button').at(1).simulate('click');
             postToVSCodeStub.should.not.have.been.called;
+            setTransactionSubmittedStub.should.not.have.been.calledOnce;
+
         });
 
         it('should clear the activeTransaction if a new/updated smartContract is supplied and the activeTransaction no longer exists', () => {
@@ -684,7 +698,7 @@ describe('TransactionInputContainer component', () => {
 
         describe('Without associatedTxdata', () => {
             beforeEach(() => {
-                component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={{}} preselectedTransaction={preselectedTransaction}/>);
+                component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={{}} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub} />);
                 component = toggleContentSwitcher(component);
             });
 
@@ -715,17 +729,19 @@ describe('TransactionInputContainer component', () => {
             it('should not submit if no directory is associated as the submit button is disabled', () => {
                 component.find('#submit-button').at(1).simulate('click');
                 postToVSCodeStub.should.not.have.been.called;
+                setTransactionSubmittedStub.should.not.have.been.calledOnce;
             });
 
             it('should not submit if no directory is associated as the evaluate button is disabled', () => {
                 component.find('#evaluate-button').at(1).simulate('click');
                 postToVSCodeStub.should.not.have.been.called;
+                setTransactionSubmittedStub.should.not.have.been.calledOnce;
             });
         });
 
         describe('With associatedTxdata', () => {
             beforeEach(() => {
-                component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} />);
+                component = mount(<TransactionInputContainer smartContract={greenContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>);
                 component = toggleContentSwitcher(component);
             });
 
@@ -792,6 +808,7 @@ describe('TransactionInputContainer component', () => {
                         txDataFile: 'transactionData.txdata',
                     }
                 });
+                setTransactionSubmittedStub.should.have.been.calledOnce;
             });
 
             it('should attempt to evaluate a transaction when the submit button is clicked ', () => {
@@ -813,6 +830,7 @@ describe('TransactionInputContainer component', () => {
                         txDataFile: 'transactionData.txdata',
                     }
                 });
+                setTransactionSubmittedStub.should.have.been.calledOnce;
             });
 
             it('should attempt to submit a transaction with custom peers when the submit button is clicked', () => {
@@ -838,6 +856,7 @@ describe('TransactionInputContainer component', () => {
                         txDataFile: 'transactionData.txdata',
                     }
                 });
+                setTransactionSubmittedStub.should.have.been.calledOnce;
             });
 
             it('should attempt to submit a transaction with custom peers when the evaluate button is clicked', () => {
@@ -863,23 +882,26 @@ describe('TransactionInputContainer component', () => {
                         txDataFile: 'transactionData.txdata',
                     }
                 });
+                setTransactionSubmittedStub.should.have.been.calledOnce;
             });
 
             it('should not submit if no transaction has been selected as the submit button is disabled', () => {
                 component.find('#submit-button').at(1).simulate('click');
                 postToVSCodeStub.should.not.have.been.called;
+                setTransactionSubmittedStub.should.not.have.been.calledOnce;
             });
 
             it('should not submit if no transaction has been selected as the evaluate button is disabled', () => {
                 component.find('#evaluate-button').at(1).simulate('click');
                 postToVSCodeStub.should.not.have.been.called;
+                setTransactionSubmittedStub.should.not.have.been.calledOnce;
             });
         });
     });
 
     describe('Manual input for contracts with no metadata', () => {
         beforeEach(() => {
-            component = mount(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction}/>);
+            component = mount(<TransactionInputContainer smartContract={purpleContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>);
         });
 
         it('updates when the user types a transaction name in the inputText', () => {
@@ -957,6 +979,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to evaluate a transaction when the evaluate button is clicked', () => {
@@ -977,6 +1000,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with transient data when the submit button is clicked ', () => {
@@ -997,6 +1021,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to evaluate a transaction with transient data when the evaluate button is clicked', () => {
@@ -1017,6 +1042,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with custom peers when the submit button is clicked', () => {
@@ -1042,6 +1068,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should attempt to submit a transaction with custom peers when the evaluate button is clicked', () => {
@@ -1067,12 +1094,14 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('should not submit if no transaction name has been introduced as the submit button is disabled', () => {
             component = updateManualInputValues(component, undefined, '["Purple"]', '{"some": "data"}', false);
             component.find('#submit-button').at(1).simulate('click');
             postToVSCodeStub.should.not.have.been.called;
+            setTransactionSubmittedStub.should.not.have.been.calledOnce;
         });
 
         it('should not submit if no transaction name has been introduced as the evaluate button is disabled', () => {
@@ -1081,6 +1110,7 @@ describe('TransactionInputContainer component', () => {
             expect(submit.prop('disabled')).toBeTruthy();
             submit.simulate('click');
             postToVSCodeStub.should.not.have.been.called;
+            setTransactionSubmittedStub.should.not.have.been.calledOnce;
         });
 
         it('when a transaction is submitted, it correctly parses the textarea when it contains an array rather than a JSON object', () => {
@@ -1102,6 +1132,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('when a transaction is submitted, it correctly parses the textarea with extra whitespace', () => {
@@ -1126,6 +1157,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
 
         it('when a transaction is submitted, it correctly parses the textarea with an empty string as the only value', () => {
@@ -1147,6 +1179,7 @@ describe('TransactionInputContainer component', () => {
                     txDataFile: undefined,
                 }
             });
+            setTransactionSubmittedStub.should.have.been.calledOnce;
         });
     });
 

--- a/packages/blockchain-ui/enzyme/tests/TransactionOutput.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionOutput.test.tsx
@@ -10,14 +10,14 @@ chai.use(sinonChai);
 describe('TransactionOutput component', () => {
     it('should render the expected snapshot', async () => {
         const component: any = renderer
-            .create(<TransactionOutput output='some output'/>)
+            .create(<TransactionOutput output='some output' isLoading={false} />)
             .toJSON();
         expect(component).toMatchSnapshot();
     });
 
     it('should render the expected snapshot when no output is received', async () => {
         const component: any = renderer
-            .create(<TransactionOutput output=''/>)
+            .create(<TransactionOutput output='' isLoading={false} />)
             .toJSON();
         expect(component).toMatchSnapshot();
     });

--- a/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
@@ -11,6 +11,8 @@ import ITransaction from '../../src/interfaces/ITransaction';
 import ISmartContract from '../../src/interfaces/ISmartContract';
 import IDataFileTransaction from '../../src/interfaces/IDataFileTransaction';
 import IAssociatedTxData from '../../src/interfaces/IAssociatedTxdata';
+import TransactionInputContainer from '../../src/components/elements/TransactionInputContainer/TransactionInputContainer';
+
 chai.should();
 chai.use(sinonChai);
 
@@ -237,6 +239,22 @@ describe('TransactionPage component', () => {
             transactionOutput: moreMockTransactionOutput
         });
         componentDidUpdateSpy.should.have.been.called;
+        component.state().transactionSubmitted.should.equal(false);
         component.state().transactionOutput.should.equal(moreMockTransactionOutput);
+    });
+
+    it('should show the loading spinner when setTransactionSubmitted is called with true', () => {
+        const loadingID = '#output-loading';
+        let component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        component.state().transactionSubmitted.should.be.false;
+        expect(component.find(loadingID).exists()).toBeFalsy();
+
+        act(() => {
+            component.find(TransactionInputContainer).prop('setTransactionSubmitted')(true);
+        });
+        component = component.update();
+
+        component.state().transactionSubmitted.should.be.true;
+        expect(component.find(loadingID).exists()).toBeTruthy();
     });
 });

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -16,6 +16,7 @@ interface IProps {
     smartContract: ISmartContract | undefined;
     associatedTxdata: IAssociatedTxdata;
     preselectedTransaction: ITransaction;
+    setTransactionSubmitted: (submitted: boolean) => void;
 }
 
 const emptyTransaction: ITransaction = { name: '', parameters: [], returns: { type: '' }, tag: [] };
@@ -65,7 +66,7 @@ const getArgsFromTransactionAndConvertToJSON: any = (transaction: ITransaction, 
     return '[]';
 };
 
-const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, associatedTxdata, preselectedTransaction }) => {
+const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, associatedTxdata, preselectedTransaction, setTransactionSubmitted }) => {
     const [smartContractName, setNewSmartContractName] = useState(smartContract ? smartContract.name : '');
     const [currentPreselectedTransaction, setCurrentPreselectedTransaction] = useState(preselectedTransaction);
 
@@ -141,6 +142,7 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
         };
 
         Utils.postToVSCode({ command, data });
+        setTransactionSubmitted(true);
     };
 
     const updateCustomPeers: any = (event: { selectedItems: { id: string; label: string}[] } ): void => {

--- a/packages/blockchain-ui/src/components/elements/TransactionOutput/TransactionOutput.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionOutput/TransactionOutput.tsx
@@ -1,4 +1,5 @@
 import React, { FunctionComponent } from 'react';
+import { Loading } from 'carbon-components-react';
 import { Launch32 } from '@carbon/icons-react';
 import { ExtensionCommands } from '../../../ExtensionCommands';
 import CommandLink from '../CommandLink/CommandLink';
@@ -7,9 +8,10 @@ import block from '../../../resources/block.svg';
 
 interface IProps {
     output: string;
+    isLoading: boolean;
 }
 
-const TransactionOutput: FunctionComponent<IProps> = ({ output }) => {
+const TransactionOutput: FunctionComponent<IProps> = ({ output, isLoading }) => {
     return (
         <div className='output-panel' id='output-panel'>
             <p className='output-title'>Transaction output</p>
@@ -32,6 +34,7 @@ const TransactionOutput: FunctionComponent<IProps> = ({ output }) => {
                     )
                 }
             </div>
+            {isLoading && <Loading id='output-loading' description='Waiting for transaction output to be sent' withOverlay />}
         </div>
     );
 };

--- a/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
+++ b/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
@@ -25,6 +25,7 @@ interface IState {
     associatedTxdata: IAssociatedTxdata;
     transactionOutput: string;
     activeSmartContract: ISmartContract | undefined;
+    transactionSubmitted: boolean;
 }
 
 class TransactionPage extends Component<IProps, IState> {
@@ -39,6 +40,7 @@ class TransactionPage extends Component<IProps, IState> {
             preselectedSmartContract,
             // If only a single smartContract is given, force it to be active
             activeSmartContract: smartContracts.length === 1 ? smartContracts[0] : preselectedSmartContract,
+            transactionSubmitted: false,
         };
     }
 
@@ -83,6 +85,7 @@ class TransactionPage extends Component<IProps, IState> {
         }
 
         if (prevProps.transactionOutput !== transactionOutput) {
+            this.setTransactionSubmitted(false);
             this.setState({
                 transactionOutput,
             });
@@ -108,9 +111,15 @@ class TransactionPage extends Component<IProps, IState> {
         });
     }
 
+    setTransactionSubmitted(transactionSubmitted: boolean): void {
+        this.setState({
+            transactionSubmitted,
+        })
+    }
+
     render(): JSX.Element {
         const { preselectedTransaction } = this.props.transactionViewData;
-        const { gatewayName, smartContracts, associatedTxdata, transactionOutput, activeSmartContract } = this.state;
+        const { gatewayName, smartContracts, associatedTxdata, transactionOutput, activeSmartContract, transactionSubmitted } = this.state;
 
         const breadcrumb: Array<string> = this.createBreadcrumb(gatewayName, activeSmartContract, smartContracts && smartContracts.length > 1);
         return (
@@ -138,10 +147,11 @@ class TransactionPage extends Component<IProps, IState> {
                                     smartContract={activeSmartContract}
                                     associatedTxdata={associatedTxdata}
                                     preselectedTransaction={preselectedTransaction}
+                                    setTransactionSubmitted={(isSubmitted: boolean) => this.setTransactionSubmitted(isSubmitted)}
                                 />
                             </div>
                             <div className='bx--col-lg-10 bx--col-md-4 bx--col-sm-4'>
-                                <TransactionOutput output={transactionOutput} />
+                                <TransactionOutput output={transactionOutput} isLoading={transactionSubmitted} />
                             </div>
                         </div>
                     </div>

--- a/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
+++ b/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
@@ -114,7 +114,7 @@ class TransactionPage extends Component<IProps, IState> {
     setTransactionSubmitted(transactionSubmitted: boolean): void {
         this.setState({
             transactionSubmitted,
-        })
+        });
     }
 
     render(): JSX.Element {


### PR DESCRIPTION
### Summary
Added a loading spinner when a transaction is submitted/evaluated. This should indicate to the user that something has happened, at the moment if the response is the same there is no indication that anything has happened on the backend.
Spinner: https://react.carbondesignsystem.com/?path=/docs/loading--default

### Video

**Real time (shorter)**
https://user-images.githubusercontent.com/17385115/104039082-d0e8df00-51cd-11eb-8a3e-f8510f06deb9.mp4

**With 5 second sleep (longer so you can see in more detail)**
https://user-images.githubusercontent.com/17385115/104039089-d3e3cf80-51cd-11eb-9784-17249d7d82a3.mp4

### Testing
Updated tests

Signed-off-by: James Wallis <j@wallis.dev>