### PR TITLE
Fix pdf build

### DIFF
--- a/azure-templates/build-pdf.yml
+++ b/azure-templates/build-pdf.yml
@@ -12,6 +12,10 @@
 
 jobs: 
   - job: buildPdf
+
+    pool:
+      vmImage: 'ubuntu-latest'
+
     steps:
       - script: |
           set -ex


### PR DESCRIPTION
Build failing without a pool specified:

##[warning]An image label with the label Ubuntu16 does not exist.
,##[error]The remote provider was unable to process the request.

Signed-off-by: James Taylor <jamest@uk.ibm.com>