### PR TITLE
Fix transaction view for chaincodes with same name in different channels

### DIFF
--- a/packages/blockchain-extension/extension/commands/deployCommand.ts
+++ b/packages/blockchain-extension/extension/commands/deployCommand.ts
@@ -77,7 +77,7 @@ export async function deploySmartContract(requireCommit: boolean, fabricEnvironm
                     }
                 }
 
-                const smartContracts: ISmartContract[] = await getSmartContracts(gatewayConnection, smartContractDefinition.name);
+                const smartContracts: ISmartContract[] = await getSmartContracts(gatewayConnection, smartContractDefinition.name, channelName);
                 await TransactionView.updateSmartContracts(smartContracts);
             }
         });

--- a/packages/blockchain-extension/extension/util/ExtensionUtil.ts
+++ b/packages/blockchain-extension/extension/util/ExtensionUtil.ts
@@ -299,7 +299,7 @@ export class ExtensionUtil {
             await fabric2View.openView(true, vscode.ViewColumn.Beside);
         }));
 
-        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_TRANSACTION_PAGE, (treeItem: InstantiatedTreeItem, selectedTransactionName: string) => {
+        context.subscriptions.push(vscode.commands.registerCommand(ExtensionCommands.OPEN_TRANSACTION_PAGE, (treeItem: InstantiatedTreeItem | ContractTreeItem, selectedTransactionName: string) => {
             return openTransactionView(treeItem, selectedTransactionName);
         }));
 

--- a/packages/blockchain-extension/test/commands/deployCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/deployCommand.test.ts
@@ -174,12 +174,12 @@ describe('deployCommand', () => {
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
             orgMap.set('Org2MSP', ['peerTwo', 'peerThree']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, orgMap, packageRegistryEntry);
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
             logSpy.should.have.been.calledWith(LogType.INFO, 'Deploy Smart Contract');
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully deployed smart contract');
         });
@@ -187,12 +187,12 @@ describe('deployCommand', () => {
         it('should deploy the smart contract through the command with endorsement policy', async () => {
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, orgMap, packageRegistryEntry);
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId', `OutOf(1, 'Org1.member', 'Org2.member')`));
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId', `OutOf(1, 'Org1.member', 'Org2.member')`));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId', `OutOf(1, 'Org1.member', 'Org2.member')`));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId', `OutOf(1, 'Org1.member', 'Org2.member')`));
             logSpy.should.have.been.calledWith(LogType.INFO, 'Deploy Smart Contract');
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully deployed smart contract');
         });
@@ -200,11 +200,11 @@ describe('deployCommand', () => {
         it('should deploy the smart contract through the command but not commit', async () => {
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, false, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, false, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, orgMap, packageRegistryEntry);
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
             executeCommandStub.should.not.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT);
             logSpy.should.have.been.calledWith(LogType.INFO, 'Deploy Smart Contract');
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Partially deployed smart contract - commit not performed');
@@ -215,7 +215,7 @@ describe('deployCommand', () => {
             orgMap.set('Org1MSP', ['peerOne']);
             environmentConnectionStub.returns(undefined);
 
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.not.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT);
@@ -227,7 +227,7 @@ describe('deployCommand', () => {
             executeCommandStub.withArgs(ExtensionCommands.INSTALL_SMART_CONTRACT).resolves([undefined, 'other']);
             const error: Error = new Error('Package was not installed. No packageId was returned');
 
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, orgMap, packageRegistryEntry);
@@ -242,12 +242,12 @@ describe('deployCommand', () => {
             installApproveMap.set('Org1MSP', ['peerOne']);
             commitMap.set('Org1MSP', ['peerOne']);
             commitMap.set('Org2MSP', ['peerTwo', 'peerThree']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', installApproveMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1), commitMap);
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', installApproveMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1), commitMap);
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, installApproveMap, packageRegistryEntry);
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'mychannel', installApproveMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'mychannel', commitMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'myChannel', installApproveMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'myChannel', commitMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
             logSpy.should.have.been.calledWith(LogType.INFO, 'Deploy Smart Contract');
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully deployed smart contract');
         });
@@ -278,12 +278,12 @@ describe('deployCommand', () => {
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
             orgMap.set('Org2MSP', ['peerTwo', 'peerThree']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1));
 
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_ENVIRONMENT, environmentRegistryEntry);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.INSTALL_SMART_CONTRACT, orgMap, packageRegistryEntry);
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
-            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'mychannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.APPROVE_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
+            executeCommandStub.should.have.been.calledWith(ExtensionCommands.COMMIT_SMART_CONTRACT, 'myOrderer', 'myChannel', orgMap, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, 'myPackageId'));
             logSpy.should.have.been.calledWith(LogType.INFO, 'Deploy Smart Contract');
             logSpy.should.have.been.calledWith(LogType.SUCCESS, 'Successfully deployed smart contract');
             getConnectionStub.should.have.been.called;
@@ -328,7 +328,7 @@ describe('deployCommand', () => {
             getConnectionStub.returns(undefined);
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
         });
 
         it('should call the CONNECT_TO_GATEWAY command if not already connected and submit a smart contract using the connected gateway when the Transaction View is open', async () => {
@@ -354,7 +354,7 @@ describe('deployCommand', () => {
 
             const orgMap: Map<string, string[]> = new Map<string, string[]>();
             orgMap.set('Org1MSP', ['peerOne']);
-            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'mychannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
+            await vscode.commands.executeCommand(ExtensionCommands.DEPLOY_SMART_CONTRACT, true, environmentRegistryEntry, 'myOrderer', 'myChannel', orgMap, packageRegistryEntry, new FabricSmartContractDefinition('mySmartContract', '0.0.1', 1, undefined, `OutOf(1, 'Org1.member', 'Org2.member')`));
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_GATEWAY);
             getSmartContractStub.should.have.been.calledWith('anotherGateway');
         });

--- a/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
+++ b/packages/blockchain-extension/test/commands/openTransactionViewCommand.test.ts
@@ -102,6 +102,7 @@ describe('OpenTransactionViewCommand', () => {
     let executeCommandStub: sinon.SinonStub;
     let getConnectionStub: sinon.SinonStub;
     let showInstantiatedSmartContractQuickPickStub: sinon.SinonStub;
+    let showChannelFromGatewayQuickPickBoxStub: sinon.SinonStub;
 
     let fabricConnectionManager: FabricGatewayConnectionManager;
 
@@ -131,6 +132,7 @@ describe('OpenTransactionViewCommand', () => {
 
             const map: Map<string, Array<string>> = new Map<string, Array<string>>();
             map.set('myChannel', ['peerOne']);
+            map.set('otherChannel', ['otherPeer']);
             fabricClientConnectionMock.createChannelMap.resolves(map);
             fabricClientConnectionMock.getChannelCapabilityFromPeer.resolves([UserInputUtil.V2_0]);
             fabricConnectionManager = FabricGatewayConnectionManager.instance();
@@ -197,6 +199,9 @@ describe('OpenTransactionViewCommand', () => {
                     }
                 }
             );
+
+            showChannelFromGatewayQuickPickBoxStub = mySandBox.stub(UserInputUtil, 'showChannelFromGatewayQuickPickBox');
+            showChannelFromGatewayQuickPickBoxStub.resolves({label: 'myChannel'});
 
             showInstantiatedSmartContractQuickPickStub = mySandBox.stub(UserInputUtil, 'showClientInstantiatedSmartContractsQuickPick');
             showInstantiatedSmartContractQuickPickStub.resolves({
@@ -507,6 +512,17 @@ describe('OpenTransactionViewCommand', () => {
             logSpy.should.have.been.calledWith(LogType.INFO, undefined, `Open Transaction View`);
             executeCommandStub.should.have.been.calledWith(ExtensionCommands.CONNECT_TO_GATEWAY);
             showInstantiatedSmartContractQuickPickStub.should.not.have.been.called;
+            openViewStub.should.not.have.been.called;
+        });
+
+        it('should handle cancellation when choosing a channel', async () => {
+            showChannelFromGatewayQuickPickBoxStub.resolves();
+
+            await vscode.commands.executeCommand(ExtensionCommands.OPEN_TRANSACTION_PAGE);
+
+            logSpy.should.have.been.calledWith(LogType.INFO, undefined, `Open Transaction View`);
+            showChannelFromGatewayQuickPickBoxStub.should.have.been.calledOnce;
+            showInstantiatedSmartContractQuickPickStub.should.have.not.been.called;
             openViewStub.should.not.have.been.called;
         });
 

--- a/packages/blockchain-ui/cypress/integration/transaction_page.spec.ts
+++ b/packages/blockchain-ui/cypress/integration/transaction_page.spec.ts
@@ -78,7 +78,7 @@ describe('Transaction page', () => {
 
     const associatedTxdata: IAssociatedTxdata = {
         [greenContract.name]: {
-            channelName: 'channelName',
+            channelName: 'mychannel',
             transactionDataPath: 'transactionDataPath',
             transactions: txdataTransactions,
         }

--- a/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
+++ b/packages/blockchain-ui/enzyme/tests/TransactionInputContainer.test.tsx
@@ -173,7 +173,7 @@ describe('TransactionInputContainer component', () => {
 
     const associatedTxdata: IAssociatedTxdata = {
         [greenContract.name]: {
-            channelName: 'channelName',
+            channelName: 'mychannel',
             transactionDataPath: 'transactionDataPath',
             transactions: txdataTransactions,
         }
@@ -800,6 +800,20 @@ describe('TransactionInputContainer component', () => {
                         channel,
                     }
                 });
+            });
+
+            it('should not show the transaction dropdown as enabled because directory is associated with contract in wrong channel', () => {
+                const wrongChannelContract: ISmartContract = {
+                    ...greenContract,
+                    channel: 'otherChannel'
+                };
+            
+                component = mount(<TransactionInputContainer smartContract={wrongChannelContract} associatedTxdata={associatedTxdata} preselectedTransaction={preselectedTransaction} setTransactionSubmitted={setTransactionSubmittedStub}/>);
+                component = toggleContentSwitcher(component);
+
+                const dropdown: any = component.find(transactionNameSelector);
+                expect(dropdown.prop('disabled')).toBeTruthy();
+                expect(dropdown.prop('items')).toEqual([]);
             });
 
             it('should show the transaction dropdown as enabled and display the txdataTransactions as a directory is associated', () => {

--- a/packages/blockchain-ui/src/components/elements/TransactionDataInput/TransactionDataInput.tsx
+++ b/packages/blockchain-ui/src/components/elements/TransactionDataInput/TransactionDataInput.tsx
@@ -39,7 +39,11 @@ const TransactionDataInput: FunctionComponent<IProps> = ({ smartContract, associ
     };
 
     const displayChooseOption: IDataFileTransaction = { transactionName: 'Select the transaction name', transactionLabel: '', txDataFile: '', arguments: [], transientData: {} };
-    const activeAssociatedTxData: { channelName: string, transactionDataPath: string, transactions: IDataFileTransaction[] } | undefined = smartContract && associatedTxdata && associatedTxdata[smartContract.name];
+    let activeAssociatedTxData: { channelName: string, transactionDataPath: string, transactions: IDataFileTransaction[] } | undefined;
+    if (smartContract && associatedTxdata && associatedTxdata[smartContract.name] && associatedTxdata[smartContract.name].channelName === smartContract.channel) {
+        activeAssociatedTxData = associatedTxdata[smartContract.name];
+    }
+
     return (
         <>
             <div className='associate-tx-data'>


### PR DESCRIPTION
Also fixed directory data: We can have chaincodes with the same name in different channels, and we need to always associate the correct directory data. However, the view always displayed directory data and corresponding transactions **if there was any associated with a contract of the same name**, regardless of the channel in which it had been deployed.

We now have to associate directory data if there is nothing for the chaincode name in use and in the channel in use.


closes #2854 

Signed-off-by: Leonor Quintais <lquintai@uk.ibm.com>