### PR TITLE
Fixed typo in a2.md

### DIFF
--- a/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a2.md
+++ b/packages/blockchain-extension/resources/tutorials/new-tutorials/basic-tutorials/a2.md
@@ -152,12 +152,12 @@ Each method uses the world state to read the current value of a set of business 
 const buffer = await ctx.stub.getState(myAssetId);
 ```
 
-The *getState* method returns from the world state the current value associated with the key described by *myAssetId*. This method only reads the value of business object, it does not change it. That's why the myAssetExists() method was decorated @Transaction(false).
+The *getState* method returns from the world state the current value associated with the key described by *myAssetId*. This method only reads the value of business object, it does not change it. That's why the myAssetExists() method was decorated @Transaction(*false*).
 
 Now take a look at the second method:
 
 ```typescript
-@Transaction()
+@Transaction(true)
 public async createMyAsset(ctx: Context, myAssetId: string, value: string): Promise<void> {
 ```
 This ends with the line:
@@ -166,7 +166,7 @@ This ends with the line:
 await ctx.stub.putState(myAssetId, buffer);
 ```
 
-The putState method changes the current value of a business object with the key myAssetId to the value buffer. That's why the createMyAsset method was decorated with @transaction(true).
+The putState method changes the current value of a business object with the key myAssetId to the value buffer. That's why the createMyAsset method was decorated with @Transaction(*true*).
 
 The transaction response is generated automatically by Hyperledger Fabric when the smart contract execution completes.  It comprises the states that have been read and those that are to be written if the transaction is successfully committed to the ledger.
 


### PR DESCRIPTION
Reference: https://github.com/IBM-Blockchain/blockchain-vscode-extension/issues/3166

The automatically generated contract `my-asset-contract.ts` is supposed to be generated with the method `createMyAsset(...)` and the decorator `@Transaction(true)`. However, `createMyAsset(...)` is decorated with `@Transaction()` - notice it's missing "true".

The tutorial follows this mistake and writes the example with `@Transaction()`, but later references it as `@Transaction(true)`.