### PR TITLE
[v2-rc] fail audit log when high/critical severity vulnerabilities found

### DIFF
--- a/azure-templates/setup-steps.yml
+++ b/azure-templates/setup-steps.yml
@@ -46,4 +46,7 @@ steps:
   - script: |
       set -ev
       node ./.azure/audit.js
+      if [ $? != 0 ]; then
+        exit 1
+      fi
     displayName: run npm audit


### PR DESCRIPTION
Can only be enabled once all high severity vulnerabilities are resolved.

Closes #2815 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>