### PR TITLE
[master] custom query handler for evaluate transaction

### DIFF
--- a/packages/blockchain-extension/extension/commands/submitTransaction.ts
+++ b/packages/blockchain-extension/extension/commands/submitTransaction.ts
@@ -284,6 +284,7 @@ export async function submitTransaction(evaluate: boolean, treeItem?: Instantiat
             return;
         } else if (channelPeerInfo.length === 1) {
             selectPeers = UserInputUtil.DEFAULT;
+            peerTargetNames.push(channelPeerInfo[0].name);
         } else {
             selectPeers = await UserInputUtil.showQuickPick('Select a peer-targeting policy for this transaction', [UserInputUtil.DEFAULT, UserInputUtil.CUSTOM]) as string;
         }

--- a/packages/blockchain-extension/test/commands/submitTransaction.test.ts
+++ b/packages/blockchain-extension/test/commands/submitTransaction.test.ts
@@ -452,7 +452,7 @@ describe('SubmitTransactionCommand', () => {
         it('should submit the smart contract through the command with function but no args', async () => {
             showInputBoxStub.onFirstCall().resolves('[]');
             await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with no args on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction');
@@ -463,7 +463,7 @@ describe('SubmitTransactionCommand', () => {
         it('should submit the smart contract through the command with function but no args or brackets', async () => {
             showInputBoxStub.onFirstCall().resolves('');
             await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with no args on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction');
@@ -474,7 +474,7 @@ describe('SubmitTransactionCommand', () => {
         it('should submit the smart contract through the command with transient data', async () => {
             showInputBoxStub.onSecondCall().resolves('{ "key" : "value"}');
             await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract', { key: Buffer.from('value') }, false, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract', { key: Buffer.from('value') }, false, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with args arg1,arg2,arg3 on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction');
@@ -485,7 +485,7 @@ describe('SubmitTransactionCommand', () => {
         it('should submit the smart contract through the command with transient data even if there is trailing/leading whitespace', async () => {
             showInputBoxStub.onSecondCall().resolves('    { "key" : "value"}    ');
             await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract', { key: Buffer.from('value') }, false, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', ['arg1', 'arg2', 'arg3'], 'my-contract', { key: Buffer.from('value') }, false, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with args arg1,arg2,arg3 on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction');
@@ -698,7 +698,7 @@ describe('SubmitTransactionCommand', () => {
             fabricClientConnectionMock.submitTransaction.resolves(result);
             showInputBoxStub.onFirstCall().resolves('[]');
             await vscode.commands.executeCommand(ExtensionCommands.SUBMIT_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, false, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `submitting transaction transaction1 with no args on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully submitted transaction', `Returned value from transaction1: ${result}`);
@@ -713,7 +713,7 @@ describe('SubmitTransactionCommand', () => {
             fabricClientConnectionMock.submitTransaction.resolves(result);
             showInputBoxStub.onFirstCall().resolves('[]');
             await vscode.commands.executeCommand(ExtensionCommands.EVALUATE_TRANSACTION);
-            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, true, []);
+            fabricClientConnectionMock.submitTransaction.should.have.been.calledWithExactly('myContract', 'transaction1', 'myChannel', [], 'my-contract', undefined, true, [peerNames[0]]);
             showInputBoxStub.should.have.been.calledTwice;
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `evaluating transaction transaction1 with no args on channel myChannel`);
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully evaluated transaction', `No value returned from transaction1`);

--- a/packages/blockchain-fabric-admin/src/EvaluateQueryHandler.ts
+++ b/packages/blockchain-fabric-admin/src/EvaluateQueryHandler.ts
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { Network, Query, QueryHandler, QueryHandlerFactory, QueryResponse, QueryResults } from 'fabric-network';
+import { Channel, Endorser } from 'fabric-common';
+
+/**
+ * Governs the construction of querys to evaluate transactions with user determined peers.
+ *
+ *   Allows the user to select peers by modifying this value when creating a transaction
+ *   object. Without the static peers, we would not be able to change the target peers of
+ *   a transaction, since the QueryHandler needs to be assigned when connecting to the
+ *   gateway.
+ */
+export class EvaluateQueryHandler implements QueryHandler {
+    private static peers: Endorser[];
+
+    public static setPeers(peers: Endorser[]): void {
+        EvaluateQueryHandler.peers = peers;
+    }
+    public static getPeers(): Endorser[] {
+        return EvaluateQueryHandler.peers;
+    }
+
+    /**
+     * Set peers to all peers in the network. This QueryHandler will be used
+     * as a gateway option when connecting to the gateway.
+     * @param network
+     */
+    public static createQueryHandler: QueryHandlerFactory = (network: Network) => {
+        const mspId: string = network.getGateway().getIdentity().mspId;
+        const channel: Channel = network.getChannel();
+        const orgPeers: Endorser[] = channel.getEndorsers(mspId);
+        const otherPeers: Endorser[] = channel.getEndorsers().filter((peer) => !orgPeers.includes(peer));
+        const allPeers: Endorser[] = orgPeers.concat(otherPeers);
+
+        EvaluateQueryHandler.setPeers(allPeers);
+        return new EvaluateQueryHandler();
+    };
+
+    /**
+     * Evaluate the supplied query on appropriate peers.
+     * @param {Query} query - A query object that will send the
+     * query proposal to the peers and format the responses for this query handler
+     * @returns {Buffer} Query result.
+     */
+    public async evaluate(query: Query): Promise<Buffer> {
+        const errorMessages: string[] = [];
+
+        if (EvaluateQueryHandler.peers && EvaluateQueryHandler.peers.length > 0) {
+            for (const peer of EvaluateQueryHandler.peers) {
+                const results: QueryResults = await query.evaluate([peer]);
+                const result: QueryResponse | Error = results[peer.name];
+                if (result instanceof Error) {
+                    errorMessages.push(`Peer ${peer.name}: ${result.toString()}`);
+                } else {
+                    if (result.isEndorsed) {
+                        return result.payload;
+                    }
+                    errorMessages.push(`Peer ${peer.name}: ${result.message}`);
+                }
+            }
+        } else {
+            errorMessages.push('No target peers provided');
+        }
+        const message: string = `Query failed. Errors: ${JSON.stringify(errorMessages)}`;
+        const error: Error = new Error(message);
+        throw error;
+    }
+}

--- a/packages/blockchain-fabric-admin/src/index.ts
+++ b/packages/blockchain-fabric-admin/src/index.ts
@@ -18,6 +18,7 @@ export * from './V2SmartContractPackage';
 export {SmartContractType} from './packager/BasePackager'
 
 export * from './Lifecycle';
-export * from  './LifecyclePeer';
+export * from './LifecyclePeer';
 export * from './LifecycleChannel';
+export * from './EvaluateQueryHandler';
 export {Collection} from './CollectionConfig';

--- a/packages/blockchain-fabric-admin/test/EvaluateQueryHandler.test.ts
+++ b/packages/blockchain-fabric-admin/test/EvaluateQueryHandler.test.ts
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import * as chaiAsPromised from 'chai-as-promised';
+import { EvaluateQueryHandler } from '../src/EvaluateQueryHandler';
+import { Endorser } from 'fabric-common';
+import { Query, QueryResponse, QueryResults } from 'fabric-network';
+
+chai.use(sinonChai);
+chai.use(chaiAsPromised);
+const should: Chai.Should = chai.should();
+
+// tslint:disable:no-unused-expression
+describe('EvaluateQueryHandler', () => {
+
+    describe('getPeers', () => {
+        it(`confirm getPeers works`, () => {
+            const result: Endorser[] = EvaluateQueryHandler.getPeers();
+            should.equal(undefined, result);
+        });
+    });
+
+    describe('setPeers', () => {
+        it(`confirm setPeers works`, () => {
+            const originalPeers: Endorser[] = EvaluateQueryHandler.getPeers();
+            const newPeers: Endorser[] = [{name: 'peer1', mspid: 'Org1MSP'} as Endorser];
+            EvaluateQueryHandler.setPeers(newPeers);
+            const result: Endorser[] = EvaluateQueryHandler.getPeers();
+            result.should.deep.equal(newPeers);
+            EvaluateQueryHandler.setPeers(originalPeers);
+        });
+    });
+
+    describe('createQueryHandler', () => {
+        let mockNetwork: any;
+        let getGatewayStub: sinon.SinonStub;
+        let getChannelStub: sinon.SinonStub;
+        let mySandBox: sinon.SinonSandbox;
+        let gatewayStub: any;
+        let getIdentityStub: sinon.SinonStub;
+        let channelStub: any;
+        let getEndorsersStub: sinon.SinonStub;
+        let peers: Endorser[];
+        let mspId: string;
+
+        beforeEach(() => {
+            mySandBox = sinon.createSandbox();
+
+            peers = [{name: 'peer1', mspid: 'Org1MSP'} as Endorser, {name: 'peer2', mspid: 'Org2MSP'} as Endorser];
+            mspId = 'Org1MSP';
+
+            getIdentityStub = mySandBox.stub().returns({mspId: mspId});
+            gatewayStub = {
+                getIdentity: getIdentityStub
+            }
+            getGatewayStub = mySandBox.stub().returns(gatewayStub);
+
+            getEndorsersStub = mySandBox.stub().returns(peers);
+            getEndorsersStub.withArgs(mspId).returns([peers[0]])
+            channelStub = {
+                getEndorsers: getEndorsersStub
+            }
+            getChannelStub = mySandBox.stub().returns(channelStub);
+
+            mockNetwork = {
+                getGateway: getGatewayStub,
+                getChannel: getChannelStub
+            };
+        });
+
+        it(`should set EvaluateQueryHandler peers to all available peers`, () => {
+            EvaluateQueryHandler.createQueryHandler(mockNetwork);
+            EvaluateQueryHandler.getPeers().should.deep.equal(peers);
+        });
+    });
+
+    describe('evaluate', () => {
+        const handler: EvaluateQueryHandler = new EvaluateQueryHandler();
+        let peers: Endorser[];
+        let query: sinon.SinonStubbedInstance<Query>;
+
+        class TestQuery implements Query {
+            async evaluate(_peers: Endorser[]): Promise<QueryResults> {
+                return;
+            }
+        }
+
+
+        beforeEach(() => {
+            peers = [{name: 'peer1', mspid: 'Org1MSP'} as Endorser, {name: 'peer2', mspid: 'Org2MSP'} as Endorser];
+            query = sinon.createStubInstance(TestQuery)
+            EvaluateQueryHandler.setPeers(peers);
+        });
+
+        it(`should return payload if present`, async () => {
+            const response0: QueryResponse = {
+                isEndorsed: true,
+                payload: Buffer.from('some payload buffer'),
+                status: 200,
+                message: ''
+            }
+            query.evaluate.resolves({[peers[0].name]: response0});
+
+            const result: Buffer = await handler.evaluate(query);
+            result.should.deep.equal(response0.payload);
+            query.evaluate.should.have.been.called;
+        });
+
+        it(`should return payload if present even if previous peers returned error`, async () => {
+            const response0: Error = new Error('some message');
+            query.evaluate.onFirstCall().resolves({[peers[0].name]: response0});
+
+            const response1: QueryResponse = {
+                isEndorsed: true,
+                payload: Buffer.from('some payload buffer'),
+                status: 200,
+                message: ''
+            }
+            query.evaluate.onSecondCall().resolves({[peers[1].name]: response1});
+
+            const result: Buffer = await handler.evaluate(query);
+            result.should.deep.equal(response1.payload);
+            query.evaluate.should.have.been.calledTwice;
+        });
+
+        it(`should return payload if present even if previous peers returned non endorsed result`, async () => {
+            const response0: QueryResponse = {
+                isEndorsed: false,
+                payload: Buffer.from('some payload buffer'),
+                status: 500,
+                message: 'some mesage'
+            }
+            query.evaluate.resolves({[peers[0].name]: response0});
+
+            const response1: QueryResponse = {
+                isEndorsed: true,
+                payload: Buffer.from('some payload buffer'),
+                status: 200,
+                message: ''
+            }
+            query.evaluate.onSecondCall().resolves({[peers[1].name]: response1});
+
+            const result: Buffer = await handler.evaluate(query);
+            result.should.deep.equal(response1.payload);
+            query.evaluate.should.have.been.calledTwice;
+        });
+
+        it(`should throw error if all results are not endorsed`, async () => {
+            EvaluateQueryHandler.setPeers([peers[0]]);
+
+            const response0: QueryResponse = {
+                isEndorsed: false,
+                payload: Buffer.from('some payload buffer'),
+                status: 500,
+                message: 'some mesage'
+            }
+            query.evaluate.resolves({[peers[0].name]: response0});
+
+            const expectedError: string = `Query failed. Errors: ${JSON.stringify([`Peer ${peers[0].name}: ${response0.message}`])}`;
+
+            await handler.evaluate(query).should.eventually.rejectedWith(expectedError);
+            query.evaluate.should.have.been.called;
+        });
+
+        it(`should throw error if no peers`, async () => {
+            EvaluateQueryHandler.setPeers(undefined);
+
+            await handler.evaluate(query).should.eventually.rejectedWith('No target peers provided');
+            query.evaluate.should.not.have.been.called;
+        });
+
+        it(`should throw error if all peers return error`, async () => {
+            const response0: Error = new Error('some error');
+            query.evaluate.onFirstCall().resolves({[peers[0].name]: response0});
+
+            const response1: Error = new Error('some other error');
+            query.evaluate.onSecondCall().resolves({[peers[1].name]: response1});
+
+            const expectedError: string = `Query failed. Errors: ${JSON.stringify([`Peer ${peers[0].name}: ${response0.toString()}`, `Peer ${peers[1].name}: ${response1.toString()}`])}`;
+
+            await handler.evaluate(query).should.eventually.rejectedWith(expectedError);
+            query.evaluate.should.have.been.calledTwice;
+        });
+    });
+});

--- a/packages/blockchain-gateway-v1/src/FabricConnection.ts
+++ b/packages/blockchain-gateway-v1/src/FabricConnection.ts
@@ -19,6 +19,7 @@ import { ConsoleOutputAdapter, FabricSmartContractDefinition, OutputAdapter } fr
 import { FabricWallet } from 'ibm-blockchain-platform-wallet';
 import { Lifecycle, LifecyclePeer, LifecycleChannel, DefinedSmartContract } from 'ibm-blockchain-platform-fabric-admin';
 import { Endorser, Channel } from 'fabric-common';
+import { EvaluateQueryHandler } from 'ibm-blockchain-platform-fabric-admin';
 
 export abstract class FabricConnection {
 
@@ -105,6 +106,7 @@ export abstract class FabricConnection {
     }
 
     public disconnect(): void {
+        EvaluateQueryHandler.setPeers(undefined);
         this.gateway.disconnect();
     }
 
@@ -196,7 +198,8 @@ export abstract class FabricConnection {
                 asLocalhost: this.discoveryAsLocalhost,
                 enabled: this.discoveryEnabled
             },
-            eventHandlerOptions: { commitTimeout: timeout }
+            eventHandlerOptions: { commitTimeout: timeout },
+            queryHandlerOptions: { strategy: EvaluateQueryHandler.createQueryHandler }
         };
 
         await this.gateway.connect(connectionProfile, options);

--- a/packages/blockchain-gateway-v1/test/FabricConnection.test.ts
+++ b/packages/blockchain-gateway-v1/test/FabricConnection.test.ts
@@ -208,6 +208,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -231,6 +234,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -254,6 +260,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -277,6 +286,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -300,6 +312,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -323,6 +338,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -346,6 +364,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -369,6 +390,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });
@@ -392,6 +416,9 @@ describe('FabricConnection', () => {
                 },
                 eventHandlerOptions: {
                     commitTimeout: timeout
+                },
+                queryHandlerOptions: {
+                    strategy: sinon.match.any/*queryFactory.createQueryHandler*/
                 }
             });
         });


### PR DESCRIPTION
The query handler is a gateway option, used at connect time. Therefore it's not possible to change the query handler being used by a gateway while maintaining the connection.

In this PR the custom query has a static variable for peers, which allows the extension to modify the peers before submitting the evaluate transactions, not requiring a disconnect/reconnect to the gateway.

If evaluating a transaction in multiple peers, as soon as a valid response is obtained the result will be returned. This is true even if an error was returned by a previous peer.


Closes #2907 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>