### PR TITLE
Fix transaction stuck loading forever

### DIFF
--- a/packages/blockchain-ui/enzyme/tests/App.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/App.test.tsx
@@ -10,6 +10,8 @@ import ITutorialObject from '../../src/interfaces/ITutorialObject';
 import IPackageRegistryEntry from '../../src/interfaces/IPackageRegistryEntry';
 import ISmartContract from '../../src/interfaces/ISmartContract';
 import IRepositoryObject from '../../src/interfaces/IRepositoryObject';
+import TransactionPage from '../../src/components/pages/TransactionPage/TransactionPage';
+import { act } from 'react-dom/test-utils';
 
 chai.should();
 chai.use(sinonChai);
@@ -487,4 +489,18 @@ describe('App', () => {
         dispatchEvent(msg);
         component.state().transactionOutput.should.deep.equal(transactionOutput);
     });
+
+    it('clears the transactionOutput when the clearTransactionOutput function is called by the child component TransactionPage', () => {
+        const transactionOutput: string = 'here is some output from a transaction';
+        let component: any = mount(<App/>);
+        component.setState({ redirectPath: '/transaction', transactionOutput });
+        component = component.update();
+        component.state().transactionOutput.should.deep.equal(transactionOutput);
+
+        act(() => {
+            component.find(TransactionPage).prop('clearTransactionOutput')();
+        });
+        component = component.update();
+        component.state().transactionOutput.should.deep.equal('');
+    })
 });

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -171,7 +171,7 @@ describe('TransactionInputContainer component', () => {
         tag: [],
     };
 
-    let setTransactionSubmittedStub: (setSubmitted: boolean) => void;
+    let setTransactionSubmittedStub: () => void;
 
     beforeEach(async () => {
         mySandbox = sinon.createSandbox();

--- a/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionPage.test.tsx
@@ -19,6 +19,7 @@ chai.use(sinonChai);
 describe('TransactionPage component', () => {
     let mySandBox: sinon.SinonSandbox;
     let postMessageHandlerStub: sinon.SinonStub;
+    let clearTransactionOutputStub: sinon.SinonStub;
 
     const transactionOne: ITransaction = {
         name: 'transactionOne',
@@ -68,6 +69,7 @@ describe('TransactionPage component', () => {
     beforeEach(async () => {
         mySandBox = sinon.createSandbox();
         postMessageHandlerStub = mySandBox.stub();
+        clearTransactionOutputStub = mySandBox.stub();
     });
 
     afterEach(async () => {
@@ -76,7 +78,7 @@ describe('TransactionPage component', () => {
 
     it('should render the expected snapshot', async () => {
         const component: any = renderer
-            .create(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>)
+            .create(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub} />)
             .toJSON();
         expect(component).toMatchSnapshot();
     });
@@ -87,7 +89,7 @@ describe('TransactionPage component', () => {
             greenContract,
         ];
         multipleContractsTransactionData.preselectedSmartContract = undefined;
-        const component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        const component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('smartContracts', multipleContractsTransactionData.smartContracts);
         expect(component.state()).toHaveProperty('activeSmartContract', multipleContractsTransactionData.smartContracts[0]);
 
@@ -101,7 +103,7 @@ describe('TransactionPage component', () => {
             greenContract,
             { ...greenContract, contractName: 'other contract' },
         ];
-        const component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        const component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('smartContracts', multipleContractsTransactionData.smartContracts);
 
         const contractDropdown: any = component.find('#contract-select');
@@ -116,7 +118,7 @@ describe('TransactionPage component', () => {
         ];
         multipleContractsTransactionData.preselectedSmartContract = undefined;
 
-        let component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('smartContracts', multipleContractsTransactionData.smartContracts);
         expect(component.state()).toHaveProperty('activeSmartContract', undefined);
 
@@ -137,7 +139,7 @@ describe('TransactionPage component', () => {
         ];
         multipleContractsTransactionData.preselectedSmartContract = undefined;
 
-        let component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={multipleContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('preselectedSmartContract', undefined);
 
         component.setProps({ transactionViewData: { ...multipleContractsTransactionData, preselectedSmartContract: multipleContractsTransactionData.smartContracts[1] } });
@@ -146,7 +148,7 @@ describe('TransactionPage component', () => {
 
     it('should update the smartContract when a new one is passed down through props', async () => {
         const componentDidUpdateSpy: sinon.SinonSpy = mySandBox.spy(TransactionPage.prototype, 'componentDidUpdate');
-        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('smartContracts', [greenContract]);
 
         const newContract: ISmartContract =  { ...greenContract, name: 'updatedContract' };
@@ -161,7 +163,7 @@ describe('TransactionPage component', () => {
     });
 
     it('should clear the activeSmartContract when no smartContracts are sent', () => {
-        let component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
 
         component.setProps({ transactionViewData: { ...transactionViewData, smartContracts: [] } });
         expect(component.state()).toHaveProperty('smartContracts', []);
@@ -176,7 +178,7 @@ describe('TransactionPage component', () => {
         ];
         twoContractsTransactionData.preselectedSmartContract = twoContractsTransactionData.smartContracts[1];
 
-        let component: any = mount(<TransactionPage transactionViewData={twoContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={twoContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('activeSmartContract', twoContractsTransactionData.smartContracts[1]);
 
 
@@ -199,7 +201,7 @@ describe('TransactionPage component', () => {
         ];
         twoContractsTransactionData.preselectedSmartContract = undefined;
 
-        let component: any = mount(<TransactionPage transactionViewData={twoContractsTransactionData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={twoContractsTransactionData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('activeSmartContract', undefined);
 
 
@@ -216,7 +218,7 @@ describe('TransactionPage component', () => {
 
     it('should update the associatedTxdata when something new is passed down through props', async () => {
         const componentDidUpdateSpy: sinon.SinonSpy = mySandBox.spy(TransactionPage.prototype, 'componentDidUpdate');
-        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         expect(component.state()).toHaveProperty('associatedTxdata', {});
 
         component.setProps({
@@ -232,7 +234,7 @@ describe('TransactionPage component', () => {
 
     it('should update the transaction output when something new is passed down through props', async () => {
         const componentDidUpdateSpy: sinon.SinonSpy = mySandBox.spy(TransactionPage.prototype, 'componentDidUpdate');
-        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        const component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         component.state().transactionOutput.should.equal(mockTransactionOutput);
 
         component.setProps({
@@ -245,7 +247,7 @@ describe('TransactionPage component', () => {
 
     it('should show the loading spinner when setTransactionSubmitted is called with true', () => {
         const loadingID = '#output-loading';
-        let component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput}/>);
+        let component: any = mount(<TransactionPage transactionViewData={transactionViewData} transactionOutput={mockTransactionOutput} clearTransactionOutput={clearTransactionOutputStub}/>);
         component.state().transactionSubmitted.should.be.false;
         expect(component.find(loadingID).exists()).toBeFalsy();
 
@@ -256,5 +258,6 @@ describe('TransactionPage component', () => {
 
         component.state().transactionSubmitted.should.be.true;
         expect(component.find(loadingID).exists()).toBeTruthy();
+        clearTransactionOutputStub.should.have.been.called;
     });
 });

--- a/packages/blockchain-ui/src/App.tsx
+++ b/packages/blockchain-ui/src/App.tsx
@@ -33,8 +33,9 @@ class App extends Component<{}, IAppState> {
     componentDidMount(): void {
         window.addEventListener('message', (event: MessageEvent) => {
 
-            const newState: any = {
-                redirectPath: event.data.path
+            const newState: IAppState = {
+                ...this.state,
+                redirectPath: event.data.path,
             };
 
             if (event.data.version) {
@@ -105,7 +106,12 @@ class App extends Component<{}, IAppState> {
                             <DeployPage deployData={this.state.deployData} />}>
                         </Route>
                         <Route exact path='/transaction' render={(): JSX.Element =>
-                            <TransactionPage transactionViewData={this.state.transactionViewData} transactionOutput={this.state.transactionOutput}/>}>
+                            <TransactionPage
+                                transactionViewData={this.state.transactionViewData}
+                                transactionOutput={this.state.transactionOutput}
+                                clearTransactionOutput={() => this.setState({ transactionOutput: '' })}
+                            />}
+                        >
                         </Route>
                     </div>
                 </div>

--- a/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionInputContainer/TransactionInputContainer.tsx
@@ -16,7 +16,7 @@ interface IProps {
     smartContract: ISmartContract | undefined;
     associatedTxdata: IAssociatedTxdata;
     preselectedTransaction: ITransaction;
-    setTransactionSubmitted: (submitted: boolean) => void;
+    setTransactionSubmitted: () => void;
 }
 
 const emptyTransaction: ITransaction = { name: '', parameters: [], returns: { type: '' }, tag: [] };
@@ -142,7 +142,7 @@ const TransactionInputContainer: FunctionComponent<IProps> = ({ smartContract, a
         };
 
         Utils.postToVSCode({ command, data });
-        setTransactionSubmitted(true);
+        setTransactionSubmitted();
     };
 
     const updateCustomPeers: any = (event: { selectedItems: { id: string; label: string}[] } ): void => {

--- a/packages/blockchain-ui/src/components/elements/TransactionOutput/TransactionOutput.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionOutput/TransactionOutput.tsx
@@ -16,7 +16,7 @@ const TransactionOutput: FunctionComponent<IProps> = ({ output, isLoading }) => 
         <div className='output-panel' id='output-panel'>
             <p className='output-title'>Transaction output</p>
             <div className='output-panel-inner'>
-                {output
+                {output || isLoading
                     ?  output.split('\n').map((line) => <p className='output-body'>{line}</p>)
                     : (
                         <div className='output-placeholder-container'>

--- a/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
+++ b/packages/blockchain-ui/src/components/pages/TransactionPage/TransactionPage.tsx
@@ -16,6 +16,7 @@ interface IProps {
         preselectedTransaction: ITransaction
     };
     transactionOutput: string;
+    clearTransactionOutput: () => void;
 }
 
 interface IState {
@@ -85,9 +86,10 @@ class TransactionPage extends Component<IProps, IState> {
         }
 
         if (prevProps.transactionOutput !== transactionOutput) {
-            this.setTransactionSubmitted(false);
             this.setState({
                 transactionOutput,
+                // Only update transactionSubmitted if some transactionOutput is returned
+                transactionSubmitted: transactionOutput ? false : this.state.transactionSubmitted,
             });
         }
     }
@@ -111,10 +113,11 @@ class TransactionPage extends Component<IProps, IState> {
         });
     }
 
-    setTransactionSubmitted(transactionSubmitted: boolean): void {
+    setTransactionSubmitted(): void {
         this.setState({
-            transactionSubmitted,
+            transactionSubmitted: true,
         });
+        this.props.clearTransactionOutput();
     }
 
     render(): JSX.Element {
@@ -147,7 +150,7 @@ class TransactionPage extends Component<IProps, IState> {
                                     smartContract={activeSmartContract}
                                     associatedTxdata={associatedTxdata}
                                     preselectedTransaction={preselectedTransaction}
-                                    setTransactionSubmitted={(isSubmitted: boolean) => this.setTransactionSubmitted(isSubmitted)}
+                                    setTransactionSubmitted={() => this.setTransactionSubmitted()}
                                 />
                             </div>
                             <div className='bx--col-lg-10 bx--col-md-4 bx--col-sm-4'>


### PR DESCRIPTION
Fixes bug where the transaction loading component would never disappear when the passed in `transactionOutput` is the same as the previous transaction. 

Clears the `transactionOutput` when a transaction is submitted.

Signed-off-by: James Wallis <j@wallis.dev>