### PR TITLE
Fix typo in basic tutorial

### DIFF
--- a/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a3.md
+++ b/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a3.md
@@ -84,7 +84,7 @@ Expand the next section of the tutorial to continue.
 <summary><b>Package and deploy the smart contract</b></summary>
 
 
-We will now package and deploy our smart contract into the local environment. The VS Code extension has a simplified version of the process to deploy a smart contract and the default options provided work well for for simple projects such as this demo-contract.
+We will now package and deploy our smart contract into the local environment. The VS Code extension has a simplified version of the process to deploy a smart contract and the default options provided work well for simple projects such as this demo-contract.
 
 > <br>
    > <b>Want to know more?</b><br>For more about smart contract packages (chaincode) and the lifecycle, check out the <a href="https://hyperledger-fabric.readthedocs.io/en/latest/chaincode_lifecycle.html">Hyperledger Fabric documentation</a>.


### PR DESCRIPTION
Fixed a simple typo in the basic tutorial (A3.4 - 2x "for")