### PR TITLE
Adjust the caching of the Environment Connections

### DIFF
--- a/packages/blockchain-common/src/registries/FabricEnvironmentRegistryEntry.ts
+++ b/packages/blockchain-common/src/registries/FabricEnvironmentRegistryEntry.ts
@@ -12,6 +12,7 @@
  * limitations under the License.
 */
 
+import { IFabricEnvironmentConnection } from '../..';
 import {RegistryEntry} from './RegistryEntry';
 
 export enum EnvironmentFlags {
@@ -35,6 +36,8 @@ export enum EnvironmentType {
     MANAGED = EnvironmentFlags.MANAGED
 }
 
+// environmentConnection acts as a cache of connection to speed up the UI
+// For more info see comments in environmentConnectCommand.ts
 export class FabricEnvironmentRegistryEntry extends RegistryEntry {
 
     public managedRuntime?: boolean; // True if the Local environment
@@ -43,6 +46,7 @@ export class FabricEnvironmentRegistryEntry extends RegistryEntry {
     public url?: string;
     public numberOfOrgs?: number;
     public fabricCapabilities?: string;
+    public environmentConnection?: IFabricEnvironmentConnection;
     constructor(fields?: FabricEnvironmentRegistryEntry) {
         super();
         Object.assign(this, fields);

--- a/packages/blockchain-extension/extension/commands/deleteNodeCommand.ts
+++ b/packages/blockchain-extension/extension/commands/deleteNodeCommand.ts
@@ -129,6 +129,8 @@ export async function deleteNode(nodeTreeItem: NodeTreeItem | FabricNode, hideNo
             const connectedRegistry: FabricEnvironmentRegistryEntry = FabricEnvironmentManager.instance().getEnvironmentRegistryEntry();
             if (connectedRegistry && connectedRegistry.name === environmentRegistryEntry.name) {
                 // only connect if already connected to this environment or in setup for this environment
+                // For more info see comments in environmentConnectCommand.ts
+                connectedRegistry.environmentConnection=undefined;
                 await vscode.commands.executeCommand(ExtensionCommands.CONNECT_TO_ENVIRONMENT, connectedRegistry);
             }
         }

--- a/packages/blockchain-extension/extension/fabric/environments/FabricEnvironmentManager.ts
+++ b/packages/blockchain-extension/extension/fabric/environments/FabricEnvironmentManager.ts
@@ -91,6 +91,12 @@ export class FabricEnvironmentManager extends EventEmitter {
         }
 
         if (this.environmentRegistryEntry) {
+            // ensure that the connection is disconencted and removed
+            // For more info see comments in environmentConnectCommand.ts
+            if (this.environmentRegistryEntry.environmentConnection){
+                this.environmentRegistryEntry.environmentConnection.disconnect();
+                this.environmentRegistryEntry.environmentConnection = undefined;
+            }
             this.environmentRegistryEntry = null;
         }
 


### PR DESCRIPTION
This is a prototype fix for the UI slowdown. The original issue reported was the 'deploySmartContract' wasn't responding. Started with the assumption that it was this function that was getting current state of the resources that was slowing down, and delaying bringing up the correct dialog.

However it seemed that it wasn't even starting; with the number of entries in the view, there was a massive about of obtaining connections to the managed IBP instance. It seemed that every click in the window would kick off another connection creation. And this would then slow the UI down considerably.

These changes attempt to get the connection once and once only. It seems to work.

To add some information on how I *think* this is working; the `environmentCreateConnection` is doing I believe a double duty of both creating the connection and also of refreshing state; so in the case of one of the test failures where a node was deleted, the code, after deletion, calls connect again. In this case though the connect is really a refresh to update the view. Becuase the connection was being cached this update didn't occur - hence the change to invalidate the cache in that regard.

The decision to make the views automatically refresh is a difficult problem - when does the refresh occur and how do you stop it swamping the UI with 'refresh' events.  The code is suggesting to me that this isn't quite right in the extension.  Though we don't have the scope at present to fully explore or understand the internal structure. 

I believe this fix is stable, all the tests pass, and practical usage of the extension seems to be good. 


Signed-off-by: Matthew B White <whitemat@uk.ibm.com>