### PR TITLE
Update workaround for dockerinstall script

### DIFF
--- a/packages/blockchain-extension/scripts/installdocker.sh
+++ b/packages/blockchain-extension/scripts/installdocker.sh
@@ -1,38 +1,73 @@
-# Install latest version of Docker Desktop for Mac
-echo 'Downloading and then running docker brew formula ...'
-
-# The brew formula below will install Docker Desktop for Mac, v2.0.0.3,31259.
-dockerInstallationScriptName='docker.rb'
-dockerInstallationScriptUrl="https://raw.githubusercontent.com/Homebrew/homebrew-cask/8ce4e89d10716666743b28c5a46cd54af59a9cc2/Casks/$dockerInstallationScriptName"
-curl -L  $dockerInstallationScriptUrl > $dockerInstallationScriptName && brew install $dockerInstallationScriptName
-
-
-echo 'Installing Docker Desktop for Mac ...'
-sudo /Applications/Docker.app/Contents/MacOS/Docker --quit-after-install --unattended
-/Applications/Docker.app/Contents/MacOS/Docker --unattended &
-
-echo 'Starting Docker service ...'
-
-start=$SECONDS
+#!/usr/bin/env bash
 
 retries=0
-maxRetries=30
+brew install --cask docker
+
+# manually setup docker, as versions after 2.0.0.3-ce-mac81,31259 cannot be installed using cli
+# thanks to https://github.com/docker/for-mac/issues/2359#issuecomment-853420567
+
+# allow the app to run without confirmation
+xattr -d -r com.apple.quarantine /Applications/Docker.app
+
+# preemptively do docker.app's setup to avoid any gui prompts
+sudo /bin/cp /Applications/Docker.app/Contents/Library/LaunchServices/com.docker.vmnetd /Library/PrivilegedHelperTools
+
+# the plist we need used to be in /Applications/Docker.app/Contents/Resources, but
+# is now dynamically generated. So we dynamically generate our own
+sudo tee "/Library/LaunchDaemons/com.docker.vmnetd.plist" > /dev/null <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.docker.vmnetd</string>
+	<key>Program</key>
+	<string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Library/PrivilegedHelperTools/com.docker.vmnetd</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>Sockets</key>
+	<dict>
+		<key>Listener</key>
+		<dict>
+			<key>SockPathMode</key>
+			<integer>438</integer>
+			<key>SockPathName</key>
+			<string>/var/run/com.docker.vmnetd.sock</string>
+		</dict>
+	</dict>
+	<key>Version</key>
+	<string>59</string>
+</dict>
+</plist>
+
+EOF
+
+sudo /bin/chmod 544 /Library/PrivilegedHelperTools/com.docker.vmnetd
+sudo /bin/chmod 644 /Library/LaunchDaemons/com.docker.vmnetd.plist
+sudo /bin/launchctl load /Library/LaunchDaemons/com.docker.vmnetd.plist
+
+sleep 5
+
+# install docker as before
+open -g /Applications/Docker.app || exit
 
 while ! docker info 2>/dev/null ; do
-    sleep 5s
-    ((retries=retries+1))
-
-    if pgrep -xq -- 'Docker'; then
-        echo 'Docker still running'
+    sleep 5
+    retries=`expr $retries + 1`
+    if pgrep -xq -- "Docker"; then
+        echo 'docker still running'
     else
-        echo 'Docker not running, restart'
-        /Applications/Docker.app/Contents/MacOS/Docker --unattended &
+        echo 'docker not running, restart'
+        open -g /Applications/Docker.app || exit
     fi
-
-    if [[ ${retries} -gt ${maxRetries} ]]; then
+    if [ $retries -gt 60 ]; then
         >&2 echo 'Failed to run docker'
         exit 1
     fi;
 
-    echo 'Waiting for Docker service to be in running state ...'
+    echo 'Waiting for docker service to be in the running state'
 done


### PR DESCRIPTION
In [my last PR](https://github.com/IBM-Blockchain/blockchain-vscode-extension/pull/3032) I downgraded the version of docker that we were installing for our Mac unit tests, as the workaround we'd been using to install/run Docker Desktop headlessly has been broken by an update. This PR updates `dockerinstall.sh` with a workaround for the workaround that brings us back up to latest. Many thanks to [this comment](https://github.com/docker/for-mac/issues/2359#issuecomment-853420567)!

Signed-off-by: Erin Hughes <Erin.Hughes@ibm.com>